### PR TITLE
 Fix duplicate packages when printing dependencies

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -99,6 +99,20 @@ func getDepCatagories(pkgs []string, dt *depTree) (*depCatagories, error) {
 		})
 	}
 
+	dupes := make(map[*alpm.Package]struct{})
+	filteredRepo := make([]*alpm.Package, 0)
+
+	for _, pkg := range dc.Repo {
+		_, ok := dupes[pkg]
+		if ok {
+			continue
+		}
+		dupes[pkg] = struct{}{}
+		filteredRepo = append(filteredRepo, pkg)
+	}
+
+	dc.Repo = filteredRepo
+
 	return dc, nil
 }
 

--- a/dependencies.go
+++ b/dependencies.go
@@ -211,10 +211,10 @@ func repoTreeRecursive(pkg *alpm.Package, dt *depTree, localDb *alpm.Db, syncDb 
 	}
 
 	dt.Repo[pkg.Name()] = pkg
-	/*(*pkg).Provides().ForEach(func(dep alpm.Depend) (err error) {
+	(*pkg).Provides().ForEach(func(dep alpm.Depend) (err error) {
 		dt.Repo[dep.Name] = pkg
 		return nil
-	})*/
+	})
 
 	(*pkg).Depends().ForEach(func(dep alpm.Depend) (err error) {
 		_, exists := dt.Repo[dep.Name]


### PR DESCRIPTION
e01c4b3 made some bad assumptions.
Removing the aliases caused packages to not installed when required only
through provides and not their package name. This fixes that by
re enabling the aliases and simply removing duplicates at the end.

I did some more testing on this and It does seem to work perfectly so I'll go ahead and merge this right away seems as this fix is pretty important.