### PR TITLE
Fix install not listing all dependencies

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -175,6 +175,10 @@ func repoTreeRecursive(pkg *alpm.Package, dt *depTree, localDb *alpm.Db, syncDb 
 	}
 
 	dt.Repo[pkg.Name()] = pkg
+	(*pkg).Provides().ForEach(func(dep alpm.Depend) (err error) {
+		dt.Repo[dep.Name] = pkg
+		return nil
+	})
 
 	(*pkg).Depends().ForEach(func(dep alpm.Depend) (err error) {
 		_, exists := dt.Repo[dep.Name]


### PR DESCRIPTION
Sometimes yay will not list all of the dependancies it needs when
installing packages. I mostly noticed this on libjpeg-turbo and the
issue was that the packages requring libjpeg-turbo were only requesting
libjpeg which was provided by libjpeg-turbo.

Now when we cache package info from the syncdb also alias the package name
to all of it's provides.