### PR TITLE
Print VCS error details

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -71,9 +72,11 @@ func (info *Info) needsUpdate() bool {
 	}
 	defer r.Body.Close()
 
-	err = json.NewDecoder(r.Body).Decode(&newRepo)
+	body, _ := ioutil.ReadAll(r.Body)
+	err = json.Unmarshal(body, &newRepo)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Printf("Cannot update '%v'\nError: %v\nStatus code: %v\nBody: %v\n",
+			info.Package, err, r.StatusCode, string(body))
 		return false
 	}
 


### PR DESCRIPTION
I've experienced a couple of times issues when I cannot update VCS packages, but looking at the error I have no idea what is wrong. This change adds some details.

Before:

```
:: Checking development packages...
json: cannot unmarshal object into Go value of type main.branches

there is nothing to do
```

This tells me it's time to change my internet connection:

```
:: Checking development packages...
Cannot update 'neovim-gtk3-git'
Error: json: cannot unmarshal object into Go value of type main.branches
Status code: 403
Body: {"message":"API rate limit exceeded for XX.XX.XX.XX. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://developer.github.com/v3/#rate-limiting"}
```

This tells me that yay doesn't cleanup this file after deleting a package called `neovim-gtk3-git` (or I made a mistake by manually fixing vcs.json (#66))

```
:: Checking development packages...
Cannot update 'neovim-gtk3-git'
Error: json: cannot unmarshal object into Go value of type main.branches
Status code: 404
Body: {"message":"Not Found","documentation_url":"https://developer.github.com/v3"}

there is nothing to do
```
