### PR TITLE
Fix crash when package version is "invalid"

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -60,14 +60,9 @@ func (u upSlice) Less(i, j int) bool {
 // Print prints the details of the packages to upgrade.
 func (u upSlice) Print(start int) {
 	for k, i := range u {
-		old, err := pkgb.NewCompleteVersion(i.LocalVersion)
-		if err != nil {
-			fmt.Println(i.Name, err)
-		}
-		new, err := pkgb.NewCompleteVersion(i.RemoteVersion)
-		if err != nil {
-			fmt.Println(i.Name, err)
-		}
+		old, errOld := pkgb.NewCompleteVersion(i.LocalVersion)
+		new, errNew := pkgb.NewCompleteVersion(i.RemoteVersion)
+		var left, right string
 
 		f := func(name string) (color int) {
 			var hash = 5381
@@ -79,16 +74,18 @@ func (u upSlice) Print(start int) {
 		fmt.Printf("\x1b[33m%-2d\x1b[0m ", len(u)+start-k-1)
 		fmt.Printf("\x1b[1;%dm%s\x1b[0m/\x1b[1;39m%-25s\t\t\x1b[0m", f(i.Repository), i.Repository, i.Name)
 
-		if old.Version != new.Version {
-			fmt.Printf("\x1b[31m%18s\x1b[0m-%s -> \x1b[1;32m%s\x1b[0m-%s\x1b[0m",
-				old.Version, old.Pkgrel,
-				new.Version, new.Pkgrel)
+		if errOld != nil {
+			left = fmt.Sprintf("\x1b[31m%20s\x1b[0m", "Invalid Version")
 		} else {
-			fmt.Printf("\x1b[0m%18s-\x1b[31m%s\x1b[0m -> %s-\x1b[32m%s\x1b[0m",
-				old.Version, old.Pkgrel,
-				new.Version, new.Pkgrel)
+			left = fmt.Sprintf("\x1b[31m%18s\x1b[0m-%s", old.Version, old.Pkgrel)
 		}
-		print("\n")
+
+		if errNew != nil {
+			right = fmt.Sprintf("\x1b[31m%s\x1b[0m", "Invalid Version")
+		} else {
+			right = fmt.Sprintf("\x1b[31m%s\x1b[0m-%s", new.Version, new.Pkgrel)
+		}
+		fmt.Printf("%s -> %s\n", left, right)
 	}
 }
 


### PR DESCRIPTION
This will fix #78. And keep the formatting if a package version is invalid.

Before:
![image](https://user-images.githubusercontent.com/16593899/34457821-f022a700-edb4-11e7-8d18-bf3e7ede43ad.png)

After:
![image](https://user-images.githubusercontent.com/16593899/34457824-fb69cfb2-edb4-11e7-9922-99719afbe08a.png)

The root of this issue comes from gopkgbuild which seems to throw an error whenever a pkver contains a `~` (and possibly other symbols) which should be a valid character.

Currently yay should work as expected apart from displaying "Invalid Version"  for effected packages. Once this is fixed in gopkgbuild it should display normally.