### PR TITLE
upgrade: be consistent about no colors

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -65,6 +65,9 @@ func (u upSlice) Print(start int) {
 		var left, right string
 
 		f := func(name string) (output string) {
+			if alpmConf.Options&alpm.ConfColor == 0 {
+				return name
+			}
 			var hash = 5381
 			for i := 0; i < len(name); i++ {
 				hash = int(name[i]) + ((hash << 5) + (hash))


### PR DESCRIPTION
If pacman's color is off, don't use colors to mark the repos of
upgradeable packages.