### PR TITLE
Update manpage and usage

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -39,12 +39,12 @@ New operations:
 Permanent configuration options:
     --topdown            Shows repository's packages first and then AUR's
     --bottomup           Shows AUR's packages first and then repository's
-    --devel              Check -git/-svn/-hg development version
-    --nodevel            Disable development version checking
-    --afterclean         Clean package sources after successful build
-    --noafterclean       Disable package sources cleaning after successful build
-    --timeupdate         Check package's modification date and version
-    --notimeupdate       Check only package version change
+    --devel              Check development packages during sysupgrade
+    --nodevel            Do not check development packages
+    --afterclean         Remove package sources after successful install
+    --noafterclean       Do not remove package sources after successful build
+    --timeupdate         Check package's AUR page for changes during sysupgrade
+    --notimeupdate       Do not checking of AUR page changes
 
 Print specific options:
     -c --complete        Used for completions
@@ -55,9 +55,8 @@ Print specific options:
     -u --upgrades        Print update list
 
 Yay specific options:
-    -g --getpkgbuild     Download PKGBUILD from ABS or AUR
     -c --clean           Remove unneeded dependencies
-    --gendb              Generates development package DB used for updating.
+       --gendb           Generates development package DB used for updating
 
 If no operation is provided -Y will be assumed`)
 }
@@ -426,8 +425,6 @@ func handleYay() (err error) {
 		}
 	} else if cmdArgs.existsArg("c", "clean") {
 		err = cleanDependencies()
-	} else if cmdArgs.existsArg("g", "getpkgbuild") {
-		err = handleGetpkgbuild()
 	} else if len(cmdArgs.targets) > 0 {
 		err = handleYogurt()
 	}

--- a/dependencies.go
+++ b/dependencies.go
@@ -60,7 +60,6 @@ func getDepCatagories(pkgs []string, dt *depTree) (*depCatagories, error) {
 		dc.Bases[pkg.PackageBase] = append(dc.Bases[pkg.PackageBase], pkg)
 	}
 
-
 	for _, pkg := range pkgs {
 		dep := getNameFromDep(pkg)
 		alpmpkg, exists := dt.Repo[dep]
@@ -187,7 +186,6 @@ func getDepTree(pkgs []string) (*depTree, error) {
 			continue
 		}
 
-		
 		_, isGroup := syncDb.PkgCachebyGroup(pkg)
 		if isGroup == nil {
 			continue

--- a/yay.8
+++ b/yay.8
@@ -1,5 +1,5 @@
-'\" t
-.TH "YAY" "8" "2018-01-31" "Yay v2\&.295" "Yay Manual"
+/n'\" t
+.TH "YAY" "8" "2018-02-29" "Yay v3\&.411+" "Yay Manual"
 .nh
 .ad l
 .SH "NAME"
@@ -11,14 +11,17 @@ yay \- AUR Helper written in go
 \fIyay\fR <search pattern>
 .SH "DESCRIPTION"
 .sp
-Yay is a Pacman wrapper with AUR support\&. It passes options to Makepkg and Pacman after resolving packages to install/upgrade\&.
+Yay is a Pacman wrapper with AUR support\&. It passes options to Makepkg and
+Pacman after resolving packages to install/upgrade\&.
 .sp
-This manpage only covers options unique to Yay\&. For other options see \fBpacman(8)\fR\&.
+This manpage only covers options unique to Yay\&. For other options see
+\fBpacman(8)\fR\&.
 .SH "YAY OPERATIONS"
 .PP
 \fB\-Y, --yay\fR
 .RS 4
-Perform yay specific operations\&. This is the default if no other operation is selected\&.
+Perform yay specific operations\&. This is the default if no other operation is
+selected\&.
 .RE
 .PP
 \fB\-P, --print\fR
@@ -36,7 +39,7 @@ If no operation is selected -Y will be assumed\&.
 .PP
 \fB\-S, -Si, -Ss, -Su\fR
 .RS 4
-These operations are extended to support the AUR as well as repo packages\&.
+These operations are extended to support both AUR and repo packages\&.
 .RE
 .PP
 \fB\-R\fR
@@ -47,13 +50,16 @@ Yay will also remove cached data about devel packages\&.
 .PP
 \fB<NO OPTION>\fR
 .RS 4
-Displays list of packages matching search terms and prompts the user on which packages to install(yogurt mode)\&.
+Displays a list of packages matching the search terms and prompts the user on
+which packages to install (yogurt mode)\&.
 .RE
 .PP
-\fB\-g \-\-getpkgbuild\fR
+\fB   \-\-gendb\fR
 .RS 4
-Downloads PKGBUILD from ABS or AUR\&.
-.RE
+Generate development package databse\&. Tracks the latest commit for each
+development package, when there is a new commit Yay will know to update\&. This
+is done per package whenever a package is synced. This option should only be
+used when migrating to Yay from another AUR helper.
 .RE
 .PP
 \fB\-c \-\-clean\fR
@@ -61,6 +67,17 @@ Downloads PKGBUILD from ABS or AUR\&.
 Remove unneeded dependencies\&.
 .RE
 .SH "PRINT OPTIONS (APPLY TO -P AND --PRINT)"
+\fB\-c \-\-complete\fR
+.RS 4
+Print a list of all AUR and repo packages\&. This is to allow shell completion
+and is not intended to be used directly by the user\&.
+.RE
+.PP
+\fB\-f \-\-fish\fR
+.RS 4
+During complete adjust the output for the fish shell\&.
+.RE
+.PP
 \fB\-d \-\-defaultconfig\fR
 .RS 4
 Print default yay configuration\&.
@@ -73,20 +90,22 @@ Print current yay configuration\&.
 .PP
 \fB\-n \-\-numberupgrades\fR
 .RS 4
-Print number of updates\&.
+Print number of packages that need to be updated\&. Note this does not preform
+a database refresh\&. Run \fByay -Sy\fR Before this for an up to date result\&.
 .RE
 .PP
 \fB\-s \-\-stats\fR
 .RS 4
-Displays information about installed packages and system health\&. If there are orphaned or out-of-date packages, warnings will be displayed\&.
+Displays information about installed packages and system health\&. If there are
+orphaned, out-of-date or packages that no longer exist on the AUR warnings will
+be displayed\&.
 .RE
 .PP
 \fB\-u \-\-upgrades\fR
 .RS 4
-Print update list\&.
-.RE
+Print Names of packages that need to be updated\&. Note this does not preform
+a database refresh\&. Run \fByay -Sy\fR Before this for an up to date result\&.
 .PP
-
 .SH "PERMANENT CONFIGURATION SETTINGS"
 .PP
 These options will be saved to disk and reapplied next time Yay is ran\&.
@@ -103,32 +122,34 @@ Show AUR packages first and then repository packages\&.
 .PP
 \fB\-\-devel\fR
 .RS 4
-Check -git/-svn/-hg development version\&.
+During sysupgrade also check AUR development packages for updates\&. Currently
+only GitHub packages are supported\&.
 .RE
 .PP
 \fB\-\-nodevel\fR
 .RS 4
-Disable development version checking\&.
+Do not check for development packages updates during sysupgrade\&.
 .RE
 .PP
 \fB\-\-afterclean\fR
 .RS 4
-Clean package sources after successful build\&.
+Remove package sources after successful Install\&.
 .RE
 .PP
 \fB\-\-noafterclean\fR
 .RS 4
-Disable package sources cleaning after successful build\&.
+Do not remove package sources after successful Install\&.
 .RE
 .PP
 \fB\-\-timeupdate\fR
 .RS 4
-Check package's modification date and version\&.
+During sysupgrade also compare the build time of installed packages against
+the last modification time of each package's AUR page\&.
 .RE
 .PP
 \fB\-\-notimeupdate\fR
 .RS 4
-Check only package version change\&.
+Do not consider build times during sysupgrade\&.
 .RE
 .SH "EXAMPLES"
 .PP
@@ -179,3 +200,5 @@ Please report bugs to our GitHub page https://github\&.com/Jguer/yay
 .SH "AUTHORS"
 .sp
 Jguer <joaogg3@gmail\&.com>
+.br
+Morgana <morganamilo@gmail\&.com>


### PR DESCRIPTION
Reword a lot of manpage and usage options.

Remove the `-Yg` and `-Y --getpkgbuild` options from documentation and
code as they have moved to `-G` and `--getpgkbuild`.

Update the version in the man page. Because our version is based on our
commit number added a `+` after the version number to indicated that
this is the version the manpage was written at but it also applies to
newer versions.

Added missing `-c --complete` and `-f --fish` options to the manpage.
But left them out of usage.

Added myself to the authors section. I do feel a bit bad about adding
myself and only myself but I thought it was not a good idea to add 20
names and fill up the page. There's currently no rules on who should be
added and not really a huge need for them right now. I guess we can just
add more people when we deem they belong there whatever that criteria
is.