### PR TITLE
Correctly mark packages as dependencies

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -690,6 +691,38 @@ func passToPacman(args *arguments) error {
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	err := cmd.Run()
 	return err
+}
+
+//passToPacman but return the output instead of showing the user
+func passToPacmanCapture(args *arguments) (string, string, error) {
+	var outbuf, errbuf bytes.Buffer
+	var cmd *exec.Cmd
+	argArr := make([]string, 0)
+
+	if args.needRoot() {
+		argArr = append(argArr, "sudo")
+	}
+
+	argArr = append(argArr, config.PacmanBin)
+	argArr = append(argArr, cmdArgs.formatGlobals()...)
+	argArr = append(argArr, args.formatArgs()...)
+	if config.NoConfirm {
+		argArr = append(argArr, "--noconfirm")
+	}
+
+	argArr = append(argArr, "--")
+
+	argArr = append(argArr, args.formatTargets()...)
+
+	cmd = exec.Command(argArr[0], argArr[1:]...)
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+
+	err := cmd.Run()
+	stdout := outbuf.String()
+	stderr := errbuf.String()
+
+	return stdout, stderr, err
 }
 
 // passToMakepkg outsources execution to makepkg binary without modifications.

--- a/install.go
+++ b/install.go
@@ -137,9 +137,9 @@ func install(parser *arguments) error {
 		}
 
 		if len(depArguments.targets) > 0 {
-			err = passToPacman(depArguments)
+			_, stderr, err := passToPacmanCapture(depArguments)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s%s", stderr, err)
 			}
 		}
 	}
@@ -495,9 +495,9 @@ func buildInstallPkgBuilds(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 
 		updateVSCdb(bases[pkg.PackageBase], srcinfo)
 		if len(depArguments.targets) > 0 {
-			err = passToPacman(depArguments)
+			_, stderr, err := passToPacmanCapture(depArguments)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s%s", stderr, err)
 			}
 		}
 		config.NoConfirm = oldConfirm


### PR DESCRIPTION
Previously Installing repo targets and repo dependencies of aur targets
was done in two steps.

doing `yay -S repo1 repo2 aur1 aur2` would lead to yay calling
`pacman -S repo1 repo2`. Then after we find all the dependencies of the
aur packages we call `pacman -S --asdeps <all repo dependencies>`. This
was an easy way to correctly mark dependencies. Since 005635b4 Both
these calls were merged into one command but dependency marking was
forgoten about.

Now correctly mark the dependencies through `pacman -D`