### PR TITLE
Improvements to install algorithm

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -702,11 +702,6 @@ func passToMakepkg(dir string, args ...string) (err error) {
 	err = cmd.Run()
 	if err == nil {
 		_ = saveVCSInfo()
-		if config.CleanAfter {
-			fmt.Println(boldGreenFg(arrow +
-				" CleanAfter enabled. Deleting source folder."))
-			os.RemoveAll(dir)
-		}
 	}
 	return
 }

--- a/dependencies.go
+++ b/dependencies.go
@@ -80,6 +80,22 @@ func getDepCatagories(pkgs []string, dt *depTree) (*depCatagories, error) {
 		}
 	}
 
+	for _, base := range dc.Bases {
+		for _, pkg := range base {
+			for _, dep := range pkg.Depends {
+				dc.MakeOnly.remove(dep)
+			}
+		}
+	}
+
+	for _, pkg := range dc.Repo {
+		pkg.Depends().ForEach(func(_dep alpm.Depend) error {
+			dep := _dep.Name
+			dc.MakeOnly.remove(dep)
+
+			return nil
+		})
+	}
 
 	return dc, nil
 }

--- a/install.go
+++ b/install.go
@@ -195,6 +195,11 @@ func install(parser *arguments) error {
 			config.NoConfirm = oldValue
 		}
 
+		if config.CleanAfter {
+			clean(dc.AurMake)
+			clean(dc.Aur)
+		}
+
 		return nil
 	}
 
@@ -415,6 +420,17 @@ func buildInstallPkgBuilds(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 
 	return nil
 }
+
+func clean(pkgs []*rpc.Pkg) {
+	for _, pkg := range pkgs {
+		dir := config.BuildDir + pkg.PackageBase + "/"
+
+		fmt.Println(boldGreenFg(arrow +
+			" CleanAfter enabled. Deleting " + pkg.Name  +" source folder."))
+		os.RemoveAll(dir)
+	}
+}
+
 
 func completeFileName(dir, name string) (string, error) {
         files, err := ioutil.ReadDir(dir)

--- a/install.go
+++ b/install.go
@@ -84,6 +84,30 @@ func install(parser *arguments) error {
 		if !continueTask("Proceed with install?", "nN") {
 			return fmt.Errorf("Aborting due to user")
 		}
+
+		if len(dc.RepoMake) + len(dc.Repo) > 0 {
+			arguments := parser.copy()
+			arguments.delArg("u", "sysupgrade")
+			arguments.delArg("y", "refresh")
+			arguments.op = "S"
+			arguments.targets = make(stringSet)
+			arguments.addArg("needed", "asdeps")
+			for _, pkg := range dc.Repo {
+				arguments.addTarget(pkg.Name())
+			}
+			for _, pkg := range dc.RepoMake {
+				arguments.addTarget(pkg.Name())
+			}
+
+			oldConfirm := config.NoConfirm
+			config.NoConfirm = true
+			passToPacman(arguments)
+			config.NoConfirm = oldConfirm
+			if err != nil {
+				return err
+			}
+		}
+
 		// if !continueTask("Proceed with download?", "nN") {
 		// 	return fmt.Errorf("Aborting due to user")
 		// }

--- a/install.go
+++ b/install.go
@@ -110,6 +110,15 @@ func install(parser *arguments) error {
 			return err
 		}
 		
+		err = parseSRCINFOs(dc.AurMake)
+		if err != nil {
+			return err
+		}
+		err = parseSRCINFOs(dc.Aur)
+		if err != nil {
+			return err
+		}
+
 		if _, ok := arguments.options["gendb"]; ok {
 			fmt.Println("GenDB finished. No packages were installed")
 			return nil
@@ -270,8 +279,15 @@ func askEditPkgBuilds(pkgs []*rpc.Pkg) (error)  {
 			if err != nil {
 				return err
 			}
-		}
+		}	
+	}
 
+	return nil
+}
+
+func parseSRCINFOs(pkgs []*rpc.Pkg) error {
+	for _, pkg := range pkgs {
+		dir := config.BuildDir + pkg.PackageBase + "/"
 
 		pkgbuild, err := gopkg.ParseSRCINFO(dir + ".SRCINFO")
 		if err == nil {
@@ -280,12 +296,11 @@ func askEditPkgBuilds(pkgs []*rpc.Pkg) (error)  {
 				if owner != "" && repo != "" {
 					err = branchInfo(pkg.Name, owner, repo)
 					if err != nil {
-						fmt.Println(err)
+						return err
 					}
 				}
 			}
 		}
-
 	}
 
 	return nil

--- a/install.go
+++ b/install.go
@@ -136,7 +136,7 @@ func install(parser *arguments) error {
 			}
 
 			removeArguments := makeArguments()
-			removeArguments.addOP("R")
+			removeArguments.addArg("R", "u")
 
 			for _, pkg := range dc.RepoMake {
 				removeArguments.addTarget(pkg.Name())

--- a/install.go
+++ b/install.go
@@ -81,27 +81,7 @@ func install(parser *arguments) error {
 		if !continueTask("Proceed with install?", "nN") {
 			return fmt.Errorf("Aborting due to user")
 		}
-
-		if len(dc.Repo) > 0 {
-			arguments := parser.copy()
-			arguments.delArg("u", "sysupgrade")
-			arguments.delArg("y", "refresh")
-			arguments.op = "S"
-			arguments.targets = make(stringSet)
-			arguments.addArg("needed", "asdeps")
-			for _, pkg := range dc.Repo {
-				arguments.addTarget(pkg.Name())
-			}
-
-			oldConfirm := config.NoConfirm
-			config.NoConfirm = true
-			passToPacman(arguments)
-			config.NoConfirm = oldConfirm
-			if err != nil {
-				return err
-			}
-		}
-
+	
 		// if !continueTask("Proceed with download?", "nN") {
 		// 	return fmt.Errorf("Aborting due to user")
 		// }
@@ -122,6 +102,27 @@ func install(parser *arguments) error {
 		if err != nil {
 			return err
 		}
+		
+		if len(dc.Repo) > 0 {
+			arguments := parser.copy()
+			arguments.delArg("u", "sysupgrade")
+			arguments.delArg("y", "refresh")
+			arguments.op = "S"
+			arguments.targets = make(stringSet)
+			arguments.addArg("needed", "asdeps")
+			for _, pkg := range dc.Repo {
+				arguments.addTarget(pkg.Name())
+			}
+
+			oldConfirm := config.NoConfirm
+			config.NoConfirm = true
+			passToPacman(arguments)
+			config.NoConfirm = oldConfirm
+			if err != nil {
+				return err
+			}
+		}
+
 			
 		if _, ok := arguments.options["gendb"]; ok {
 			fmt.Println("GenDB finished. No packages were installed")

--- a/install.go
+++ b/install.go
@@ -109,16 +109,7 @@ func install(parser *arguments) error {
 		if err != nil {
 			return err
 		}
-		
-		err = parseSRCINFOs(dc.AurMake)
-		if err != nil {
-			return err
-		}
-		err = parseSRCINFOs(dc.Aur)
-		if err != nil {
-			return err
-		}
-
+			
 		if _, ok := arguments.options["gendb"]; ok {
 			fmt.Println("GenDB finished. No packages were installed")
 			return nil
@@ -133,6 +124,15 @@ func install(parser *arguments) error {
 			return err
 		}
 		err = downloadPkgBuildsSources(dc.Aur)
+		if err != nil {
+			return err
+		}
+
+		err = parseSRCINFOs(dc.AurMake)
+		if err != nil {
+			return err
+		}
+		err = parseSRCINFOs(dc.Aur)
 		if err != nil {
 			return err
 		}
@@ -323,7 +323,7 @@ func dowloadPkgBuilds(pkgs []*rpc.Pkg) (err error) {
 func downloadPkgBuildsSources(pkgs []*rpc.Pkg) (err error) {
 	for _, pkg := range pkgs {
 		dir := config.BuildDir + pkg.PackageBase + "/"
-		err = passToMakepkg(dir, "-f", "--verifysource")
+		err = passToMakepkg(dir, "--nobuild", "--nocheck", "--noprepare", "--nodeps")
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This pr tweaks the install algorithm quite a bit but the main focuses are:

- Removing makepkg -s and -i (fixes #119)
- Package caching (implements #135)
- Fixing cleanafter (fixes #141)
- Better split package handling 

Now when a package is stored in cache it can be reinstalled via `yay -S` without doing a rebuild. A rebuilt will still occur if there is a newer version of the package available.

Cleanafter is now part of `install()` and runs in batch at the end instead of after every `passToMakepkg()`

Split packages are now displayed together for nicer output. Each pkgbase is built and installed only once and in one transaction. This should be enough to get a yes for split package support on the wiki but more testing is needed before changing that.

Here is an example of the new output:
 - libc++ and libc++abi are bing installed which belong to the libc++ pkgbase
 - python-virtualfish is being installed which belongs to the virtualfish pkgbase
 - discord is being installed

![printscreen-2018-02-16_15 48 48](https://user-images.githubusercontent.com/16593899/36318500-f71ec6da-1337-11e8-9ba7-dda78ac384fd.png)

Old output:
![image](https://user-images.githubusercontent.com/16593899/36319377-ab8c13b4-133a-11e8-99fe-168678efb2ff.png)

For more details see individual commits.