### PR TITLE
Fixes #122 properly

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,6 +61,9 @@ var completionFile string
 // Updated returns if database has been updated
 var updated bool
 
+// changedConfig holds whether or not the config has changed
+var changedConfig bool
+
 // YayConf holds the current config values for yay.
 var config Configuration
 

--- a/parser.go
+++ b/parser.go
@@ -447,10 +447,6 @@ func (parser *arguments) parseShortOption(arg string, param string) (usedNext bo
 
 	arg = arg[1:]
 
-	if isYayParam(arg) {
-		return
-	}
-
 	for k, _char := range arg {
 		char := string(_char)
 
@@ -484,10 +480,6 @@ func (parser *arguments) parseLongOption(arg string, param string) (usedNext boo
 	}
 
 	arg = arg[2:]
-
-	if isYayParam(arg) {
-		return
-	}
 
 	if hasParam(arg) {
 		err = parser.addParam(arg, param)


### PR DESCRIPTION
Options such as --devel are now striped from the parser before handling
the command but the option is still processed so that config.devel would
be true.

Also changed `changedConfig` to a global in config.go