### PR TITLE
Fix makepkg not behaving correctly

### DIFF
--- a/install.go
+++ b/install.go
@@ -27,7 +27,7 @@ func install(parser *arguments) error {
 	}
 
 	if len(aurs) != 0 {
-		err := aurInstall(aurs, []string{"-S"})
+		err := aurInstall(aurs, []string{})
 		if err != nil {
 			fmt.Println("Error installing aur packages.")
 		}


### PR DESCRIPTION
This bug was caused by me not thinking when passing flags to aurInstall.
Currently a bunch of functions take an array of flags but we don't really
use them any more after the argument parsing update. These should be
refactored out eventually but I'm holding off until I'm more sure about
how these functions should look.