### PR TITLE
Save the VSC info when install finishes.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -127,8 +127,6 @@ func initYay() (err error) {
 	/////////////////
 	// vcs config //
 	////////////////
-	updated = false
-
 	vfile, err := os.OpenFile(vcsFile, os.O_RDONLY|os.O_CREATE, 0644)
 	if err == nil {
 		defer vfile.Close()
@@ -236,15 +234,6 @@ cleanup:
 	//from here on out dont exit if an error occurs
 	//if we fail to save the configuration
 	//at least continue on and try clean up other parts
-
-	if updated {
-		err = saveVCSInfo()
-
-		if err != nil {
-			fmt.Println(err)
-			status = 1
-		}
-	}
 
 	if changedConfig {
 		err = config.saveConfig()

--- a/config.go
+++ b/config.go
@@ -57,9 +57,6 @@ var vcsFile string
 //completion file
 var completionFile string
 
-// Updated returns if database has been updated
-var updated bool
-
 // changedConfig holds whether or not the config has changed
 var changedConfig bool
 

--- a/vcs.go
+++ b/vcs.go
@@ -129,7 +129,7 @@ func inStore(pkgName string) *Info {
 
 // branchInfo updates saved information
 func branchInfo(pkgName string, owner string, repoName string) (err error) {
-	updated = true
+	updated := false
 	var newRepo repo
 	var newBranches branches
 	url := "https://api.github.com/repos/" + owner + "/" + repoName
@@ -155,6 +155,8 @@ func branchInfo(pkgName string, owner string, repoName string) (err error) {
 
 	for _, e := range newBranches {
 		if e.Name == defaultBranch {
+			updated = true
+
 			if packinfo != nil {
 				packinfo.Package = pkgName
 				packinfo.URL = url
@@ -163,6 +165,10 @@ func branchInfo(pkgName string, owner string, repoName string) (err error) {
 				savedInfo = append(savedInfo, Info{Package: pkgName, URL: url, SHA: e.Commit.SHA})
 			}
 		}
+	}
+
+	if updated {
+		saveVCSInfo()
 	}
 
 	return


### PR DESCRIPTION
Save the VSC Info as soon as the package install finishes. This should
ensure the VSC db does not end up in an incorrect state if an install
fails or is cancelled by the user.

This also adds better support for split packages. When one or more
packages are installed from the same base each individual package is
added to the db not just the base. This allows us to track individual
updates from the same base so that if one package gets updated we don't
assume all packages in the base are updated.

fixes #88