### PR TITLE
cmd: error on unknown command

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -438,6 +438,9 @@ func handleYay() (err error) {
 		err = handleGetpkgbuild()
 	} else if len(cmdArgs.targets) > 0 {
 		err = handleYogurt()
+	} else {
+		args := cmdArgs.formatArgs()
+		err = fmt.Errorf("unknown command: %s", strings.Join(args, " "))
 	}
 
 	return


### PR DESCRIPTION
Don't silently ignore it.

Before:

	$ yay --foo

After:

	$ yay --foo
	unknown command: -Y --foo

Updates #163.