### PR TITLE
Prettify repository download messages

### DIFF
--- a/config.go
+++ b/config.go
@@ -186,7 +186,7 @@ func continueTask(s string, def string) (cont bool) {
 	}
 
 	var response string
-	fmt.Print(boldGreenFg(arrow+" "+s), boldWhiteFg(postFix))
+	fmt.Print(boldGreenFg(arrow+" "+s+" "), boldWhiteFg(postFix))
 
 	n, err := fmt.Scanln(&response)
 	if err != nil || n == 0 {

--- a/install.go
+++ b/install.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 
-	alpm "github.com/jguer/go-alpm"
 	rpc "github.com/mikkeloscar/aur"
 	gopkg "github.com/mikkeloscar/gopkgbuild"
 )
@@ -70,37 +68,10 @@ func install(parser *arguments) error {
 			}
 		}
 
-		fmt.Println()
-
-		p1 := func(a []*alpm.Package) {
-			for _, v := range a {
-				fmt.Print("  ", v.Name())
-			}
-		}
-
-		p2 := func(a []*rpc.Pkg) {
-			for _, v := range a {
-				fmt.Print("  ", v.Name)
-			}
-		}
-
-		fmt.Print("Repo (" + strconv.Itoa(len(dc.Repo)) + "):")
-		p1(dc.Repo)
-		fmt.Println()
-
-		fmt.Print("Repo Make (" + strconv.Itoa(len(dc.RepoMake)) + "):")
-		p1(dc.RepoMake)
-		fmt.Println()
-
-		fmt.Print("Aur (" + strconv.Itoa(len(dc.Aur)) + "):")
-		p2(dc.Aur)
-		fmt.Println()
-
-		fmt.Print("Aur Make (" + strconv.Itoa(len(dc.AurMake)) + "):")
-		p2(dc.AurMake)
-		fmt.Println()
-
-		fmt.Println()
+		printDownloadsFromRepo("Repo", dc.Repo)
+		printDownloadsFromRepo("Repo Make", dc.RepoMake)
+		printDownloadsFromAur("AUR", dc.Aur)
+		printDownloadsFromAur("AUR Make", dc.AurMake)
 
 		askCleanBuilds(dc.AurMake)
 		askCleanBuilds(dc.Aur)

--- a/print.go
+++ b/print.go
@@ -100,8 +100,10 @@ func printDownloadsFromRepo(repoType string, repo []*alpm.Package) {
 	for _, v := range repo {
 		packages += v.Name() + " "
 	}
+	repoInfo := boldBlueFg(
+		"[" + repoType + ", " + strconv.Itoa(len(repo)) + " packages] ")
 	if len(repo) > 0 {
-		printDownloads(repoType, packages, len(repo))
+		printDownloads(repoInfo, packages)
 	}
 }
 
@@ -111,15 +113,15 @@ func printDownloadsFromAur(repoType string, repo []*rpc.Pkg) {
 	for _, v := range repo {
 		packages += v.Name + " "
 	}
+	repoInfo := redFg(
+		"[" + repoType + ", " + strconv.Itoa(len(repo)) + " packages] ")
 	if len(repo) > 0 {
-		printDownloads(repoType, packages, len(repo))
+		printDownloads(repoInfo, packages)
 	}
 }
 
-func printDownloads(repoType, packages string, numPackages int) {
-	fmt.Println(
-		redFg("["+repoType+", "+strconv.Itoa(numPackages)+" packages] ") +
-			yellowFg(packages))
+func printDownloads(repoInfo, packages string) {
+	fmt.Println(repoInfo + yellowFg(packages))
 }
 
 func printDeps(repoDeps []string, aurDeps []string) {

--- a/print.go
+++ b/print.go
@@ -94,6 +94,34 @@ func (s repoQuery) printSearch() {
 	}
 }
 
+// printDownloadsFromRepo prints repository packages to be downloaded
+func printDownloadsFromRepo(repoType string, repo []*alpm.Package) {
+	var packages string
+	for _, v := range repo {
+		packages += v.Name() + " "
+	}
+	if len(repo) > 0 {
+		printDownloads(repoType, packages, len(repo))
+	}
+}
+
+// printDownloadsFromAur prints AUR packages to be downloaded
+func printDownloadsFromAur(repoType string, repo []*rpc.Pkg) {
+	var packages string
+	for _, v := range repo {
+		packages += v.Name + " "
+	}
+	if len(repo) > 0 {
+		printDownloads(repoType, packages, len(repo))
+	}
+}
+
+func printDownloads(repoType, packages string, numPackages int) {
+	fmt.Println(
+		redFg("["+repoType+", "+strconv.Itoa(numPackages)+" packages] ") +
+			yellowFg(packages))
+}
+
 func printDeps(repoDeps []string, aurDeps []string) {
 	if len(repoDeps) != 0 {
 		fmt.Print(boldGreenFg(arrow + " Repository dependencies: "))


### PR DESCRIPTION
A simple commit to improve the looks of the message saying what will be downloaded and from which repositories.

Before:

![image](https://user-images.githubusercontent.com/2140932/35826392-3913281e-0a7e-11e8-8693-0e0fc6a85d38.png)

After:

![screenshot from 2018-02-05 14-10-25](https://user-images.githubusercontent.com/2140932/35826476-6ef007d6-0a7e-11e8-96f6-3ab187d25b45.png)
