### PR TITLE
Check for groups when creating the depTree

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -187,6 +187,12 @@ func getDepTree(pkgs []string) (*depTree, error) {
 			continue
 		}
 
+		
+		_, isGroup := syncDb.PkgCachebyGroup(pkg)
+		if isGroup == nil {
+			continue
+		}
+
 		dt.ToProcess.set(pkg)
 	}
 


### PR DESCRIPTION
And if we do find a group just ignore it completley and pass it to
pacman.

Because it's ignored by the depTree it fails to show up when printing
whats to be installed under [Repo]. This is a minor visual thing for now
so I think it's probably best to figure that out at another point.

fixes #185 