### PR TITLE
No longer split on space in getNameFromDep()

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -45,7 +45,7 @@ func makeDependCatagories() *depCatagories {
 
 func getNameFromDep(dep string) string {
 	return strings.FieldsFunc(dep, func(c rune) bool {
-		return c == '>' || c == '<' || c == '=' || c == ' '
+		return c == '>' || c == '<' || c == '='
 	})[0]
 }
 


### PR DESCRIPTION
This should not make any real difference as pkgnames and pkgvers
should not contain whitespace. But there was a problem where a packagepkg
connected two deps by quoting them.

depends=('make qt5-tools')

Because we split on spaces this caused yay to generate an error saying
it couldn't find 'make' when instead it should say it cant find
'make qt5tools' which was a little confusing.

This commit should fix the misleading error.