### PR TITLE
Abort if editor does not return 0

### DIFF
--- a/install.go
+++ b/install.go
@@ -307,7 +307,10 @@ func askEditPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg) error {
 		if !continueTask(str, "yY") {
 			editcmd := exec.Command(editor(), dir+"PKGBUILD")
 			editcmd.Stdin, editcmd.Stdout, editcmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-			editcmd.Run()
+			err := editcmd.Run()
+			if err != nil {
+				return fmt.Errorf("Editor did not exit successfully, Abotring: %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This allows the user to abort the install by telling the editor to exit
with a non zero status. e.g. `:cq` in vim. This should also catch errors
if the editor does actually fail or if the configured editor does not
exist.

This does kind of implement #140 but instead of just removing the package from what is to be installed we abort the install all together. This is preferable and much easier to implement. Just removing the one package from whats to be installed could mess up the dependencies. 