### PR TITLE
Fix TimeUpdate param usage

### DIFF
--- a/aur/aur.go
+++ b/aur/aur.go
@@ -167,7 +167,7 @@ func Upgrade(flags []string) error {
 
 		if _, ok := foreign[res.Name]; ok {
 			// Leaving this here for now, warn about downgrades later
-			if (!config.YayConf.TimeUpdate && (int64(res.LastModified) > foreign[res.Name].BuildDate().Unix())) ||
+			if (config.YayConf.TimeUpdate && (int64(res.LastModified) > foreign[res.Name].BuildDate().Unix())) ||
 				alpm.VerCmp(foreign[res.Name].Version(), res.Version) < 0 {
 				buffer.WriteString(fmt.Sprintf("\x1b[1m\x1b[32m==>\x1b[33;1m %s: \x1b[0m%s \x1b[33;1m-> \x1b[0m%s\n",
 					res.Name, foreign[res.Name].Version(), res.Version))

--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ type Configuration struct {
 	SearchMode int    `json:"-"`
 	SortMode   int    `json:"sortmode"`
 	TarBin     string `json:"tarbin"`
-	TimeUpdate bool   `json:"versionupdate"`
+	TimeUpdate bool   `json:"timeupdate"`
 }
 
 // YayConf holds the current config values for yay.


### PR DESCRIPTION
TimeUpdate is `false` by default. We want to compare modification time only when user changes this parameter to `true`. The current code seems to have inverted logic at the moment.

@Jguer please have a look, am I correctly interpreting this logic with TimeUpdate?