### PR TITLE
Improvements to install algorithm

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -488,10 +488,10 @@ func handleSync() (err error) {
 		err = syncSearch(targets)
 	} else if cmdArgs.existsArg("c", "clean") {
 		err = passToPacman(cmdArgs)
-	} else if cmdArgs.existsArg("u", "sysupgrade") {
-		err = upgradePkgs(make([]string, 0))
 	} else if cmdArgs.existsArg("i", "info") {
 		err = syncInfo(targets)
+	} else if cmdArgs.existsArg("u", "sysupgrade") {
+		err = install(cmdArgs)
 	} else if len(cmdArgs.targets) > 0 {
 		err = install(cmdArgs)
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -593,9 +593,8 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 		aurQ.printSearch(numpq + 1)
 	}
 
-	fmt.Println(greenFg("Type the numbers or ranges (e.g. 1-10) you want to install. " +
-		"Separate each one of them with a space."))
-	fmt.Print("Numbers: ")
+	fmt.Println(boldGreenFg(arrow) + boldGreenFg(" Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)"))
+	fmt.Print(boldGreenFg(arrow + " "))
 	reader := bufio.NewReader(os.Stdin)
 	numberBuf, overflow, err := reader.ReadLine()
 	if err != nil || overflow {

--- a/cmd.go
+++ b/cmd.go
@@ -448,16 +448,7 @@ func handleYay() (err error) {
 }
 
 func handleGetpkgbuild() (err error) {
-	for pkg := range cmdArgs.targets {
-		err = getPkgbuild(pkg)
-		if err != nil {
-			//we print the error instead of returning it
-			//seems as we can handle multiple errors without stoping
-			//theres no easy way around this right now
-			fmt.Println(pkg+":", err)
-		}
-	}
-
+	err = getPkgbuilds(cmdArgs.formatTargets())
 	return
 }
 

--- a/dependencies.go
+++ b/dependencies.go
@@ -118,7 +118,7 @@ func repoDepCatagoriesRecursive(pkg *alpm.Package, dc *depCatagories, dt *depTre
 }
 
 func depCatagoriesRecursive(pkg *rpc.Pkg, dc *depCatagories, dt *depTree, isMake bool, seen stringSet) {
-	for _, deps := range [2][]string{pkg.Depends, pkg.MakeDepends} {
+	for _, deps := range [3][]string{pkg.Depends, pkg.MakeDepends, pkg.CheckDepends} {
 		for _, _dep := range deps {
 			dep := getNameFromDep(_dep)
 
@@ -276,7 +276,7 @@ func depTreeRecursive(dt *depTree, localDb *alpm.Db, syncDb alpm.DbList, isMake 
 		}
 
 		//for each dep and makedep
-		for _, deps := range [2][]string{pkg.Depends, pkg.MakeDepends} {
+		for _, deps := range [3][]string{pkg.Depends, pkg.MakeDepends, pkg.CheckDepends} {
 			for _, versionedDep := range deps {
 				dep := getNameFromDep(versionedDep)
 

--- a/dependencies.go
+++ b/dependencies.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"strings"
 	alpm "github.com/jguer/go-alpm"
 	rpc "github.com/mikkeloscar/aur"
+	"strings"
 )
 
 type depTree struct {

--- a/download.go
+++ b/download.go
@@ -61,7 +61,7 @@ func downloadAndUnpack(url string, path string, trim bool) (err error) {
 	return
 }
 
-func getPkgbuilds(pkgs []string) (error) {
+func getPkgbuilds(pkgs []string) error {
 	//possibleAurs := make([]string, 0, 0)
 	wd, err := os.Getwd()
 	if err != nil {
@@ -85,7 +85,7 @@ func getPkgbuildsfromABS(pkgs []string, path string) (missing []string, err erro
 		return
 	}
 
-	nextPkg:
+nextPkg:
 	for _, pkgN := range pkgs {
 		for _, db := range dbList.Slice() {
 			pkg, err := db.PkgByName(pkgN)
@@ -103,7 +103,7 @@ func getPkgbuildsfromABS(pkgs []string, path string) (missing []string, err erro
 				if errD != nil {
 					fmt.Println(boldYellowFg(pkg.Name()), boldGreenFg(errD.Error()))
 				}
-				
+
 				fmt.Println(boldGreenFg(arrow), boldGreenFg("Downloaded"), boldYellowFg(pkg.Name()), boldGreenFg("from ABS"))
 				continue nextPkg
 			}

--- a/download.go
+++ b/download.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	rpc "github.com/mikkeloscar/aur"
 )
 
 func downloadFile(path string, url string) (err error) {
@@ -63,60 +61,71 @@ func downloadAndUnpack(url string, path string, trim bool) (err error) {
 	return
 }
 
-func getPkgbuild(pkg string) (err error) {
+func getPkgbuilds(pkgs []string) (error) {
+	//possibleAurs := make([]string, 0, 0)
 	wd, err := os.Getwd()
 	if err != nil {
-		return
+		return err
 	}
 	wd = wd + "/"
 
-	err = getPkgbuildfromABS(pkg, wd)
-	if err == nil {
-		return
+	missing, err := getPkgbuildsfromABS(pkgs, wd)
+	if err != nil {
+		return err
 	}
 
-	err = getPkgbuildfromAUR(pkg, wd)
-	return
+	err = getPkgbuildsfromAUR(missing, wd)
+	return err
 }
 
 // GetPkgbuild downloads pkgbuild from the ABS.
-func getPkgbuildfromABS(pkgN string, path string) (err error) {
+func getPkgbuildsfromABS(pkgs []string, path string) (missing []string, err error) {
 	dbList, err := alpmHandle.SyncDbs()
 	if err != nil {
 		return
 	}
 
-	for _, db := range dbList.Slice() {
-		pkg, err := db.PkgByName(pkgN)
-		if err == nil {
-			var url string
-			if db.Name() == "core" || db.Name() == "extra" {
-				url = "https://projects.archlinux.org/svntogit/packages.git/snapshot/packages/" + pkg.Base() + ".tar.gz"
-			} else if db.Name() == "community" {
-				url = "https://projects.archlinux.org/svntogit/community.git/snapshot/community-packages/" + pkg.Base() + ".tar.gz"
-			} else {
-				return fmt.Errorf("Not in standard repositories")
+	nextPkg:
+	for _, pkgN := range pkgs {
+		for _, db := range dbList.Slice() {
+			pkg, err := db.PkgByName(pkgN)
+			if err == nil {
+				var url string
+				if db.Name() == "core" || db.Name() == "extra" {
+					url = "https://projects.archlinux.org/svntogit/packages.git/snapshot/packages/" + pkg.Base() + ".tar.gz"
+				} else if db.Name() == "community" {
+					url = "https://projects.archlinux.org/svntogit/community.git/snapshot/community-packages/" + pkg.Base() + ".tar.gz"
+				} else {
+					fmt.Println(pkgN + " not in standard repositories")
+				}
+
+				errD := downloadAndUnpack(url, path, true)
+				if errD != nil {
+					fmt.Println(boldYellowFg(pkg.Name()), boldGreenFg(errD.Error()))
+				}
+				
+				fmt.Println(boldGreenFg(arrow), boldGreenFg("Downloaded"), boldYellowFg(pkg.Name()), boldGreenFg("from ABS"))
+				continue nextPkg
 			}
-			fmt.Println(boldGreenFg(arrow), boldYellowFg(pkgN), boldGreenFg("found in ABS."))
-			errD := downloadAndUnpack(url, path, true)
-			return errD
 		}
+
+		missing = append(missing, pkgN)
 	}
-	return fmt.Errorf("package not found")
+
+	return
 }
 
 // GetPkgbuild downloads pkgbuild from the AUR.
-func getPkgbuildfromAUR(pkgN string, dir string) (err error) {
-	aq, err := rpc.Info([]string{pkgN})
+func getPkgbuildsfromAUR(pkgs []string, dir string) (err error) {
+	aq, err := aurInfo(pkgs)
 	if err != nil {
 		return err
 	}
 
-	if len(aq) == 0 {
-		return fmt.Errorf("no results")
+	for _, pkg := range aq {
+		downloadAndUnpack(baseURL+aq[0].URLPath, dir, false)
+		fmt.Println(boldGreenFg(arrow), boldGreenFg("Downloaded"), boldYellowFg(pkg.Name), boldGreenFg("from AUR"))
 	}
 
-	fmt.Println(boldGreenFg(arrow), boldYellowFg(pkgN), boldGreenFg("found in AUR."))
-	downloadAndUnpack(baseURL+aq[0].URLPath, dir, false)
 	return
 }

--- a/install.go
+++ b/install.go
@@ -59,15 +59,6 @@ func install(parser *arguments) error {
 			return err
 		}
 
-		for _, pkg := range dc.Aur {
-			if pkg.Maintainer == "" {
-				fmt.Println(boldRedFgBlackBg(arrow+" Warning:"),
-					blackBg(pkg.Name+"-"+pkg.Version+" is orphaned"))
-			}
-		}
-
-
-
 		//printDownloadsFromRepo("Repo", dc.Repo)
 		//printDownloadsFromRepo("Repo Make", dc.RepoMake)
 		//printDownloadsFromAur("AUR", dc.Aur)

--- a/install.go
+++ b/install.go
@@ -481,7 +481,7 @@ func buildInstallPkgBuilds(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 			fmt.Println(boldRedFgBlackBg(arrow+" Warning:"),
 				blackBg(pkg.Name+"-"+pkg.Version+" Already made -- skipping build"))
 		} else {
-			err := passToMakepkg(dir, "-Cscf", "--noconfirm")
+			err := passToMakepkg(dir, "-Ccf", "--noconfirm")
 			if err != nil {
 				return err
 			}

--- a/install.go
+++ b/install.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
 	"strconv"
+	"strings"
 
 	alpm "github.com/jguer/go-alpm"
 	rpc "github.com/mikkeloscar/aur"
@@ -17,7 +17,7 @@ import (
 func install(parser *arguments) error {
 	aur, repo, err := packageSlices(parser.targets.toSlice())
 	if err != nil {
-		return  err
+		return err
 	}
 
 	srcinfos := make(map[string]*gopkg.PKGBUILD)
@@ -29,7 +29,7 @@ func install(parser *arguments) error {
 	//remotenames: names of all non repo packages on the system
 	_, _, _, remoteNames, err := filterPackages()
 	if err != nil {
-		return  err
+		return err
 	}
 
 	//cache as a stringset. maybe make it return a string set in the first
@@ -44,10 +44,10 @@ func install(parser *arguments) error {
 		requestTargets = append(requestTargets, remoteNames...)
 	}
 
-	if len(aur) > 0 ||  parser.existsArg("u", "sysupgrade") && len(remoteNames) > 0 {
+	if len(aur) > 0 || parser.existsArg("u", "sysupgrade") && len(remoteNames) > 0 {
 		fmt.Println(boldCyanFg("::"), boldFg("Querying AUR..."))
 	}
-	dt , err := getDepTree(requestTargets)
+	dt, err := getDepTree(requestTargets)
 	if err != nil {
 		return err
 	}
@@ -66,9 +66,9 @@ func install(parser *arguments) error {
 	arguments.delArg("y", "refresh")
 	arguments.op = "S"
 	arguments.targets = make(stringSet)
-	
+
 	if parser.existsArg("u", "sysupgrade") {
-		repoUp, aurUp, err  := upgradePkgs(dt)
+		repoUp, aurUp, err := upgradePkgs(dt)
 		if err != nil {
 			return err
 		}
@@ -76,12 +76,11 @@ func install(parser *arguments) error {
 		for pkg := range aurUp {
 			parser.addTarget(pkg)
 		}
-		
+
 		for pkg := range repoUp {
 			arguments.addTarget(pkg)
 		}
 
-	
 		//discard stuff thats
 		//not a target and
 		//not an upgrade and
@@ -111,7 +110,6 @@ func install(parser *arguments) error {
 		fmt.Println("nothing to do ")
 		return nil
 	}
-
 
 	if hasAur {
 		printDepCatagories(dc)
@@ -143,12 +141,11 @@ func install(parser *arguments) error {
 		uask := alpm.Question(ask) | alpm.QuestionConflictPkg
 		cmdArgs.globals["ask"] = fmt.Sprint(uask)
 
-		
 		askCleanBuilds(dc.Aur, dc.Bases)
 
 		// if !continueTask("Proceed with download?", "nN") {
 		// 	return fmt.Errorf("Aborting due to user")
-		// }	
+		// }
 
 		err = dowloadPkgBuilds(dc.Aur, dc.Bases)
 		if err != nil {
@@ -179,7 +176,7 @@ func install(parser *arguments) error {
 				return err
 			}
 		}*/
-	
+
 		// if !continueTask("Proceed with install?", "nN") {
 		// 	return fmt.Errorf("Aborting due to user")
 		// }
@@ -188,14 +185,13 @@ func install(parser *arguments) error {
 		//a version bumb for vsc packages
 		//that should not edit the sources so we should be safe to skip
 		//it and parse the srcinfo at the current version
-		if arguments.existsArg("gendb") {	
+		if arguments.existsArg("gendb") {
 			err = parsesrcinfosFile(dc.Aur, srcinfos, dc.Bases)
 			if err != nil {
 				return err
 			}
 
-
-			fmt.Println(boldGreenFg(arrow+" GenDB finished. No packages were installed"))
+			fmt.Println(boldGreenFg(arrow + " GenDB finished. No packages were installed"))
 			return nil
 		}
 
@@ -203,7 +199,6 @@ func install(parser *arguments) error {
 		if err != nil {
 			return err
 		}
-
 
 		err = parsesrcinfosGenerate(dc.Aur, srcinfos, dc.Bases)
 		if err != nil {
@@ -354,7 +349,6 @@ func parsesrcinfosFile(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, bas
 		str := boldCyanFg("::") + boldFg(" Parsing SRCINFO (%d/%d): %s\n")
 		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
 
-
 		pkgbuild, err := gopkg.ParseSRCINFO(dir + ".SRCINFO")
 		if err != nil {
 			return fmt.Errorf("%s: %s", pkg.Name, err)
@@ -373,7 +367,7 @@ func parsesrcinfosGenerate(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 
 		str := boldCyanFg("::") + boldFg(" Parsing SRCINFO (%d/%d): %s\n")
 		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
-		
+
 		cmd := exec.Command(config.MakepkgBin, "--printsrcinfo")
 		cmd.Stderr = os.Stderr
 		cmd.Dir = dir
@@ -400,7 +394,7 @@ func dowloadPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg) (err error) 
 		//todo make pretty
 		str := boldCyanFg("::") + boldFg(" Downloading (%d/%d): %s\n")
 
-		fmt.Printf(str, k+1, len(pkgs),  formatPkgbase(pkg, bases))
+		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
 
 		err = downloadAndUnpack(baseURL+pkg.URLPath, config.BuildDir, false)
 		if err != nil {

--- a/install.go
+++ b/install.go
@@ -44,8 +44,9 @@ func install(parser *arguments) error {
 		requestTargets = append(requestTargets, remoteNames...)
 	}
 
-
-	fmt.Println(boldCyanFg("::"), boldFg("Querying AUR..."))
+	if len(requestTargets) > 0 {
+		fmt.Println(boldCyanFg("::"), boldFg("Querying AUR..."))
+	}
 	dt , err := getDepTree(requestTargets)
 	if err != nil {
 		return err

--- a/install.go
+++ b/install.go
@@ -295,7 +295,7 @@ func checkForConflicts(dc *depCatagories) error {
 		fmt.Println(
 			redFg("Package conflicts found:"))
 		for name, pkgs := range toRemove {
-			str := yellowFg("\t" + name) + " Replaces"
+			str := "\tInstalling " + yellowFg(name) + " will remove"
 			for pkg := range pkgs {
 				str += " " + yellowFg(pkg)
 			}

--- a/print.go
+++ b/print.go
@@ -109,7 +109,6 @@ func formatPkgbase(pkg *rpc.Pkg, bases map[string][]*rpc.Pkg) string {
 	return str
 }
 
-
 // printDownloadsFromRepo prints repository packages to be downloaded
 func printDepCatagories(dc *depCatagories) {
 	repo := ""
@@ -300,7 +299,7 @@ func printNumberOfUpdates() error {
 		return err
 	}
 	fmt.Println(len(aurUp) + len(repoUp))
-	
+
 	return nil
 }
 

--- a/print.go
+++ b/print.go
@@ -256,53 +256,7 @@ func localStatistics() error {
 	biggestPackages()
 	fmt.Println(boldCyanFg("==========================================="))
 
-	var q aurQuery
-	var j int
-	for i := len(remoteNames); i != 0; i = j {
-		j = i - config.RequestSplitN
-		if j < 0 {
-			j = 0
-		}
-		qtemp, err := rpc.Info(remoteNames[j:i])
-		q = append(q, qtemp...)
-		if err != nil {
-			return err
-		}
-	}
-
-	var outcast []string
-	for _, s := range remoteNames {
-		found := false
-		for _, i := range q {
-			if s == i.Name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			outcast = append(outcast, s)
-		}
-	}
-
-	if err != nil {
-		return err
-	}
-
-	for _, res := range q {
-		if res.Maintainer == "" {
-			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
-				boldYellowFgBlackBg(res.Name), whiteFgBlackBg("is orphaned"))
-		}
-		if res.OutOfDate != 0 {
-			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
-				boldYellowFgBlackBg(res.Name), whiteFgBlackBg("is out-of-date in AUR"))
-		}
-	}
-
-	for _, res := range outcast {
-		fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
-			boldYellowFgBlackBg(res), whiteFgBlackBg("is not available in AUR"))
-	}
+	aurInfo(remoteNames)
 
 	return nil
 }

--- a/print.go
+++ b/print.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"os"
+//	"os"
 	"strconv"
 	"strings"
 
@@ -272,7 +272,8 @@ func printMissing(missing stringSet) {
 
 //todo make it less hacky
 func printNumberOfUpdates() error {
-	old := os.Stdout // keep backup of the real stdout
+	//todo
+	/*old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
 	aurUp, repoUp, err := upList()
 	os.Stdout = old // restoring the real stdout
@@ -280,11 +281,13 @@ func printNumberOfUpdates() error {
 		return err
 	}
 	fmt.Println(len(aurUp) + len(repoUp))
+	*/
 	return nil
 }
 
 //todo make it less hacky
 func printUpdateList() error {
+	/*
 	old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
 	aurUp, repoUp, err := upList()
@@ -299,7 +302,7 @@ func printUpdateList() error {
 	for _, pkg := range aurUp {
 		fmt.Println(pkg.Name)
 	}
-
+*/
 	return nil
 }
 

--- a/print.go
+++ b/print.go
@@ -94,6 +94,22 @@ func (s repoQuery) printSearch() {
 	}
 }
 
+func formatPkgbase(pkg *rpc.Pkg, bases map[string][]*rpc.Pkg) string {
+	str := pkg.PackageBase
+	if len(bases[pkg.PackageBase]) > 1 || pkg.PackageBase != pkg.Name {
+		str2 := " ("
+		for _, split := range bases[pkg.PackageBase] {
+			str2 += split.Name + " "
+		}
+		str2 = str2[:len(str2)-1] + ")"
+
+		str += str2
+	}
+
+	return str
+}
+
+
 // printDownloadsFromRepo prints repository packages to be downloaded
 func printDepCatagories(dc *depCatagories) {
 	repo := ""

--- a/print.go
+++ b/print.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-//	"os"
+	"os"
 	"strconv"
 	"strings"
 
@@ -273,24 +273,28 @@ func printMissing(missing stringSet) {
 //todo make it less hacky
 func printNumberOfUpdates() error {
 	//todo
-	/*old := os.Stdout // keep backup of the real stdout
+	old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
-	aurUp, repoUp, err := upList()
+	_, _, localNames, remoteNames, err := filterPackages()
+	dt, _ := getDepTree(append(localNames, remoteNames...))
+	aurUp, repoUp, err := upList(dt)
 	os.Stdout = old // restoring the real stdout
 	if err != nil {
 		return err
 	}
 	fmt.Println(len(aurUp) + len(repoUp))
-	*/
+	
 	return nil
 }
 
 //todo make it less hacky
 func printUpdateList() error {
-	/*
 	old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
-	aurUp, repoUp, err := upList()
+	_, _, localNames, remoteNames, err := filterPackages()
+	dt, _ := getDepTree(append(localNames, remoteNames...))
+	aurUp, repoUp, err := upList(dt)
+
 	os.Stdout = old // restoring the real stdout
 	if err != nil {
 		return err
@@ -302,7 +306,7 @@ func printUpdateList() error {
 	for _, pkg := range aurUp {
 		fmt.Println(pkg.Name)
 	}
-*/
+
 	return nil
 }
 

--- a/print.go
+++ b/print.go
@@ -201,6 +201,7 @@ func PrintInfo(a *rpc.Pkg) {
 	fmt.Println(boldWhiteFg("Licenses        :"), strings.Join(a.License, "  "))
 	fmt.Println(boldWhiteFg("Depends On      :"), strings.Join(a.Depends, "  "))
 	fmt.Println(boldWhiteFg("Make Deps       :"), strings.Join(a.MakeDepends, "  "))
+	fmt.Println(boldWhiteFg("Check Deps      :"), strings.Join(a.CheckDepends, "  "))
 	fmt.Println(boldWhiteFg("Optional Deps   :"), strings.Join(a.OptDepends, "  "))
 	fmt.Println(boldWhiteFg("Conflicts With  :"), strings.Join(a.Conflicts, "  "))
 	fmt.Println(boldWhiteFg("Maintainer      :"), a.Maintainer)

--- a/query.go
+++ b/query.go
@@ -394,7 +394,7 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	}
 
 	for n := 0; n < len(names); n += config.RequestSplitN {
-		max := min(len(names), n + config.RequestSplitN)
+		max := min(len(names), n+config.RequestSplitN)
 		wg.Add(1)
 		go makeRequest(n, max)
 	}
@@ -429,7 +429,7 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	if len(missing) > 0 {
 		fmt.Print(boldRedFgBlackBg(arrow + " Missing AUR Packages:"))
 		for _, name := range missing {
-				fmt.Print(" " + boldYellowFgBlackBg(name))
+			fmt.Print(" " + boldYellowFgBlackBg(name))
 		}
 		fmt.Println()
 	}
@@ -437,7 +437,7 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	if len(orphans) > 0 {
 		fmt.Print(boldRedFgBlackBg(arrow + " Orphaned AUR Packages:"))
 		for _, name := range orphans {
-				fmt.Print(" " + boldYellowFgBlackBg(name))
+			fmt.Print(" " + boldYellowFgBlackBg(name))
 		}
 		fmt.Println()
 	}
@@ -445,7 +445,7 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	if len(outOfDate) > 0 {
 		fmt.Print(boldRedFgBlackBg(arrow + " Out Of Date AUR Packages:"))
 		for _, name := range outOfDate {
-				fmt.Print(" " + boldYellowFgBlackBg(name))
+			fmt.Print(" " + boldYellowFgBlackBg(name))
 		}
 		fmt.Println()
 	}

--- a/query.go
+++ b/query.go
@@ -380,3 +380,50 @@ big:
 	}
 	return
 }
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return a
+}
+
+func aurInfo(names []string) ([]rpc.Pkg, error) {
+	info := make([]rpc.Pkg, 0, len(names))
+	seen := make(map[string]int)
+
+	for n := 0; n < len(names); n += config.RequestSplitN {
+		max := min(len(names), n + config.RequestSplitN)
+		tempInfo, err := rpc.Info(names[n:max])
+		if err != nil {
+			return info, err
+		}
+		info = append(info, tempInfo...)
+	}
+
+	for k, pkg := range info {
+		seen[pkg.Name] = k
+	}
+
+	for _, name := range names {
+		i, ok := seen[name]
+		if !ok {
+			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
+				boldYellowFgBlackBg(name), whiteFgBlackBg("is not available in AUR"))
+			continue
+		}
+
+		pkg := info[i]
+
+		if pkg.Maintainer == "" {
+			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
+				boldYellowFgBlackBg(pkg.Name), whiteFgBlackBg("is orphaned"))
+		}
+		if pkg.OutOfDate != 0 {
+			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
+				boldYellowFgBlackBg(pkg.Name), whiteFgBlackBg("is out-of-date in AUR"))
+		}
+	}
+
+	return info, nil
+}

--- a/query.go
+++ b/query.go
@@ -373,6 +373,10 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	var wg sync.WaitGroup
 	var err error
 
+	missing := make([]string, 0, len(names))
+	orphans := make([]string, 0, len(names))
+	outOfDate := make([]string, 0, len(names))
+
 	makeRequest := func(n, max int) {
 		tempInfo, requestErr := rpc.Info(names[n:max])
 		if err != nil {
@@ -408,21 +412,42 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	for _, name := range names {
 		i, ok := seen[name]
 		if !ok {
-			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
-				boldYellowFgBlackBg(name), whiteFgBlackBg("is not available in AUR"))
+			missing = append(missing, name)
 			continue
 		}
 
 		pkg := info[i]
 
 		if pkg.Maintainer == "" {
-			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
-				boldYellowFgBlackBg(pkg.Name), whiteFgBlackBg("is orphaned"))
+			orphans = append(orphans, name)
 		}
 		if pkg.OutOfDate != 0 {
-			fmt.Println(boldRedFgBlackBg(arrow+"Warning:"),
-				boldYellowFgBlackBg(pkg.Name), whiteFgBlackBg("is out-of-date in AUR"))
+			outOfDate = append(outOfDate, name)
 		}
+	}
+
+	if len(missing) > 0 {
+		fmt.Print(boldRedFgBlackBg(arrow + " Missing AUR Packages:"))
+		for _, name := range missing {
+				fmt.Print(" " + boldYellowFgBlackBg(name))
+		}
+		fmt.Println()
+	}
+
+	if len(orphans) > 0 {
+		fmt.Print(boldRedFgBlackBg(arrow + " Orphaned AUR Packages:"))
+		for _, name := range orphans {
+				fmt.Print(" " + boldYellowFgBlackBg(name))
+		}
+		fmt.Println()
+	}
+
+	if len(outOfDate) > 0 {
+		fmt.Print(boldRedFgBlackBg(arrow + " Out Of Date AUR Packages:"))
+		for _, name := range outOfDate {
+				fmt.Print(" " + boldYellowFgBlackBg(name))
+		}
+		fmt.Println()
 	}
 
 	return info, nil

--- a/upgrade.go
+++ b/upgrade.go
@@ -10,7 +10,6 @@ import (
 	"unicode"
 
 	alpm "github.com/jguer/go-alpm"
-	rpc "github.com/mikkeloscar/aur"
 	pkgb "github.com/mikkeloscar/gopkgbuild"
 )
 
@@ -203,7 +202,7 @@ func upAUR(remote []alpm.Package, remoteNames []string) (toUpgrade upSlice, err 
 
 		routines++
 		go func(local []alpm.Package, remote []string) {
-			qtemp, err := rpc.Info(remote)
+			qtemp, err := aurInfo(remote)
 			if err != nil {
 				fmt.Println(err)
 				done <- true

--- a/upgrade.go
+++ b/upgrade.go
@@ -57,27 +57,27 @@ func (u upSlice) Less(i, j int) bool {
 }
 
 func getVersionDiff(oldVersion, newversion string) (left, right string) {
-		old, errOld := pkgb.NewCompleteVersion(oldVersion)
-		new, errNew := pkgb.NewCompleteVersion(newversion)
-		
-		if errOld != nil {
-			left = redFg("Invalid Version")
-		}
-		if errNew != nil {
-			right = redFg("Invalid Version")
-		}
+	old, errOld := pkgb.NewCompleteVersion(oldVersion)
+	new, errNew := pkgb.NewCompleteVersion(newversion)
 
-		if errOld == nil && errNew == nil {
-			if old.Version == new.Version {
-				left = string(old.Version) + "-" + redFg(string(old.Pkgrel))
-				right = string(new.Version) + "-" + greenFg(string(new.Pkgrel))
-			} else {
-				left = redFg(string(old.Version)) + "-" + string(old.Pkgrel)
-				right = boldGreenFg(string(new.Version)) + "-" + string(new.Pkgrel)
-			}
-		}
+	if errOld != nil {
+		left = redFg("Invalid Version")
+	}
+	if errNew != nil {
+		right = redFg("Invalid Version")
+	}
 
-		return
+	if errOld == nil && errNew == nil {
+		if old.Version == new.Version {
+			left = string(old.Version) + "-" + redFg(string(old.Pkgrel))
+			right = string(new.Version) + "-" + greenFg(string(new.Pkgrel))
+		} else {
+			left = redFg(string(old.Version)) + "-" + string(old.Pkgrel)
+			right = boldGreenFg(string(new.Version)) + "-" + string(new.Pkgrel)
+		}
+	}
+
+	return
 }
 
 // Print prints the details of the packages to upgrade.
@@ -169,7 +169,7 @@ func upDevel(remote []alpm.Package, packageC chan upgrade, done chan bool) {
 					fmt.Print(yellowFg("Warning: "))
 					fmt.Printf("%s ignoring package upgrade (%s => %s)\n", pkg.Name(), pkg.Version(), "git")
 				} else {
-					packageC <- upgrade{e.Package, "devel", pkg.Version() , "commit-" + e.SHA[0:6]}
+					packageC <- upgrade{e.Package, "devel", pkg.Version(), "commit-" + e.SHA[0:6]}
 				}
 			} else {
 				removeVCSPackage([]string{e.Package})
@@ -216,7 +216,7 @@ func upAUR(remote []alpm.Package, remoteNames []string, dt *depTree) (toUpgrade 
 
 		done <- true
 	}(remote, remoteNames, dt)
-			
+
 	if routineDone == routines {
 		err = nil
 		return
@@ -370,7 +370,6 @@ func upgradePkgs(dt *depTree) (stringSet, stringSet, error) {
 		repoNums = removeIntListFromList(excludeRepo, repoNums)
 	}
 
-	
 	if len(repoUp) != 0 {
 	repoloop:
 		for i, k := range repoUp {

--- a/upgrade.go
+++ b/upgrade.go
@@ -299,7 +299,6 @@ func upgradePkgs(dt *depTree) (stringSet, stringSet, error) {
 	if err != nil {
 		return repoNames, aurNames, err
 	} else if len(aurUp)+len(repoUp) == 0 {
-		fmt.Println("\nThere is nothing to do")
 		return repoNames, aurNames, err
 	}
 


### PR DESCRIPTION
This is the third big change to the install algorithm. The main changes are:
- Merge the `-S` and `-Su` actions together in to a more interconnected process.
- `-S` and `-Su`  can query the AUR together in one request, Slight speed up and less load on the AUR
- Print orphan, missing and out of date warnings whenever querying the AUR (implements #151)
- Add support for checkdepends (fixes #159) (depends on mikkeloscar/aur#2)
- Error when required targets are missing (fixes #162)
- Lots of formatting improvments

This is probably not bug free. I would make a new release before merging. Then we can merge it here to make it more available for testing. And bug fixes. 

As usual see commits for more info.