### PR TITLE
New install algorithm

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -626,16 +626,10 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 	aurI = removeListFromList(aurNI, aurI)
 	repoI = removeListFromList(repoNI, repoI)
 
-	if len(repoI) != 0 {
-		arguments := makeArguments()
-		arguments.addArg("S")
-		arguments.addTarget(repoI...)
-		err = passToPacman(arguments)
-	}
-
-	if len(aurI) != 0 {
-		err = aurInstall(aurI, nil)
-	}
+	arguments := makeArguments()
+	arguments.addTarget(repoI...)
+	arguments.addTarget(aurI...)
+	err = install(arguments)
 
 	return err
 }

--- a/install.go
+++ b/install.go
@@ -1,17 +1,28 @@
 package main
 
+
 import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 
 	rpc "github.com/mikkeloscar/aur"
 	gopkg "github.com/mikkeloscar/gopkgbuild"
+	alpm "github.com/jguer/go-alpm"
 )
 
-// Install handles package installs
+// Install handles package installs	
 func install(parser *arguments) error {
-	aurs, repos, _ := packageSlices(parser.targets.toSlice())
+	aurs, repos, missing, err := packageSlices(parser.targets.toSlice())
+	if err != nil {
+		return err
+	}
+
+	if len(missing) > 0 {
+		fmt.Println(missing)
+		return fmt.Errorf("Could not find all Targets")
+	}
 
 	arguments := parser.copy()
 	arguments.delArg("u", "sysupgrade")
@@ -27,147 +38,216 @@ func install(parser *arguments) error {
 	}
 
 	if len(aurs) != 0 {
-		err := aurInstall(aurs, []string{})
+		//todo make pretty
+		fmt.Println("Resolving Dependencies")
+		
+		dt, err := getDepTree(aurs)
 		if err != nil {
-			fmt.Println("Error installing aur packages.")
+			return err
 		}
+
+		if len(dt.Missing) >  0 {
+			fmt.Println(dt.Missing)
+			return fmt.Errorf("Could not find all Deps")
+		}
+		
+		dc, err := getDepCatagories(aurs, dt)
+		if err != nil {
+			return err
+		}
+
+		for _, pkg := range dc.AurMake {
+			if pkg.Maintainer == "" {
+				fmt.Printf("\x1b[1;31;40m==> Warning:\x1b[0;;40m %s is orphaned.\x1b[0m\n", pkg.Name + "-" + pkg.Version)
+			}
+		}
+
+		for _, pkg := range dc.Aur {
+			if pkg.Maintainer == "" {
+				fmt.Printf("\x1b[1;31;40m==> Warning:\x1b[0;;40m %s is orphaned.\x1b[0m\n", pkg.Name + "-" + pkg.Version)
+			}
+		}
+
+		fmt.Println()
+
+
+		p1 := func(a []*alpm.Package) {
+			for _, v := range a {
+				fmt.Print("  ", v.Name())
+			}
+		}
+
+		p2 := func(a []*rpc.Pkg) {
+			for _, v := range a {
+				fmt.Print("  ", v.Name)
+			}
+		}
+
+		fmt.Print("Repo (" + strconv.Itoa(len(dc.Repo)) + "):")
+		p1(dc.Repo)
+		fmt.Println()
+
+		fmt.Print("Repo Make (" + strconv.Itoa(len(dc.RepoMake)) + "):")
+		p1(dc.RepoMake)
+		fmt.Println()
+
+		fmt.Print("Aur (" + strconv.Itoa(len(dc.Aur)) + "):")
+		p2(dc.Aur)
+		fmt.Println()
+
+		fmt.Print("Aur Make (" + strconv.Itoa(len(dc.AurMake)) + "):")
+		p2(dc.AurMake)
+		fmt.Println()
+
+		fmt.Println()
+	
+		askCleanBuilds(dc.AurMake)
+		askCleanBuilds(dc.Aur)
+
+		fmt.Println()
+
+		if !continueTask("Proceed with download?", "nN") {
+			return fmt.Errorf("Aborting due to user")
+		}
+
+		err = dowloadPkgBuilds(dc.AurMake)
+		if err != nil {
+			return err
+		}
+		err = dowloadPkgBuilds(dc.Aur)
+		if err != nil {
+			return err
+		}
+
+		askEditPkgBuilds(dc.AurMake)
+		askEditPkgBuilds(dc.Aur)
+
+		if !continueTask("Proceed with install?", "nN") {
+			return fmt.Errorf("Aborting due to user")
+		}
+
+		err = downloadPkgBuildsSources(dc.AurMake)
+		if err != nil {
+			return err
+		}
+		err = downloadPkgBuildsSources(dc.Aur)
+		if err != nil {
+			return err
+		}
+
+		err = buildInstallPkgBuilds(dc.AurMake, parser.targets)
+		if err != nil {
+			return err
+		}
+		err = buildInstallPkgBuilds(dc.Aur, parser.targets)
+		if err != nil {
+			return err
+		}
+
+		if len(dc.RepoMake) + len(dc.AurMake) > 0 {
+			if continueTask("Remove make dependancies?", "yY") {
+				return nil
+			}
+
+			removeArguments := makeArguments()
+			removeArguments.addArg("R")
+			
+			for _, pkg := range dc.RepoMake {
+				removeArguments.addTarget(pkg.Name())
+			}
+
+			for _, pkg := range dc.AurMake {
+				removeArguments.addTarget(pkg.Name)
+			}
+
+			passToPacman(removeArguments)
+		}
+	
+		return nil
 	}
+
 	return nil
 }
 
-// Install sends system commands to make and install a package from pkgName
-func aurInstall(pkgName []string, flags []string) (err error) {
-	q, err := rpc.Info(pkgName)
-	if err != nil {
-		return
-	}
-
-	if len(q) != len(pkgName) {
-		fmt.Printf("Some packages from list\n%+v\n do not exist", pkgName)
-	}
-
-	var finalrm []string
-	for _, i := range q {
-		mrm, err := PkgInstall(&i, flags)
-		if err != nil {
-			fmt.Println("Error installing", i.Name, ":", err)
-		}
-		finalrm = append(finalrm, mrm...)
-	}
-
-	if len(finalrm) != 0 {
-		err = removeMakeDeps(finalrm)
-	}
-
-	return err
-}
-
-func setupPackageSpace(a *rpc.Pkg) (dir string, pkgbuild *gopkg.PKGBUILD, err error) {
-	dir = config.BuildDir + a.PackageBase + "/"
-
-	if _, err = os.Stat(dir); !os.IsNotExist(err) {
-		if !continueTask("Directory exists. Clean Build?", "yY") {
-			_ = os.RemoveAll(config.BuildDir + a.PackageBase)
-		}
-	}
-
-	if err = downloadAndUnpack(baseURL+a.URLPath, config.BuildDir, false); err != nil {
-		return
-	}
-
-	if !continueTask("Edit PKGBUILD?", "yY") {
-		editcmd := exec.Command(editor(), dir+"PKGBUILD")
-		editcmd.Stdin, editcmd.Stdout, editcmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-		editcmd.Run()
-	}
-
-	pkgbuild, err = gopkg.ParseSRCINFO(dir + ".SRCINFO")
-	if err == nil {
-		for _, pkgsource := range pkgbuild.Source {
-			owner, repo := parseSource(pkgsource)
-			if owner != "" && repo != "" {
-				err = branchInfo(a.Name, owner, repo)
-				if err != nil {
-					fmt.Println(err)
-				}
+func askCleanBuilds(pkgs []*rpc.Pkg) {
+	for _, pkg := range pkgs {
+		dir := config.BuildDir + pkg.PackageBase + "/"
+		
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			if !continueTask(pkg.Name + " Directory exists. Clean Build?", "yY") {
+				_ = os.RemoveAll(config.BuildDir + pkg.PackageBase)
 			}
 		}
 	}
+}
+
+func askEditPkgBuilds(pkgs []*rpc.Pkg) {
+	for _, pkg := range pkgs {
+		dir := config.BuildDir + pkg.PackageBase + "/"
+		
+		if !continueTask(pkg.Name + " Edit PKGBUILD?", "yY") {
+			editcmd := exec.Command(editor(), dir+"PKGBUILD")
+			editcmd.Stdin, editcmd.Stdout, editcmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+			editcmd.Run()
+		}
+
+		pkgbuild, err := gopkg.ParseSRCINFO(dir + ".SRCINFO")
+		if err == nil {
+			for _, pkgsource := range pkgbuild.Source {
+				owner, repo := parseSource(pkgsource)
+				if owner != "" && repo != "" {
+					err = branchInfo(pkg.Name, owner, repo)
+					if err != nil {
+						fmt.Println(err)
+					}
+				}
+			}
+		}
+
+	}
+}
+
+func dowloadPkgBuilds(pkgs []*rpc.Pkg) (err error) {
+	for _, pkg := range pkgs {
+		//todo make pretty
+		fmt.Println("Downloading:", pkg.Name + "-" + pkg.Version)
+
+		err = downloadAndUnpack(baseURL + pkg.URLPath, config.BuildDir, false)
+		if err != nil{
+			return
+		}
+	}
+
 	return
 }
 
-// PkgInstall handles install from Info Result.
-func PkgInstall(a *rpc.Pkg, flags []string) (finalmdeps []string, err error) {
-	fmt.Printf("\x1b[1;32m==> Installing\x1b[33m %s\x1b[0m\n", a.Name)
-	if a.Maintainer == "" {
-		fmt.Println("\x1b[1;31;40m==> Warning:\x1b[0;;40m This package is orphaned.\x1b[0m")
-	}
-
-	dir, _, err := setupPackageSpace(a)
-	if err != nil {
-		return
-	}
-
-	if specialDBsauce {
-		return
-	}
-
-	runDeps, makeDeps, err := pkgDependencies(a)
-	if err != nil {
-		return
-	}
-
-	repoDeps := append(runDeps[0], makeDeps[0]...)
-	aurDeps := append(runDeps[1], makeDeps[1]...)
-	finalmdeps = append(finalmdeps, makeDeps[0]...)
-	finalmdeps = append(finalmdeps, makeDeps[1]...)
-
-	if len(aurDeps) != 0 || len(repoDeps) != 0 {
-		if !continueTask("Continue?", "nN") {
-			return finalmdeps, fmt.Errorf("user did not like the dependencies")
+func downloadPkgBuildsSources(pkgs []*rpc.Pkg) (err error) {
+	for _, pkg := range pkgs {
+		dir := config.BuildDir + pkg.PackageBase + "/"
+		err = passToMakepkg(dir, "-f", "--verifysource")
+		if err != nil {
+			return
 		}
 	}
 
-	aurQ, _ := rpc.Info(aurDeps)
-	if len(aurQ) != len(aurDeps) {
-		(aurQuery)(aurQ).missingPackage(aurDeps)
-		if !continueTask("Continue?", "nN") {
-			return finalmdeps, fmt.Errorf("unable to install dependencies")
+	return
+}
+
+func buildInstallPkgBuilds(pkgs []*rpc.Pkg, targets stringSet) (err error) {
+	//for n := len(pkgs) -1 ; n > 0; n-- {
+	for n := 0; n < len(pkgs); n++ {
+		pkg := pkgs[n]
+
+		dir := config.BuildDir + pkg.PackageBase + "/"
+		if targets.get(pkg.Name) {
+			err = passToMakepkg(dir, "-Cscfi", "--noconfirm")
+		} else {
+			err = passToMakepkg(dir, "-Cscfi", "--noconfirm", "--asdeps")
+		}
+		if err != nil {
+			return
 		}
 	}
 
-	arguments := makeArguments()
-	arguments.addArg("S", "asdeps", "noconfirm")
-	arguments.addTarget(repoDeps...)
-
-	var depArgs []string
-	if config.NoConfirm {
-		depArgs = []string{"asdeps", "noconfirm"}
-	} else {
-		depArgs = []string{"asdeps"}
-	}
-
-	// Repo dependencies
-	if len(repoDeps) != 0 {
-		errR := passToPacman(arguments)
-		if errR != nil {
-			return finalmdeps, errR
-		}
-	}
-
-	// Handle AUR dependencies
-	for _, dep := range aurQ {
-		finalmdepsR, errA := PkgInstall(&dep, depArgs)
-		finalmdeps = append(finalmdeps, finalmdepsR...)
-
-		if errA != nil {
-			cleanRemove(repoDeps)
-			cleanRemove(aurDeps)
-			return finalmdeps, errA
-		}
-	}
-
-	flags = append(flags, "-sri")
-	err = passToMakepkg(dir, flags...)
 	return
 }

--- a/parser.go
+++ b/parser.go
@@ -9,6 +9,19 @@ import (
 
 type stringSet map[string]struct{}
 
+func (set stringSet) set(v string) {
+	set[v] = struct{}{}
+}
+
+func (set stringSet) get(v string) bool {
+	_, exists := set[v]
+	return exists
+}
+
+func (set stringSet) remove(v string) {
+	delete(set, v)
+}
+
 func (set stringSet) getAny() string {
 	for v := range set {
 		return v
@@ -30,7 +43,7 @@ func (set stringSet) toSlice() []string {
 
 func (set stringSet) removeAny() string {
 	v := set.getAny()
-	delete(set, v)
+	set.remove(v)
 	return v
 }
 

--- a/print.go
+++ b/print.go
@@ -254,3 +254,12 @@ func localStatistics() error {
 
 	return nil
 }
+
+//todo make pretty
+func printMissing(missing stringSet) {
+	fmt.Print("Packages not found in repos or aur:")
+		for pkg := range missing {
+			fmt.Print(" ", pkg)
+		}
+		fmt.Println()
+}

--- a/upgrade.go
+++ b/upgrade.go
@@ -365,8 +365,14 @@ func upgradePkgs(flags []string) error {
 		repoNums = removeIntListFromList(excludeRepo, repoNums)
 	}
 
+	arguments := cmdArgs.copy()
+	arguments.delArg("u", "sysupgrade")
+	arguments.delArg("y", "refresh")
+	
+	var repoNames []string
+	var aurNames []string
+
 	if len(repoUp) != 0 {
-		var repoNames []string
 	repoloop:
 		for i, k := range repoUp {
 			for _, j := range repoNums {
@@ -376,20 +382,9 @@ func upgradePkgs(flags []string) error {
 			}
 			repoNames = append(repoNames, k.Name)
 		}
-
-		arguments := makeArguments()
-		arguments.addArg("S", "noconfirm")
-		arguments.addArg(flags...)
-		arguments.addTarget(repoNames...)
-
-		err := passToPacman(arguments)
-		if err != nil {
-			fmt.Println("Error upgrading repo packages.")
-		}
 	}
 
 	if len(aurUp) != 0 {
-		var aurNames []string
 	aurloop:
 		for i, k := range aurUp {
 			for _, j := range aurNums {
@@ -399,7 +394,10 @@ func upgradePkgs(flags []string) error {
 			}
 			aurNames = append(aurNames, k.Name)
 		}
-		aurInstall(aurNames, flags)
 	}
-	return nil
+	
+	arguments.addTarget(repoNames...)
+	arguments.addTarget(aurNames...)
+	err = install(arguments)
+	return err
 }

--- a/vcs.go
+++ b/vcs.go
@@ -38,7 +38,9 @@ func createDevelDB() error {
 
 	config.NoConfirm = true
 	specialDBsauce = true
-	err = aurInstall(remoteNames, nil)
+	arguments := makeArguments()
+	arguments.addTarget(remoteNames...)
+	err = install(arguments)
 	return err
 }
 


### PR DESCRIPTION
```I have replaced the old install and dependancy algorithms with a new
design that attemps to be more pacaur like. Mostly in minimizing user
input. Ask every thing first then do everything with no need for more
user input.

It is not yet fully complete but is finished enough so that it works,
should not fail in most cases and provides a base for more contributors
to help address the existing problems.

The new install chain is as follows:
	Source info about the provided targets
	Fetch a list of all dependancies needed to install targets
		I put alot of effort into fetching the dependancy tree
		while making the least amount of aur requests as
		possible. I'm actually very happy with how it turned out
		and yay wil now resolve dependancies noticably faster
		than pacaur when there are many aur dependancies.
	Install repo targets by passing to pacman
	Print dependancy tree and ask to confirm
	Ask to clean build if directory already exists
	Download all pkgbuilds
	Ask to edit all pkgbuilds
	Ask to continue with the install
	Download the sources for each packagebuild
	Build and install every package
		using -s to get repo deps and -i to install
	Ask to remove make dependancies

There are still a lot of things that need to be done for a fully working
system. Here are the problems I found with this system, either new or
existing:
	Formating
		I am not so good at formatting myself, I thought best to
		leave it until last so I could get feedback on how it
		should look and help implementing it.
	Dependancy tree
		The dependancy tree is usually correct although I have
		noticed times where it doesnt detect all the
		dependancies that it should. I have only noticed this
		when there are circular dependancies so i think this
		might be the cause. It's not a big deal currently
		because makepkg -i installed repo deps for us which
		handles the repo deps for us and will get the correct
		ones. So yay might not list all the dependancies. but
		they will get installed so I consider this a visual bug.
		I have yet to see any circular dependancies in the AUR
		so I can not say what will happend but I#m guessing that
		it will break.
	Versioned packages/dependencies
		Targets and dependancies with version constriants such
		as 'linux>=4.1' will not be checked on the aur side of
		things but will be checked on the repo side.
	Ignorepkg/Ignoregroup
		Currently I do not handle this in any way but it
		shouldn't be too hard to implement.
	Conflict checking
		This is not currently implemented either
	Split Paclages
		Split packages are not Handles properly. If we only
		specify one package so install from a split package
		makepkg -i ends up installing them all anyway. If we
		specify more than one (n) package it will actually build the
		package base n times and reinstall every split package
		n times.
	Makepkg
		To get things working I decided to keep using the
		makepkg -i method. I plan to eventually replace this
		with a pacman -U based method. This should allow passing
		args such as --dbpath and --config to aur packages
		aswell as help solve some problems such as the split
		packages.
	Clean build
		I plan to improve the clean build choice to be a little
		more smart and instead of check if the directory exists,
		check if the package is already build and if so skip the
		build all together.
```

Here is an example of the install process,  printing is non final and needs to be improved.
Note makepkg has been replaced by a dud program that prints the command issued as to simplify the output for this example.
 
![image](https://user-images.githubusercontent.com/16593899/35182560-54465464-fdcf-11e7-9190-64c49c1355af.png)

![image](https://user-images.githubusercontent.com/16593899/35182562-702bf0da-fdcf-11e7-85f1-984d591a1e12.png)

This pr relates to #10 #27 #65 although might not directly fix them just yet. But they should be kept in mind. I will probably open an issue linking here and explaining the issue again after this is merged as a way to keep track of progress with this system.