### PR TITLE
Refactoring and rewriting the argument parsing system 

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -32,7 +32,7 @@ func removeVCSPackage(pkgs []string) {
 }
 
 // CleanDependencies removes all dangling dependencies in system
-func cleanDependencies(pkgs []string) error {
+func cleanDependencies() error {
 	hanging, err := hangingPackages()
 	if err != nil {
 		return err
@@ -49,12 +49,15 @@ func cleanDependencies(pkgs []string) error {
 }
 
 // CleanRemove sends a full removal command to pacman with the pkgName slice
-func cleanRemove(pkgName []string) (err error) {
-	if len(pkgName) == 0 {
+func cleanRemove(pkgNames []string) (err error) {
+	if len(pkgNames) == 0 {
 		return nil
 	}
+	
+	arguments := makeArguments()
+	arguments.addArg("R", "s", "n", "s", "noconfirm")
+	arguments.addTarget(pkgNames...)
 
-	//TODO
-	//err = passToPacman("-Rsnc", pkgName, []string{"--noconfirm"})
+	err = passToPacman(arguments)
 	return err
 }

--- a/clean.go
+++ b/clean.go
@@ -55,7 +55,7 @@ func cleanRemove(pkgNames []string) (err error) {
 	}
 	
 	arguments := makeArguments()
-	arguments.addArg("R", "s", "n", "s", "noconfirm")
+	arguments.addArg("R", "noconfirm")
 	arguments.addTarget(pkgNames...)
 
 	err = passToPacman(arguments)

--- a/clean.go
+++ b/clean.go
@@ -54,6 +54,7 @@ func cleanRemove(pkgName []string) (err error) {
 		return nil
 	}
 
-	err = passToPacman("-Rsnc", pkgName, []string{"--noconfirm"})
+	//TODO
+	//err = passToPacman("-Rsnc", pkgName, []string{"--noconfirm"})
 	return err
 }

--- a/cmd.go
+++ b/cmd.go
@@ -241,6 +241,8 @@ func handleCmd(parser *argParser) (changedConfig bool, err error) {
 		passToPacman(parser)
 	case "U", "upgrade":
 		passToPacman(parser)
+	case "G", "getpkgbuild":
+		err = handleGetpkgbuild(parser)
 	case "Y", "--yay":
 		err = handleYay(parser)
 	default:
@@ -345,6 +347,20 @@ func handleYay(parser *argParser) (err error) {
 	} else {
 		err = handleYogurt(parser)
 	}
+	
+	return
+}
+
+func handleGetpkgbuild(parser *argParser) (err error) {
+	for pkg := range parser.targets {
+			err = getPkgbuild(pkg)
+			if err != nil {
+				//we print the error instead of returning it
+				//seems as we can handle multiple errors without stoping
+				//theres no easy way arround this right now
+				fmt.Println(pkg + ":", err)
+			}
+		}
 	
 	return
 }

--- a/cmd.go
+++ b/cmd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -486,5 +487,24 @@ func complete() error {
 	defer in.Close()
 
 	_, err = io.Copy(os.Stdout, in)
+	return err
+}
+
+// PassToPacman outsorces execution to pacman binary without modifications.
+func passToPacman(parser *argParser) error {
+	var cmd *exec.Cmd
+	args := make([]string, 0)
+
+	if parser.needRoot() {
+		args = append(args, "sudo")
+	}
+
+	args = append(args, "pacman")
+	args = append(args, parser.formatArgs()...)
+
+	cmd = exec.Command(args[0], args[1:]...)
+
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	err := cmd.Run()
 	return err
 }

--- a/cmd.go
+++ b/cmd.go
@@ -389,7 +389,7 @@ func handleYay() (err error) {
 		err = localStatistics()
 	} else if cmdArgs.existsArg("cleandeps") {
 		err = cleanDependencies()
-	} else {
+	} else if len(cmdArgs.targets) > 0 {
 		err = handleYogurt()
 	}
 	
@@ -533,7 +533,7 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 	}
 
 	if len(aurI) != 0 {
-		err = aurInstall(aurI, make([]string,0))
+		err = aurInstall(aurI, nil)
 	}
 
 	return err

--- a/cmd.go
+++ b/cmd.go
@@ -142,6 +142,18 @@ func init() {
 }
 
 func main() {
+	status := run()
+	
+	err := alpmHandle.Release()
+	if err != nil {
+		fmt.Println(err)
+		status = 1
+	}
+	
+	os.Exit(status)
+}
+
+func run() (status int) {
 	var err error
 	var changedConfig bool
 	
@@ -150,7 +162,8 @@ func main() {
 	
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		status = 1
+		return
 	}
 	
 	if parser.existsArg("-") {
@@ -158,16 +171,17 @@ func main() {
 
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			status = 1
+			return
 		}
 	}
-	
-	fmt.Println(parser)
 	
 	changedConfig, err = handleCmd(parser)
 	
 	if err != nil {
 		fmt.Println(err)
+		status = 1
+		//try continue onward
 	}
 	
 	if updated {
@@ -175,6 +189,7 @@ func main() {
 		
 		if err != nil {
 			fmt.Println(err)
+			status = 1
 		}
 	}
 
@@ -183,15 +198,15 @@ func main() {
 		
 		if err != nil {
 			fmt.Println(err)
+			status = 1
 		}
 
 	}
-
-	err = alpmHandle.Release()
-	if err != nil {
-		fmt.Println(err)
-	}
+	
+	return
+	
 }
+
 
 func handleCmd(parser *argParser) (changedConfig bool, err error) {
 	var _changedConfig bool

--- a/cmd.go
+++ b/cmd.go
@@ -225,21 +225,21 @@ func handleCmd(parser *argParser) (changedConfig bool, err error) {
 
 	switch parser.op {
 	case "V", "version":
-		handleVersion()
+		handleVersion(parser)
 	case "D", "database":
-		//passToPacman()
+		passToPacman(parser)
 	case "F", "files":
-		//passToPacman()
+		passToPacman(parser)
 	case "Q", "query":
-		//passToPacman()
+		passToPacman(parser)
 	case "R", "remove":
-		//
+		passToPacman(parser)
 	case "S", "sync":
 		err = handleSync(parser)
 	case "T", "deptest":
-		//passToPacman()
+		passToPacman(parser)
 	case "U", "upgrade":
-		//passToPacman()
+		passToPacman(parser)
 	case "Y", "--yay":
 		err = handleYay(parser)
 	default:
@@ -310,7 +310,7 @@ func handleConfig(option string) (changedConfig bool, err error) {
 	return
 }
 
-func handleVersion() {
+func handleVersion(parser *argParser) {
 	fmt.Printf("yay v%s\n", version)
 }
 
@@ -338,8 +338,9 @@ func handleYay(parser *argParser) (err error) {
 	} else if parser.existsArg("stats") {
 		err = localStatistics()
 	} else if parser.existsArg("cleandeps") {
-		_,_,targets := parser.formatArgs()
-		err = cleanDependencies(targets)
+		//TODO
+		//_,_,targets := parser.formatArgs()
+		//err = cleanDependencies(targets)
 	} else {
 		err = handleYogurt(parser)
 	}
@@ -348,41 +349,37 @@ func handleYay(parser *argParser) (err error) {
 }
 
 func handleYogurt(parser *argParser) (err error) {
-	_, options, targets := parser.formatArgs()
-	
-	config.SearchMode = NumberMenu
-	err = numberMenu(targets, options)
-	
+//	TODO
+//	_, options, targets := parser.formatArgs()
+//	
+//	config.SearchMode = NumberMenu
+//	err = numberMenu(targets, options)
+//	
 	return
 }
 
 func handleSync(parser *argParser) (err error) {
-	op, options, targets := parser.formatArgs()
-	
-	fmt.Println("op", op)
-	fmt.Println("options", options)
-	fmt.Println("targets", targets)
-	
-	if parser.existsArg("y") {
-		err = passToPacman("-Sy", nil, nil)
-		if err != nil {
-			return
-		}
-	}
-	
-	if parser.existsArg("s") {
-		if parser.existsArg("i") {
-			config.SearchMode = Detailed
-		} else {
-			config.SortMode = Minimal
-		}
-		
-		err = syncSearch(targets)
-	}
-	
-	if len(targets) > 0 {
-		err = install(targets, options)
-	}
+//TODO
+//	if parser.existsArg("y") || parser.existsArg("refresh") {
+//		err = passToPacman(parser)
+//		if err != nil {
+//			return
+//		}
+//	}
+//	
+//	if parser.existsArg("s") {
+//		if parser.existsArg("i") {
+//			config.SearchMode = Detailed
+//		} else {
+//			config.SortMode = Minimal
+//		}
+//		
+//		err = syncSearch(targets)
+//	}
+//	
+//	if len(targets) > 0 {
+//		err = install(targets, options)
+//	}
 	
 	return
 }
@@ -451,7 +448,8 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 	}
 
 	if len(repoI) != 0 {
-		err = passToPacman("-S", repoI, flags)
+		//TODO
+		//err = passToPacman("-S", repoI, flags)
 	}
 
 	if len(aurI) != 0 {

--- a/cmd.go
+++ b/cmd.go
@@ -521,7 +521,7 @@ func complete() error {
 	return err
 }
 
-// PassToPacman outsorces execution to pacman binary without modifications.
+// passToPacman outsorces execution to pacman binary without modifications.
 func passToPacman(parser *arguments) error {
 	var cmd *exec.Cmd
 	args := make([]string, 0)
@@ -540,4 +540,20 @@ func passToPacman(parser *arguments) error {
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	err := cmd.Run()
 	return err
+}
+
+// passToMakepkg outsorces execution to makepkg binary without modifications.
+func passToMakepkg(dir string, args ...string) (err error) {
+	cmd := exec.Command(config.MakepkgBin, args...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	cmd.Dir = dir
+	err = cmd.Run()
+	if err == nil {
+		_ = saveVCSInfo()
+		if config.CleanAfter {
+			fmt.Println("\x1b[1;32m==> CleanAfter enabled. Deleting source folder.\x1b[0m")
+			os.RemoveAll(dir)
+		}
+	}
+	return
 }

--- a/config.go
+++ b/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"strings"
 
 	alpm "github.com/jguer/go-alpm"
 )
@@ -198,25 +197,18 @@ func continueTask(s string, def string) (cont bool) {
 }
 
 // PassToPacman outsorces execution to pacman binary without modifications.
-func passToPacman(op string, pkgs []string, flags []string) error {
+func passToPacman(parser *argParser) error {
 	var cmd *exec.Cmd
-	var args []string
-
-	args = append(args, op)
-	if len(pkgs) != 0 {
-		args = append(args, pkgs...)
+	args := make([]string, 0)
+	
+	if parser.needRoot() {
+		args = append(args, "sudo")
 	}
-
-	if len(flags) != 0 {
-		args = append(args, flags...)
-	}
-
-	if strings.Contains(op, "-Q") || op == "Si" {
-		cmd = exec.Command(config.PacmanBin, args...)
-	} else {
-		args = append([]string{config.PacmanBin}, args...)
-		cmd = exec.Command("sudo", args...)
-	}
+	
+	args = append(args, "pacman")
+	args = append(args, parser.formatArgs()...)
+	
+	cmd = exec.Command(args[0], args[1:]...)
 
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	err := cmd.Run()

--- a/config.go
+++ b/config.go
@@ -195,22 +195,3 @@ func continueTask(s string, def string) (cont bool) {
 
 	return true
 }
-
-// PassToPacman outsorces execution to pacman binary without modifications.
-func passToPacman(parser *argParser) error {
-	var cmd *exec.Cmd
-	args := make([]string, 0)
-	
-	if parser.needRoot() {
-		args = append(args, "sudo")
-	}
-	
-	args = append(args, "pacman")
-	args = append(args, parser.formatArgs()...)
-	
-	cmd = exec.Command(args[0], args[1:]...)
-
-	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-	err := cmd.Run()
-	return err
-}

--- a/install.go
+++ b/install.go
@@ -14,10 +14,11 @@ func install(pkgs []string, flags []string) error {
 	aurs, repos, _ := packageSlices(pkgs)
 
 	if len(repos) != 0 {
-		err := passToPacman("-S", repos, flags)
-		if err != nil {
-			fmt.Println("Error installing repo packages.")
-		}
+//TODO
+//		err := passToPacman("-S", repos, flags)
+//		if err != nil {
+//			fmt.Println("Error installing repo packages.")
+//		}
 	}
 
 	if len(aurs) != 0 {
@@ -138,10 +139,11 @@ func PkgInstall(a *rpc.Pkg, flags []string) (finalmdeps []string, err error) {
 	}
 	// Repo dependencies
 	if len(repoDeps) != 0 {
-		errR := passToPacman("-S", repoDeps, depArgs)
-		if errR != nil {
-			return finalmdeps, errR
-		}
+//		TODO
+//		errR := passToPacman("-S", repoDeps, depArgs)
+//		if errR != nil {
+//			return finalmdeps, errR
+//		}
 	}
 
 	// Handle AUR dependencies

--- a/install.go
+++ b/install.go
@@ -10,19 +10,23 @@ import (
 )
 
 // Install handles package installs
-func install(pkgs []string, flags []string) error {
-	aurs, repos, _ := packageSlices(pkgs)
+func install(parser *arguments) error {
+	aurs, repos, _ := packageSlices(parser.targets.toSlice())
 
+	arguments := makeArguments()
+	arguments.op = parser.op
+	arguments.options = arguments.options
+	arguments.addTarget(repos...)
+	
 	if len(repos) != 0 {
-//TODO
-//		err := passToPacman("-S", repos, flags)
-//		if err != nil {
-//			fmt.Println("Error installing repo packages.")
-//		}
+		err := passToPacman(arguments)
+		if err != nil {
+			fmt.Println("Error installing repo packages.")
+		}
 	}
 
 	if len(aurs) != 0 {
-		err := aurInstall(aurs, flags)
+		err := aurInstall(aurs, make([]string,0))
 		if err != nil {
 			fmt.Println("Error installing aur packages.")
 		}
@@ -131,19 +135,19 @@ func PkgInstall(a *rpc.Pkg, flags []string) (finalmdeps []string, err error) {
 		}
 	}
 
-	var depArgs []string
+	arguments := makeArguments()
+	arguments.addArg("S", "asdeps")
+	depArgs := arguments.formatArgs()
+	
 	if config.NoConfirm {
-		depArgs = []string{"--asdeps", "--noconfirm"}
-	} else {
-		depArgs = []string{"--asdeps"}
+		arguments.addArg("noconfirm")
 	}
 	// Repo dependencies
 	if len(repoDeps) != 0 {
-//		TODO
-//		errR := passToPacman("-S", repoDeps, depArgs)
-//		if errR != nil {
-//			return finalmdeps, errR
-//		}
+		errR := passToPacman(arguments)
+		if errR != nil {
+			return finalmdeps, errR
+		}
 	}
 
 	// Handle AUR dependencies

--- a/install.go
+++ b/install.go
@@ -162,18 +162,7 @@ func PkgInstall(a *rpc.Pkg, flags []string) (finalmdeps []string, err error) {
 		}
 	}
 
-	args := []string{"-sri"}
-	args = append(args, flags...)
-	makepkgcmd := exec.Command(config.MakepkgBin, args...)
-	makepkgcmd.Stdin, makepkgcmd.Stdout, makepkgcmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-	makepkgcmd.Dir = dir
-	err = makepkgcmd.Run()
-	if err == nil {
-		_ = saveVCSInfo()
-		if config.CleanAfter {
-			fmt.Println("\x1b[1;32m==> CleanAfter enabled. Deleting source folder.\x1b[0m")
-			os.RemoveAll(dir)
-		}
-	}
+	flags = append(flags, "-sri")
+	err = passToMakepkg(dir, flags...)
 	return
 }

--- a/install.go
+++ b/install.go
@@ -13,9 +13,10 @@ import (
 func install(parser *arguments) error {
 	aurs, repos, _ := packageSlices(parser.targets.toSlice())
 
-	arguments := makeArguments()
-	arguments.op = parser.op
-	arguments.options = arguments.options
+	arguments := parser.copy()
+	arguments.delArg("u", "sysupgrade")
+	arguments.delArg("y", "refresh")
+	arguments.targets = make(stringSet)
 	arguments.addTarget(repos...)
 	
 	if len(repos) != 0 {
@@ -135,13 +136,20 @@ func PkgInstall(a *rpc.Pkg, flags []string) (finalmdeps []string, err error) {
 		}
 	}
 
-	arguments := makeArguments()
-	arguments.addArg("S", "asdeps")
-	depArgs := arguments.formatArgs()
+	arguments := cmdArgs.copy()
+	arguments.addArg("asdeps")
+	arguments.delArg("asexplicit", "ase", "asex")
+	arguments.delArg("u", "sysupgrade")
+	arguments.delArg("y", "refresh")
+	arguments.targets = make(stringSet)
 	
+	var depArgs []string
 	if config.NoConfirm {
-		arguments.addArg("noconfirm")
+		depArgs = []string{"--asdeps", "--noconfirm"}
+	} else {
+		depArgs = []string{"--asdeps"}
 	}
+	
 	// Repo dependencies
 	if len(repoDeps) != 0 {
 		errR := passToPacman(arguments)

--- a/install.go
+++ b/install.go
@@ -18,7 +18,7 @@ func install(parser *arguments) error {
 	arguments.delArg("y", "refresh")
 	arguments.targets = make(stringSet)
 	arguments.addTarget(repos...)
-	
+
 	if len(repos) != 0 {
 		err := passToPacman(arguments)
 		if err != nil {
@@ -27,7 +27,7 @@ func install(parser *arguments) error {
 	}
 
 	if len(aurs) != 0 {
-		err := aurInstall(aurs, make([]string,0))
+		err := aurInstall(aurs, []string{"-S"})
 		if err != nil {
 			fmt.Println("Error installing aur packages.")
 		}
@@ -136,18 +136,15 @@ func PkgInstall(a *rpc.Pkg, flags []string) (finalmdeps []string, err error) {
 		}
 	}
 
-	arguments := cmdArgs.copy()
-	arguments.addArg("asdeps")
-	arguments.delArg("asexplicit", "ase", "asex")
-	arguments.delArg("u", "sysupgrade")
-	arguments.delArg("y", "refresh")
-	arguments.targets = make(stringSet)
-	
+	arguments := makeArguments()
+	arguments.addArg("S", "asdeps", "noconfirm")
+	arguments.addTarget(repoDeps...)
+
 	var depArgs []string
 	if config.NoConfirm {
-		depArgs = []string{"--asdeps", "--noconfirm"}
+		depArgs = []string{"asdeps", "noconfirm"}
 	} else {
-		depArgs = []string{"--asdeps"}
+		depArgs = []string{"asdeps"}
 	}
 	
 	// Repo dependencies

--- a/parser.go
+++ b/parser.go
@@ -195,16 +195,23 @@ func (parser *arguments) existsArg(options ...string) bool {
 	return false
 }
 
-func (parser *arguments) getArg(option string) (arg string, double bool, exists bool) {
-	arg, exists = parser.options[option]
-	
-	if exists {
-		_, double = parser.doubles[option]
-		return
-	}
+func (parser *arguments) getArg(options ...string) (arg string, double bool, exists bool) {
+	for _, option := range options {
+		arg, exists = parser.options[option]
 
-	arg, exists = parser.globals[option]
-	_, double = parser.doubles[option]
+		if exists {
+			_, double = parser.doubles[option]
+			return
+		}
+
+		arg, exists = parser.globals[option]
+		
+		if exists {
+			_, double = parser.doubles[option]
+			return
+		}
+	}
+	
 	return
 }
 
@@ -521,6 +528,14 @@ func (parser *arguments)parseCommandLine() (err error) {
 	
 	if parser.op == "" {
 		parser.op = "Y"
+	}
+	
+	if cmdArgs.existsArg("-") {
+		err = cmdArgs.parseStdin();
+
+		if err != nil {
+			return
+		}
 	}
 	
 	return

--- a/parser.go
+++ b/parser.go
@@ -7,19 +7,21 @@ import (
 	"io"
 )
 
+type set  map[string]struct{}
+
 type argParser struct {
 	op string
 	options map[string]string
-	doubles map[string]struct{} //tracks args passed twice such as -yy and -dd
-	targets map[string]struct{}
+	doubles set //tracks args passed twice such as -yy and -dd
+	targets set
 }
 
 func makeArgParser() *argParser {
 	return &argParser {
 		"",
 		make(map[string]string),
-		make(map[string]struct{}),
-		make(map[string]struct{}),
+		make(set),
+		make(set),
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -134,7 +134,32 @@ func isOp(op string) bool {
 		return true
 	case "U", "upgrade":
 		return true
+        
+    //yay specific
 	case "Y", "yay":
+		return true
+	case "G", "getpkgbuild":
+		return true
+	default:
+		return false
+	}
+}
+
+func isYayParam(arg string) bool {
+	switch arg {
+	case "afterclean":
+		return true
+	case "noafterclean":
+		return true
+	case "devel":
+		return true
+	case "nodevel":
+		return true
+	case "timeupdate":
+		return true
+	case "notimeupdate":
+		return true
+	case "topdown":
 		return true
 	default:
 		return false

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"os"
+	"fmt"
+	"strings"
+	"io"
+)
+
+type argParser struct {
+	op string
+	options map[string]string
+	doubles map[string]struct{} //tracks args passed twice such as -yy and -dd
+	targets map[string]struct{}
+}
+
+func makeArgParser() *argParser {
+	return &argParser {
+		"",
+		make(map[string]string),
+		make(map[string]struct{}),
+		make(map[string]struct{}),
+	}
+}
+
+func (praser *argParser) delArg(option string) {
+	delete(praser.options, option)
+	delete(praser.doubles, option)
+}
+
+func (praser *argParser) addOP(op string) (err error) {
+	if praser.op != "" {
+		err = fmt.Errorf("only one operation may be used at a time")
+		return
+	}
+	
+	praser.op = op
+	return
+}
+
+func (praser *argParser) addParam(option string, arg string) (err error) {
+	if isOp(option) {
+		err = praser.addOP(option)
+		return
+	}
+	
+	if praser.existsArg(option) {
+		praser.doubles[option] = struct{}{}
+	} else {
+		praser.options[option] = arg
+	}
+	
+	return
+}
+
+func (praser *argParser) addArg(option string) (err error) {
+	err = praser.addParam(option, "")
+	return
+}
+
+func (praser *argParser) existsArg(option string) (ok bool) {
+	_, ok = praser.options[option]
+	return ok
+}
+
+func (praser *argParser) getArg(option string) (arg string, double bool, exists bool) {
+	arg, exists = praser.options[option]
+	_, double = praser.doubles[option]
+	return
+}
+
+func (praser *argParser) addTarget(target string) {
+	praser.targets[target] = struct{}{}
+}
+
+func (praser *argParser) delTarget(target string) {
+	delete(praser.targets, target)
+}
+
+func (parser *argParser) existsDouble(option string) bool {
+	_, ok := parser.doubles[option]
+	return ok
+}
+
+func (parser *argParser) formatArgs() (op string, options []string, targets []string) {
+	op = formatArg(parser.op)
+	
+	for option, arg := range parser.options {
+		option = formatArg(option)
+		options = append(options, option)
+		
+		if arg != "" {
+			options = append(options, arg)
+		}
+		
+		if parser.existsDouble(option) {
+			options = append(options, option)
+		}
+	}
+	
+	for target := range parser.targets {
+		targets = append(targets, target)
+	}
+	
+	return
+	
+}
+
+func formatArg(arg string) string {
+	if len(arg) > 1 {
+		arg = "--" + arg
+	} else {
+		arg = "-" + arg
+	}
+	
+	return arg
+}
+
+func isOp(op string) bool {
+	switch op {
+	case "V", "version":
+		return true
+	case "D", "database":
+		return true
+	case "F", "files":
+		return true
+	case "Q", "query":
+		return true
+	case "R", "remove":
+		return true
+	case "S", "sync":
+		return true
+	case "T", "deptest":
+		return true
+	case "U", "upgrade":
+		return true
+	case "Y", "yay":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasParam(arg string) bool {
+	switch arg {
+	case "dbpath", "b":
+		return true
+	case "root", "r":
+		return true
+	case "sysroot":
+		return true
+	case "config":
+		return true
+	case "ignore":
+		return true
+	case "assume-installed":
+		return true
+	case "overwrite":
+		return true
+	case "ask":
+		return true
+	case "cachedir":
+		return true
+	case "hookdir":
+		return true
+	case "logfile":
+		return true
+	case "ignoregroup":
+		return true
+	case "arch":
+		return true
+	case "print-format":
+		return true
+	case "gpgdir":
+		return true
+	case "color":
+		return true
+	default:
+		return false
+	}
+}
+
+//parses short hand options such as:
+//-Syu -b/some/path -
+func (parser *argParser) parseShortOption(arg string, param string) (usedNext bool, err error) {
+	if arg == "-" {
+		err = parser.addArg("-")
+		return
+	}
+	
+	arg = arg[1:]
+	
+	for k, _char := range arg {
+		char := string(_char)
+		
+		if hasParam(char) {
+			if k < len(arg) - 2 {
+				err = parser.addParam(char, arg[k+2:])
+			} else {
+				usedNext = true
+				err = parser.addParam(char, param)
+			}
+			
+			break
+		} else {
+			err = parser.addArg(char)
+			
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}
+
+//parses full length options such as:
+//--sync --refresh --sysupgrade --dbpath /some/path --
+func (parser *argParser) parseLongOption(arg string, param string) (usedNext bool, err error){
+	if arg == "--" {
+		err = parser.addArg(arg)
+		return
+	}
+	
+	arg = arg[2:]
+	
+	if hasParam(arg) {
+		err = parser.addParam(arg, param)
+		usedNext = true
+	} else {
+		err = parser.addArg(arg)
+	}
+	
+	return
+}
+
+func (parser *argParser) parseStdin() (err error) {
+	for true {
+		var target string
+		_, err = fmt.Scan(&target)
+		
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			
+			return
+		}
+		
+		parser.addTarget(target)
+	}
+	
+	return
+}
+
+func (parser *argParser)parseCommandLine() (err error) {
+	args := os.Args[1:]
+	usedNext := false
+	
+	if len(args) < 1 {
+		err = fmt.Errorf("no operation specified (use -h for help)")
+		return
+	}
+
+	for k, arg := range args {
+		var nextArg string
+		
+		if usedNext {
+			usedNext = false
+			continue
+		}
+		
+		if k + 1 < len(args) {
+			nextArg = args[k + 1]
+		}
+		
+		if parser.existsArg("--") {
+			parser.addTarget(arg)
+		} else if strings.HasPrefix(arg, "--") {
+			usedNext, err = parser.parseLongOption(arg, nextArg)
+		} else if strings.HasPrefix(arg, "-") {
+			usedNext, err = parser.parseShortOption(arg, nextArg)
+		} else {
+			parser.addTarget(arg)
+		}
+		
+		if err != nil {
+			return
+		}
+	}
+	
+	if parser.op == "" {
+		parser.op = "Y"
+	}
+	
+	return
+}

--- a/parser.go
+++ b/parser.go
@@ -28,6 +28,52 @@ func (praser *argParser) delArg(option string) {
 	delete(praser.doubles, option)
 }
 
+func (parser *argParser) needRoot() bool {
+	if parser.existsArg("h") || parser.existsArg("help") {
+		return false
+	}
+	
+	if parser.existsArg("p") || parser.existsArg("print") {
+			return false
+	}
+	
+	switch parser.op {
+	case "V", "version":
+		return false
+	case "D", "database":
+		return true
+	case "F", "files":
+		if parser.existsArg("y") || parser.existsArg("refresh") {
+			return true
+		}
+		return false
+	case "Q", "query":
+		return false
+	case "R", "remove":
+		return true
+	case "S", "sync":
+		if parser.existsArg("s") || parser.existsArg("search") {
+			return false
+		}
+		if parser.existsArg("l") || parser.existsArg("list") {
+			return false
+		}
+		return true
+	case "T", "deptest":
+		return false
+	case "U", "upgrade":
+		return true
+        
+    //yay specific
+	case "Y", "yay":
+		return false
+	case "G", "getpkgbuild":
+		return false
+	default:
+		return false
+	}
+}
+
 func (praser *argParser) addOP(op string) (err error) {
 	if praser.op != "" {
 		err = fmt.Errorf("only one operation may be used at a time")
@@ -82,24 +128,25 @@ func (parser *argParser) existsDouble(option string) bool {
 	return ok
 }
 
-func (parser *argParser) formatArgs() (op string, options []string, targets []string) {
-	op = formatArg(parser.op)
+func (parser *argParser) formatArgs() (args []string) {
+	op := formatArg(parser.op)
+	args = append(args, op)
 	
 	for option, arg := range parser.options {
 		option = formatArg(option)
-		options = append(options, option)
+		args = append(args, option)
 		
 		if arg != "" {
-			options = append(options, arg)
+			args = append(args, arg)
 		}
 		
 		if parser.existsDouble(option) {
-			options = append(options, option)
+			args = append(args, option)
 		}
 	}
 	
 	for target := range parser.targets {
-		targets = append(targets, target)
+		args = append(args, target)
 	}
 	
 	return

--- a/query.go
+++ b/query.go
@@ -169,8 +169,11 @@ func syncInfo(pkgS []string, flags []string) (err error) {
 	}
 
 	if len(repoS) != 0 {
-		//TODO
-		//err = passToPacman("-Si", repoS, flags)
+		arguments := makeArguments()
+		arguments.addArg("S", "i")
+		//arguments.addArg(flags...)
+		arguments.addTarget(repoS...)
+		err = passToPacman(arguments)
 	}
 
 	return

--- a/query.go
+++ b/query.go
@@ -169,7 +169,8 @@ func syncInfo(pkgS []string, flags []string) (err error) {
 	}
 
 	if len(repoS) != 0 {
-		err = passToPacman("-Si", repoS, flags)
+		//TODO
+		//err = passToPacman("-Si", repoS, flags)
 	}
 
 	return

--- a/upgrade.go
+++ b/upgrade.go
@@ -332,11 +332,16 @@ func upgradePkgs(flags []string) error {
 			}
 			repoNames = append(repoNames, k.Name)
 		}
-//		TODO
-//		err := passToPacman("-S", repoNames, append(flags, "--noconfirm"))
-//		if err != nil {
-//		fmt.Println("Error upgrading repo packages.")
-//		}
+		
+		arguments := makeArguments()
+		arguments.addArg("-S --noconfirm")
+		arguments.addArg(flags...)
+		arguments.addTarget(repoNames...)
+		
+		err := passToPacman(arguments)
+		if err != nil {
+			fmt.Println("Error upgrading repo packages.")
+		}
 	}
 
 	if len(aurUp) != 0 {

--- a/upgrade.go
+++ b/upgrade.go
@@ -332,11 +332,11 @@ func upgradePkgs(flags []string) error {
 			}
 			repoNames = append(repoNames, k.Name)
 		}
-
-		err := passToPacman("-S", repoNames, append(flags, "--noconfirm"))
-		if err != nil {
-			fmt.Println("Error upgrading repo packages.")
-		}
+//		TODO
+//		err := passToPacman("-S", repoNames, append(flags, "--noconfirm"))
+//		if err != nil {
+//		fmt.Println("Error upgrading repo packages.")
+//		}
 	}
 
 	if len(aurUp) != 0 {

--- a/upgrade.go
+++ b/upgrade.go
@@ -334,7 +334,7 @@ func upgradePkgs(flags []string) error {
 		}
 		
 		arguments := makeArguments()
-		arguments.addArg("-S --noconfirm")
+		arguments.addArg("S", "noconfirm")
 		arguments.addArg(flags...)
 		arguments.addTarget(repoNames...)
 		


### PR DESCRIPTION
This started out as an attempt to fix #62 (which is funny given that its still does not work fully) but strayed into a total redesign of the argument parsing system, which required a lot of changes to the code.

Currently there is a bit of a mess with the mix of old and new but generally it is better than it was before and should be much more versatile to user input:
        `-Syu', '-S -y -u', '--sync --refresh --sysupgrade`
Should all work as expected, as well as the parsing of other arguments befond S, y and u.

Features added/fixed/changed:
- Yay now only calls sudo if root is needed
- Yay will ensure more than one operation has not been selected
- Yay will handle arguments that take arguments correctly  (e.g. -b requires a path) 
- The alpm handle will respect the command line (--config, --root, --dbpath, ect.)
- Major refactoring, should be more scalable for further argument parsing
- Change some command line arguments to be more consistent with pacman's usage (see updated usage in cmd.conf)
-  Always make sure relevant arguments are always passed to pacman  (--config, --root, --dbpath, ect.)
- Always handle fatal errors in main and ensure the relevant cleanup is called even if an error occurs (free alpmhandle, save config, ect.)
- Yay will treat everything after `--` as a literal target
- Yay will try to read from stdin after a `-`

Things that still need to be done before merging:
- [x] Update manpage to reflect usage changes
- [ ] update shell completion to reflect usage changes

Things that need to be done eventually:
- [ ] Ensure calls to makepkg also respect command line arguments
- [ ] Convert more code to use the new  cmdArgs and simlar objects instead of converting back to slices
- [ ] More testing, can be done after merge but should be done before release
- [ ] Move some options from config.go into the argument parser and use config.go for options that save to disk
- [ ] Add a more detailed yay specific help for `yay -Yh`

Bugs that exist but are not important enough to require a fix right now:
- [ ]  --cachedir will not work for multiple cachedirs
- [ ]  conflicting operations (e.g. using -i and -s on sync) will pass by without error
- [ ] reading from stdin does not work as expected and will break keyboard input, should work as expected with --noconfrim
- [ ] passing an argument twice will work (-dd, --nodeps --nodeps) will work as expected but mixing them (--nodeps -d) will not work when yay tries to check if it should skip deps, passes  to pacman will work as expected

These should be opened as issues at some point.

I realise iv'e gone and changed quite a lot here although i believe that's for the better. I suggest you give the commit messages a look. Feedback would be greatly appreciated 
  
  
  
  