### PR TITLE
Prevent file corruption by truncating the files

### DIFF
--- a/config.go
+++ b/config.go
@@ -87,7 +87,7 @@ func readAlpmConfig(pacmanconf string) (conf alpm.PacmanConfig, err error) {
 func (config *Configuration) saveConfig() error {
 	config.NoConfirm = false
 	marshalledinfo, _ := json.MarshalIndent(config, "", "\t")
-	in, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0644)
+	in, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/vcs.go
+++ b/vcs.go
@@ -129,7 +129,7 @@ func saveVCSInfo() error {
 	if err != nil || string(marshalledinfo) == "null" {
 		return err
 	}
-	in, err := os.OpenFile(vcsFile, os.O_RDWR|os.O_CREATE, 0644)
+	in, err := os.OpenFile(vcsFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I've experienced yay corrupting its config files a few times already, finally got time to investigate what's wrong.

I put a demo file below which you can use to reproduce the problem. Notice that json becomes invalid after a second write. Adding `os.O_TRUNC` does seem to solve it.

```
$ go run test.go
$ cat test.json
```

test.go

```
package main

import (
	"encoding/json"
	"log"
	"os"
)

func write(data []byte) {
	in, err := os.OpenFile("./test.json", os.O_RDWR|os.O_CREATE, 0644)
	if err != nil {
		log.Fatal(err)
	}
	defer in.Close()
	_, err = in.Write(data)
	if err != nil {
		log.Fatal(err)
	}
	err = in.Sync()
	if err != nil {
		log.Fatal(err)
	}
	log.Println("file written")
}

func main() {
	config := make(map[string]string)
	config["aaa"] = "aaa"
	config["bbb"] = "bbb"
	config["ccc"] = "ccc"
	config["ddd"] = "ddd"
	config["eee"] = "eee"
	config["fff"] = "fff"

	data, _ := json.MarshalIndent(config, "", "\t")
	write(data)

	delete(config, "eee")
	delete(config, "fff")

	data, _ = json.MarshalIndent(config, "", "\t")
	write(data)

	log.Println("done")
}
```