### PR TITLE
Suffix BuildDir with uid to avoid perm problems

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/user"
 	"strings"
 
 	alpm "github.com/jguer/go-alpm"
@@ -119,7 +120,11 @@ func SaveConfig() error {
 }
 
 func defaultSettings(config *Configuration) {
-	config.BuildDir = "/tmp/yaytmp/"
+	u, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	config.BuildDir = fmt.Sprintf("/tmp/yaytmp-%s/", u.Uid)
 	config.Editor = ""
 	config.Devel = false
 	config.MakepkgBin = "/usr/bin/makepkg"


### PR DESCRIPTION
Different users using the same `/tmp/yaytmp` has caused permission problems when another user tries to use yay when yaytmp is created by another user.

This PR changes `/tmp/yaytmp` to `/tmp/yaytmp-1000`, where 1000 is the uid.

This method is also used by Kwpolska/pkgbuilder and keenerd/packer.