### PR TITLE
Make default config file non-executable

### DIFF
--- a/config.go
+++ b/config.go
@@ -81,7 +81,7 @@ func (config *Configuration) saveConfig() error {
 	config.NoConfirm = false
 	configfile := os.Getenv("HOME") + "/.config/yay/config.json"
 	marshalledinfo, _ := json.MarshalIndent(config, "", "\t")
-	in, err := os.OpenFile(configfile, os.O_RDWR|os.O_CREATE, 0755)
+	in, err := os.OpenFile(configfile, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I can't think of a reason for this to use the existing `0755` permissions. If it is deliberate for some reason, I'm sorry for wasting your time.

Closes #52 