### PR TITLE
Clone ABS/AUR Git repository instead of tarball

### DIFF
--- a/download.go
+++ b/download.go
@@ -2,66 +2,12 @@ package main
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
-	"strings"
+	"path"
 
 	rpc "github.com/mikkeloscar/aur"
 )
-
-func downloadFile(path string, url string) (err error) {
-	// Create the file
-	out, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	// Get the data
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Writer the body to file
-	_, err = io.Copy(out, resp.Body)
-	return err
-}
-
-// DownloadAndUnpack downloads url tgz and extracts to path.
-func downloadAndUnpack(url string, path string, trim bool) (err error) {
-	err = os.MkdirAll(path, 0755)
-	if err != nil {
-		return
-	}
-
-	tokens := strings.Split(url, "/")
-	fileName := tokens[len(tokens)-1]
-
-	tarLocation := path + fileName
-	defer os.Remove(tarLocation)
-
-	err = downloadFile(tarLocation, url)
-	if err != nil {
-		return
-	}
-
-	if trim {
-		err = exec.Command("/bin/sh", "-c",
-			config.TarBin+" --strip-components 2 --include='*/"+fileName[:len(fileName)-7]+"/trunk/' -xf "+tarLocation+" -C "+path).Run()
-		os.Rename(path+"trunk", path+fileName[:len(fileName)-7]) // kurwa
-	} else {
-		err = exec.Command(config.TarBin, "-xf", tarLocation, "-C", path).Run()
-	}
-	if err != nil {
-		return
-	}
-
-	return
-}
 
 func getPkgbuild(pkg string) (err error) {
 	wd, err := os.Getwd()
@@ -80,7 +26,7 @@ func getPkgbuild(pkg string) (err error) {
 }
 
 // GetPkgbuild downloads pkgbuild from the ABS.
-func getPkgbuildfromABS(pkgN string, path string) (err error) {
+func getPkgbuildfromABS(pkgN string, dir string) (err error) {
 	dbList, err := alpmHandle.SyncDbs()
 	if err != nil {
 		return
@@ -91,14 +37,14 @@ func getPkgbuildfromABS(pkgN string, path string) (err error) {
 		if err == nil {
 			var url string
 			if db.Name() == "core" || db.Name() == "extra" {
-				url = "https://projects.archlinux.org/svntogit/packages.git/snapshot/packages/" + pkg.Name() + ".tar.gz"
+				url = "https://git.archlinux.org/svntogit/packages.git"
 			} else if db.Name() == "community" {
-				url = "https://projects.archlinux.org/svntogit/community.git/snapshot/community-packages/" + pkg.Name() + ".tar.gz"
+				url = "https://git.archlinux.org/svntogit/community.git"
 			} else {
 				return fmt.Errorf("Not in standard repositories")
 			}
 			fmt.Println(boldGreenFg(arrow), boldYellowFg(pkgN), boldGreenFg("found in ABS."))
-			errD := downloadAndUnpack(url, path, true)
+			errD := exec.Command("git", "clone", "--single-branch", "--branch", "packages/"+pkg.Name(), url, path.Join(dir, pkg.Name())).Run()
 			return errD
 		}
 	}
@@ -117,6 +63,11 @@ func getPkgbuildfromAUR(pkgN string, dir string) (err error) {
 	}
 
 	fmt.Println(boldGreenFg(arrow), boldYellowFg(pkgN), boldGreenFg("found in AUR."))
-	downloadAndUnpack(baseURL+aq[0].URLPath, dir, false)
+	url := "aur@aur.archlinux.org/" + aq[0].Name + ".git"
+	err = exec.Command("git", "clone", "ssh+git://"+url, path.Join(dir, aq[0].Name)).Run()
+	if err != nil {
+		// attempt https protocol which does not require SSH key setup
+		err = exec.Command("git", "clone", "https://"+url, path.Join(dir, aq[0].Name)).Run()
+	}
 	return
 }

--- a/download.go
+++ b/download.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 
 	rpc "github.com/mikkeloscar/aur"
 )
@@ -44,7 +44,7 @@ func getPkgbuildfromABS(pkgN string, dir string) (err error) {
 				return fmt.Errorf("Not in standard repositories")
 			}
 			fmt.Println(boldGreenFg(arrow), boldYellowFg(pkgN), boldGreenFg("found in ABS."))
-			errD := exec.Command("git", "clone", "--single-branch", "--branch", "packages/"+pkg.Name(), url, path.Join(dir, pkg.Name())).Run()
+			errD := gitCheckout(url, "packages/"+pkg.Name(), filepath.Join(dir, pkg.Name()))
 			return errD
 		}
 	}
@@ -64,10 +64,44 @@ func getPkgbuildfromAUR(pkgN string, dir string) (err error) {
 
 	fmt.Println(boldGreenFg(arrow), boldYellowFg(pkgN), boldGreenFg("found in AUR."))
 	url := "aur@aur.archlinux.org/" + aq[0].Name + ".git"
-	err = exec.Command("git", "clone", "ssh+git://"+url, path.Join(dir, aq[0].Name)).Run()
+	err = gitCheckout("ssh+git://"+url, "master", filepath.Join(dir, aq[0].Name))
 	if err != nil {
 		// attempt https protocol which does not require SSH key setup
-		err = exec.Command("git", "clone", "https://"+url, path.Join(dir, aq[0].Name)).Run()
+		err = gitCheckout("https://"+url, "master", filepath.Join(dir, aq[0].Name))
 	}
 	return
+}
+
+func gitCheckout(repo, branch, path string) error {
+	// based on https://github.com/golang/tools/blob/master/cmd/tip/tip.go checkout
+	// Clone git repo if it does not exist.
+	if _, err := os.Stat(filepath.Join(path, ".git")); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return fmt.Errorf("mkdir: %v", err)
+		}
+		if err := exec.Command("git", "clone", "--single-branch", "--branch", branch, repo, path).Run(); err != nil {
+			return fmt.Errorf("clone: %v", err)
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("stat .git: %v", err)
+	}
+
+	// Pull down changes and update to hash.
+	cmd := exec.Command("git", "fetch")
+	cmd.Dir = path
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("fetch: %v", err)
+	}
+	cmd = exec.Command("git", "reset", "--hard", "origin/"+branch)
+	cmd.Dir = path
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("reset: %v", err)
+	}
+	cmd = exec.Command("git", "clean", "-d", "-f", "-x")
+	cmd.Dir = path
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("clean: %v", err)
+	}
+	return nil
 }

--- a/install.go
+++ b/install.go
@@ -213,7 +213,7 @@ func dowloadPkgBuilds(pkgs []*rpc.Pkg) (err error) {
 		//todo make pretty
 		fmt.Println("Downloading:", pkg.Name+"-"+pkg.Version)
 
-		err = downloadAndUnpack(baseURL+pkg.URLPath, config.BuildDir, false)
+		err = getPkgbuildfromAUR(pkg.Name, config.BuildDir)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Meant for discussion. Instead of downloading and unpacking the package source tarball, clone the corresponding Git repository. Inspired by https://github.com/falconindy/asp. Adds `git` as package dependency.