### PR TITLE
Give error when failing to parse .SRCINFO

### DIFF
--- a/install.go
+++ b/install.go
@@ -280,7 +280,6 @@ func askEditPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg) error {
 }
 
 func parsesrcinfos(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD) error {
-
 	for _, pkg := range pkgs {
 		dir := config.BuildDir + pkg.PackageBase + "/"
 
@@ -294,16 +293,18 @@ func parsesrcinfos(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD) error {
 		}
 
 		pkgbuild, err := gopkg.ParseSRCINFOContent(srcinfo)
-		if err == nil {
-			srcinfos[pkg.PackageBase] = pkgbuild
+		if err != nil {
+			return fmt.Errorf("%s: %s", pkg.Name, err)
+		}
 
-			for _, pkgsource := range pkgbuild.Source {
-				owner, repo := parseSource(pkgsource)
-				if owner != "" && repo != "" {
-					err = branchInfo(pkg.Name, owner, repo)
-					if err != nil {
-						return err
-					}
+		srcinfos[pkg.PackageBase] = pkgbuild
+
+		for _, pkgsource := range pkgbuild.Source {
+			owner, repo := parseSource(pkgsource)
+			if owner != "" && repo != "" {
+				err = branchInfo(pkg.Name, owner, repo)
+				if err != nil {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
Instead of panicking later on.

"fix" for #158 
This does not really fix the issue just give a nice error message for it. The real issue comes from the PKGBUILD using an invalid arch and gomakepkg being a little too strict on it.

Hopefully the PKGBUILD will get fixed and this issue will disappear but I also made an issue to lessen the strictness of gomakepkg here /mikkeloscar/gopkgbuild/11 


