### PR TITLE
Fix duplicate packages when printing dependencies

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -205,10 +205,10 @@ func repoTreeRecursive(pkg *alpm.Package, dt *depTree, localDb *alpm.Db, syncDb 
 	}
 
 	dt.Repo[pkg.Name()] = pkg
-	(*pkg).Provides().ForEach(func(dep alpm.Depend) (err error) {
+	/*(*pkg).Provides().ForEach(func(dep alpm.Depend) (err error) {
 		dt.Repo[dep.Name] = pkg
 		return nil
-	})
+	})*/
 
 	(*pkg).Depends().ForEach(func(dep alpm.Depend) (err error) {
 		_, exists := dt.Repo[dep.Name]


### PR DESCRIPTION
The depTree holds info on all packages by name ready for the
depCatagories to catagorize and order them. To make things easier when
a repo package was added to the deptree it was also aliased to all of
its provides. So to find a package in the deptree you could search for
its provides instead of it's name and still find it.

The depCatagories is meant to filter out unneeded packages such as the
aliases but as it turns out if a package depends on a package and
something it provides then that alias is no longer unneeded and will end
up in the depCatagories.

Because these are just alias provieds still points to the original
package so you end up with the package name displaed to the user twice
when printing dependencies.

This commit just comments out the aliasing. It should have no effect
on package finding because where it used to seach by alias to find the
package it should instead fail then try to preform a lookup itself using
findSatisfyer and find the package.

This is probably a little less efficient than before but the database is
already on disk so there should be no real perfomance difference.

fixes #182