### PR TITLE
Improve printing

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -579,8 +579,8 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 		aurQ.printSearch(numpq + 1)
 	}
 
-	fmt.Println(boldGreenFg(arrow) + boldGreenFg(" Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)"))
-	fmt.Print(boldGreenFg(arrow + " "))
+	fmt.Println(bold(green(arrow) + green(" Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)")))
+	fmt.Print(bold(green(arrow + " ")))
 	reader := bufio.NewReader(os.Stdin)
 	numberBuf, overflow, err := reader.ReadLine()
 	if err != nil || overflow {

--- a/cmd.go
+++ b/cmd.go
@@ -579,7 +579,7 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 		aurQ.printSearch(numpq + 1)
 	}
 
-	fmt.Println(bold(green(arrow) + green(" Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)")))
+	fmt.Println(bold(green(arrow + " Packages to install (eg: 1 2 3, 1-3 or ^4)")))
 	fmt.Print(bold(green(arrow + " ")))
 	reader := bufio.NewReader(os.Stdin)
 	numberBuf, overflow, err := reader.ReadLine()

--- a/config.go
+++ b/config.go
@@ -142,12 +142,12 @@ func editor() string {
 		}
 		fallthrough
 	default:
-		fmt.Println(boldRedFgBlackBg("Warning:"),
-			boldYellowFgBlackBg("$EDITOR"), whiteFgBlackBg("is not set"))
+		fmt.Println(bold(red(blackBg("Warning:"))),
+			bold(yellow(blackBg("$EDITOR"))), white(blackBg("is not set")))
 		fmt.Println("Please add $EDITOR or to your environment variables.")
 
 	editorLoop:
-		fmt.Print(greenFg("Edit PKGBUILD with:"))
+		fmt.Print(green("Edit PKGBUILD with:"))
 		var editorInput string
 		_, err := fmt.Scanln(&editorInput)
 		if err != nil {
@@ -179,7 +179,7 @@ func continueTask(s string, def string) (cont bool) {
 	}
 
 	var response string
-	fmt.Print(boldGreenFg(arrow+" "+s+" "), boldWhiteFg(postFix))
+	fmt.Print(bold(green(arrow+" "+s+" ")), bold(white(postFix)))
 
 	n, err := fmt.Scanln(&response)
 	if err != nil || n == 0 {

--- a/config.go
+++ b/config.go
@@ -142,8 +142,8 @@ func editor() string {
 		}
 		fallthrough
 	default:
-		fmt.Println(bold(red(blackBg("Warning:"))),
-			bold(yellow(blackBg("$EDITOR"))), white(blackBg("is not set")))
+		fmt.Println(bold(red("Warning:")),
+			bold(magenta("$EDITOR")), "is not set")
 		fmt.Println("Please add $EDITOR or to your environment variables.")
 
 	editorLoop:
@@ -179,7 +179,7 @@ func continueTask(s string, def string) (cont bool) {
 	}
 
 	var response string
-	fmt.Print(bold(green(arrow+" "+s+" ")), bold(white(postFix)))
+	fmt.Print(bold(green(arrow+" "+s+" ")), bold(postFix))
 
 	n, err := fmt.Scanln(&response)
 	if err != nil || n == 0 {

--- a/download.go
+++ b/download.go
@@ -101,10 +101,10 @@ nextPkg:
 
 				errD := downloadAndUnpack(url, path, true)
 				if errD != nil {
-					fmt.Println(boldYellowFg(pkg.Name()), boldGreenFg(errD.Error()))
+					fmt.Println(bold(yellow(pkg.Name())), bold(green(errD.Error())))
 				}
 
-				fmt.Println(boldGreenFg(arrow), boldGreenFg("Downloaded"), boldYellowFg(pkg.Name()), boldGreenFg("from ABS"))
+				fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(yellow(pkg.Name())), bold(green("from ABS")))
 				continue nextPkg
 			}
 		}
@@ -124,7 +124,7 @@ func getPkgbuildsfromAUR(pkgs []string, dir string) (err error) {
 
 	for _, pkg := range aq {
 		downloadAndUnpack(baseURL+aq[0].URLPath, dir, false)
-		fmt.Println(boldGreenFg(arrow), boldGreenFg("Downloaded"), boldYellowFg(pkg.Name), boldGreenFg("from AUR"))
+		fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(yellow(pkg.Name)), bold(green("from AUR")))
 	}
 
 	return

--- a/download.go
+++ b/download.go
@@ -101,10 +101,10 @@ nextPkg:
 
 				errD := downloadAndUnpack(url, path, true)
 				if errD != nil {
-					fmt.Println(bold(yellow(pkg.Name())), bold(green(errD.Error())))
+					fmt.Println(bold(magenta(pkg.Name())), bold(green(errD.Error())))
 				}
 
-				fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(yellow(pkg.Name())), bold(green("from ABS")))
+				fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(magenta(pkg.Name())), bold(green("from ABS")))
 				continue nextPkg
 			}
 		}
@@ -124,7 +124,7 @@ func getPkgbuildsfromAUR(pkgs []string, dir string) (err error) {
 
 	for _, pkg := range aq {
 		downloadAndUnpack(baseURL+aq[0].URLPath, dir, false)
-		fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(yellow(pkg.Name)), bold(green("from AUR")))
+		fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(magenta(pkg.Name)), bold(green("from AUR")))
 	}
 
 	return

--- a/install.go
+++ b/install.go
@@ -24,7 +24,7 @@ func install(parser *arguments) error {
 	srcinfos := make(map[string]*gopkg.PKGBUILD)
 	var dc *depCatagories
 
-	//fmt.Println(greenFg(arrow), greenFg("Resolving Dependencies"))
+	//fmt.Println(green(arrow), green("Resolving Dependencies"))
 	requestTargets := append(aurTargets, repoTargets...)
 
 	//remotenames: names of all non repo packages on the system
@@ -46,7 +46,7 @@ func install(parser *arguments) error {
 	}
 
 	if len(aurTargets) > 0 || parser.existsArg("u", "sysupgrade") && len(remoteNames) > 0 {
-		fmt.Println(boldCyanFg("::"), boldFg("Querying AUR..."))
+		fmt.Println(bold(cyan("::") + " Querying AUR..."))
 	}
 	dt, err := getDepTree(requestTargets)
 	if err != nil {
@@ -56,7 +56,7 @@ func install(parser *arguments) error {
 	//only error if direct targets or deps are missing
 	for missingName := range dt.Missing {
 		if !remoteNamesCache.get(missingName) {
-			return fmt.Errorf(boldRedFgBlackBg(arrow+" Error: ") +
+			return fmt.Errorf(bold(red(blackBg(arrow+" Error: "))) +
 				blackBg("Could not find all required package"))
 		}
 	}
@@ -193,7 +193,7 @@ func install(parser *arguments) error {
 				return err
 			}
 
-			fmt.Println(boldGreenFg(arrow + " GenDB finished. No packages were installed"))
+			fmt.Println(bold(green(arrow + " GenDB finished. No packages were installed")))
 			return nil
 		}
 
@@ -299,11 +299,11 @@ func checkForConflicts(dc *depCatagories) error {
 
 	if len(toRemove) != 0 {
 		fmt.Println(
-			redFg("Package conflicts found:"))
+			red("Package conflicts found:"))
 		for name, pkgs := range toRemove {
-			str := "\tInstalling " + yellowFg(name) + " will remove"
+			str := "\tInstalling " + yellow(name) + " will remove"
 			for pkg := range pkgs {
-				str += " " + yellowFg(pkg)
+				str += " " + yellow(pkg)
 			}
 
 			fmt.Println(str)
@@ -357,7 +357,7 @@ func parsesrcinfosFile(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, bas
 	for k, pkg := range pkgs {
 		dir := config.BuildDir + pkg.PackageBase + "/"
 
-		str := boldCyanFg("::") + boldFg(" Parsing SRCINFO (%d/%d): %s\n")
+		str := bold(cyan("::") + " Parsing SRCINFO (%d/%d): %s\n")
 		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
 
 		pkgbuild, err := gopkg.ParseSRCINFO(dir + ".SRCINFO")
@@ -376,7 +376,7 @@ func parsesrcinfosGenerate(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 	for k, pkg := range pkgs {
 		dir := config.BuildDir + pkg.PackageBase + "/"
 
-		str := boldCyanFg("::") + boldFg(" Parsing SRCINFO (%d/%d): %s\n")
+		str := bold(cyan("::") + " Parsing SRCINFO (%d/%d): %s\n")
 		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
 
 		cmd := exec.Command(config.MakepkgBin, "--printsrcinfo")
@@ -402,7 +402,7 @@ func parsesrcinfosGenerate(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 func dowloadPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg) (err error) {
 	for k, pkg := range pkgs {
 		//todo make pretty
-		str := boldCyanFg("::") + boldFg(" Downloading (%d/%d): %s\n")
+		str := bold(cyan("::") + " Downloading (%d/%d): %s\n")
 
 		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
 
@@ -447,7 +447,7 @@ func buildInstallPkgBuilds(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 		}
 
 		if built {
-			fmt.Println(boldRedFgBlackBg(arrow+" Warning:"),
+			fmt.Println(bold(red(blackBg(arrow+" Warning:"))),
 				blackBg(pkg.Name+"-"+pkg.Version+" Already made -- skipping build"))
 		} else {
 			err := passToMakepkg(dir, "-Ccf", "--noconfirm")
@@ -510,8 +510,8 @@ func clean(pkgs []*rpc.Pkg) {
 	for _, pkg := range pkgs {
 		dir := config.BuildDir + pkg.PackageBase + "/"
 
-		fmt.Println(boldGreenFg(arrow +
-			" CleanAfter enabled. Deleting " + pkg.Name + " source folder."))
+		fmt.Println(bold(green(arrow +
+			" CleanAfter enabled. Deleting " + pkg.Name + " source folder.")))
 		os.RemoveAll(dir)
 	}
 }

--- a/install.go
+++ b/install.go
@@ -56,8 +56,8 @@ func install(parser *arguments) error {
 	//only error if direct targets or deps are missing
 	for missingName := range dt.Missing {
 		if !remoteNamesCache.get(missingName) {
-			return fmt.Errorf(bold(red(blackBg(arrow+" Error: "))) +
-				blackBg("Could not find all required package"))
+			return fmt.Errorf(bold(red(arrow+" Error: ")) +
+				"Could not find all required package")
 		}
 	}
 
@@ -106,7 +106,7 @@ func install(parser *arguments) error {
 	}
 
 	//for _, pkg := range repoTargets {
-		//arguments.addTarget(pkg)
+	//arguments.addTarget(pkg)
 	//}
 
 	if len(dc.Aur) == 0 && len(arguments.targets) == 0 {
@@ -124,7 +124,6 @@ func install(parser *arguments) error {
 		if err != nil {
 			return fmt.Errorf("Error installing repo packages.")
 		}
-
 
 		depArguments := makeArguments()
 		depArguments.addArg("D", "asdeps")
@@ -301,9 +300,9 @@ func checkForConflicts(dc *depCatagories) error {
 		fmt.Println(
 			red("Package conflicts found:"))
 		for name, pkgs := range toRemove {
-			str := "\tInstalling " + yellow(name) + " will remove"
+			str := "\tInstalling " + magenta(name) + " will remove"
 			for pkg := range pkgs {
-				str += " " + yellow(pkg)
+				str += " " + magenta(pkg)
 			}
 
 			fmt.Println(str)
@@ -447,8 +446,8 @@ func buildInstallPkgBuilds(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 		}
 
 		if built {
-			fmt.Println(bold(red(blackBg(arrow+" Warning:"))),
-				blackBg(pkg.Name+"-"+pkg.Version+" Already made -- skipping build"))
+			fmt.Println(bold(red(arrow+" Warning:")),
+				pkg.Name+"-"+pkg.Version+" Already made -- skipping build")
 		} else {
 			err := passToMakepkg(dir, "-Ccf", "--noconfirm")
 			if err != nil {

--- a/print.go
+++ b/print.go
@@ -41,7 +41,7 @@ func (q aurQuery) printSearch(start int) {
 			fmt.Println(res.Name)
 			continue
 		}
-		toprint += boldWhiteFg("aur/") + boldYellowFg(res.Name) +
+		toprint += colourHash("aur") + "/" + boldYellowFg(res.Name) +
 			" " + boldCyanFg(res.Version) +
 			" (" + strconv.Itoa(res.NumVotes) + ") "
 
@@ -75,7 +75,7 @@ func (s repoQuery) printSearch() {
 			fmt.Println(res.Name())
 			continue
 		}
-		toprint += boldWhiteFg(res.DB().Name()+"/") + boldYellowFg(res.Name()) +
+		toprint += colourHash(res.DB().Name()) + "/" + boldYellowFg(res.Name()) +
 			" " + boldCyanFg(res.Version()) + " "
 
 		if len(res.Groups().Slice()) != 0 {
@@ -85,7 +85,7 @@ func (s repoQuery) printSearch() {
 		localDb, err := alpmHandle.LocalDb()
 		if err == nil {
 			if _, err = localDb.PkgByName(res.Name()); err == nil {
-				toprint += greenFgBlackBg("Installed")
+				toprint += greenFgBlueBg("Installed")
 			}
 		}
 
@@ -416,4 +416,15 @@ func boldYellowFgBlackBg(in string) string {
 	}
 
 	return in
+}
+
+func colourHash(name string) (output string) {
+	if alpmConf.Options&alpm.ConfColor == 0 {
+		return name
+	}
+	var hash = 5381
+	for i := 0; i < len(name); i++ {
+		hash = int(name[i]) + ((hash << 5) + (hash))
+	}
+	return fmt.Sprintf("\x1b[1;%dm%s\x1b[0m", hash%6+31, name)
 }

--- a/print.go
+++ b/print.go
@@ -33,28 +33,28 @@ func (q aurQuery) printSearch(start int) {
 		var toprint string
 		if config.SearchMode == NumberMenu {
 			if config.SortMode == BottomUp {
-				toprint += yellowFg(strconv.Itoa(len(q)+start-i-1) + " ")
+				toprint += yellow(strconv.Itoa(len(q)+start-i-1) + " ")
 			} else {
-				toprint += yellowFg(strconv.Itoa(start+i) + " ")
+				toprint += yellow(strconv.Itoa(start+i) + " ")
 			}
 		} else if config.SearchMode == Minimal {
 			fmt.Println(res.Name)
 			continue
 		}
-		toprint += colourHash("aur") + "/" + boldYellowFg(res.Name) +
-			" " + boldCyanFg(res.Version) +
+		toprint += bold(colourHash("aur")) + "/" + bold(yellow(res.Name)) +
+			" " + bold(cyan(res.Version)) +
 			" (" + strconv.Itoa(res.NumVotes) + ") "
 
 		if res.Maintainer == "" {
-			toprint += redFgBlackBg("(Orphaned)") + " "
+			toprint += red(blackBg("(Orphaned)")) + " "
 		}
 
 		if res.OutOfDate != 0 {
-			toprint += redFgBlackBg("(Out-of-date)") + " "
+			toprint += red(blackBg("(Out-of-date)")) + " "
 		}
 
 		if _, err := localDb.PkgByName(res.Name); err == nil {
-			toprint += greenFgBlackBg("Installed")
+			toprint += green(blackBg("Installed"))
 		}
 		toprint += "\n    " + res.Description
 		fmt.Println(toprint)
@@ -67,16 +67,16 @@ func (s repoQuery) printSearch() {
 		var toprint string
 		if config.SearchMode == NumberMenu {
 			if config.SortMode == BottomUp {
-				toprint += yellowFg(strconv.Itoa(len(s)-i) + " ")
+				toprint += yellow(strconv.Itoa(len(s)-i) + " ")
 			} else {
-				toprint += yellowFg(strconv.Itoa(i+1) + " ")
+				toprint += yellow(strconv.Itoa(i+1) + " ")
 			}
 		} else if config.SearchMode == Minimal {
 			fmt.Println(res.Name())
 			continue
 		}
-		toprint += colourHash(res.DB().Name()) + "/" + boldYellowFg(res.Name()) +
-			" " + boldCyanFg(res.Version()) + " "
+		toprint += colourHash(res.DB().Name()) + "/" + bold(yellow(res.Name())) +
+			" " + bold(cyan(res.Version())) + " "
 
 		if len(res.Groups().Slice()) != 0 {
 			toprint += fmt.Sprint(res.Groups().Slice(), " ")
@@ -85,7 +85,7 @@ func (s repoQuery) printSearch() {
 		localDb, err := alpmHandle.LocalDb()
 		if err == nil {
 			if _, err = localDb.PkgByName(res.Name()); err == nil {
-				toprint += greenFgBlueBg("Installed")
+				toprint += green(blackBg("Installed"))
 			}
 		}
 
@@ -183,29 +183,29 @@ func printDownloads(repoName string, length int, packages string) {
 		return
 	}
 
-	repoInfo := boldBlueFg(
-		"[" + repoName + ": " + strconv.Itoa(length) + "]")
-	fmt.Println(repoInfo + yellowFg(packages))
+	repoInfo := bold(blue(
+		"[" + repoName + ": " + strconv.Itoa(length) + "]"))
+	fmt.Println(repoInfo + yellow(packages))
 }
 
 // PrintInfo prints package info like pacman -Si.
 func PrintInfo(a *rpc.Pkg) {
-	fmt.Println(boldWhiteFg("Repository      :"), "aur")
-	fmt.Println(boldWhiteFg("Name            :"), a.Name)
-	fmt.Println(boldWhiteFg("Version         :"), a.Version)
-	fmt.Println(boldWhiteFg("Description     :"), a.Description)
-	fmt.Println(boldWhiteFg("URL             :"), a.URL)
-	fmt.Println(boldWhiteFg("Licenses        :"), strings.Join(a.License, "  "))
-	fmt.Println(boldWhiteFg("Depends On      :"), strings.Join(a.Depends, "  "))
-	fmt.Println(boldWhiteFg("Make Deps       :"), strings.Join(a.MakeDepends, "  "))
-	fmt.Println(boldWhiteFg("Check Deps      :"), strings.Join(a.CheckDepends, "  "))
-	fmt.Println(boldWhiteFg("Optional Deps   :"), strings.Join(a.OptDepends, "  "))
-	fmt.Println(boldWhiteFg("Conflicts With  :"), strings.Join(a.Conflicts, "  "))
-	fmt.Println(boldWhiteFg("Maintainer      :"), a.Maintainer)
-	fmt.Println(boldWhiteFg("Votes           :"), a.NumVotes)
-	fmt.Println(boldWhiteFg("Popularity      :"), a.Popularity)
+	fmt.Println(bold(white("Repository      :")), "aur")
+	fmt.Println(bold(white("Name            :")), a.Name)
+	fmt.Println(bold(white("Version         :")), a.Version)
+	fmt.Println(bold(white("Description     :")), a.Description)
+	fmt.Println(bold(white("URL             :")), a.URL)
+	fmt.Println(bold(white("Licenses        :")), strings.Join(a.License, "  "))
+	fmt.Println(bold(white("Depends On      :")), strings.Join(a.Depends, "  "))
+	fmt.Println(bold(white("Make Deps       :")), strings.Join(a.MakeDepends, "  "))
+	fmt.Println(bold(white("Check Deps      :")), strings.Join(a.CheckDepends, "  "))
+	fmt.Println(bold(white("Optional Deps   :")), strings.Join(a.OptDepends, "  "))
+	fmt.Println(bold(white("Conflicts With  :")), strings.Join(a.Conflicts, "  "))
+	fmt.Println(bold(white("Maintainer      :")), a.Maintainer)
+	fmt.Println(bold(white("Votes           :")), a.NumVotes)
+	fmt.Println(bold(white("Popularity      :")), a.Popularity)
 	if a.OutOfDate != 0 {
-		fmt.Println(boldWhiteFg("Out-of-date     :"), "Yes")
+		fmt.Println(bold(white("Out-of-date     :")), "Yes")
 	}
 
 	fmt.Println()
@@ -226,7 +226,7 @@ func biggestPackages() {
 	}
 
 	for i := 0; i < 10; i++ {
-		fmt.Println(pkgS[i].Name() + ": " + yellowFg(human(pkgS[i].ISize())))
+		fmt.Println(pkgS[i].Name() + ": " + yellow(human(pkgS[i].ISize())))
 	}
 	// Could implement size here as well, but we just want the general idea
 }
@@ -244,15 +244,15 @@ func localStatistics() error {
 	}
 
 	fmt.Printf("\n Yay version r%s\n", version)
-	fmt.Println(boldCyanFg("==========================================="))
-	fmt.Println(boldGreenFg("Total installed packages: ") + yellowFg(strconv.Itoa(info.Totaln)))
-	fmt.Println(boldGreenFg("Total foreign installed packages: ") + yellowFg(strconv.Itoa(len(remoteNames))))
-	fmt.Println(boldGreenFg("Explicitly installed packages: ") + yellowFg(strconv.Itoa(info.Expln)))
-	fmt.Println(boldGreenFg("Total Size occupied by packages: ") + yellowFg(human(info.TotalSize)))
-	fmt.Println(boldCyanFg("==========================================="))
-	fmt.Println(boldGreenFg("Ten biggest packages"))
+	fmt.Println(bold(cyan("===========================================")))
+	fmt.Println(bold(green("Total installed packages: ")) + yellow(strconv.Itoa(info.Totaln)))
+	fmt.Println(bold(green("Total foreign installed packages: ")) + yellow(strconv.Itoa(len(remoteNames))))
+	fmt.Println(bold(green("Explicitly installed packages: ")) + yellow(strconv.Itoa(info.Expln)))
+	fmt.Println(bold(green("Total Size occupied by packages: ")) + yellow(human(info.TotalSize)))
+	fmt.Println(bold(cyan("===========================================")))
+	fmt.Println(bold(green("Ten biggest packages")))
 	biggestPackages()
-	fmt.Println(boldCyanFg("==========================================="))
+	fmt.Println(bold(cyan("===========================================")))
 
 	aurInfo(remoteNames)
 
@@ -299,120 +299,65 @@ func printUpdateList() error {
 	return nil
 }
 
+func red(in string) string {
+	if alpmConf.Options&alpm.ConfColor > 0 {
+		return "\x1b[31m" + in + "\x1b[0m"
+	}
+
+	return in
+}
+
+func green(in string) string {
+	if alpmConf.Options&alpm.ConfColor > 0 {
+		return "\x1b[32m" + in + "\x1b[0m"
+	}
+
+	return in
+}
+
+func yellow(in string) string {
+	if alpmConf.Options&alpm.ConfColor > 0 {
+		return "\x1b[33m" + in + "\x1b[0m"
+	}
+
+	return in
+}
+
+func blue(in string) string {
+	if alpmConf.Options&alpm.ConfColor > 0 {
+		return "\x1b[34m" + in + "\x1b[0m"
+	}
+
+	return in
+}
+
+func cyan(in string) string {
+	if alpmConf.Options&alpm.ConfColor > 0 {
+		return "\x1b[36m" + in + "\x1b[0m"
+	}
+
+	return in
+}
+
+func white(in string) string {
+	if alpmConf.Options&alpm.ConfColor > 0 {
+		return "\x1b[37m" + in + "\x1b[0m"
+	}
+
+	return in
+}
+
 func blackBg(in string) string {
 	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[0;;40m" + in + "\x1b[0m"
+		return "\x1b[40m" + in + "\x1b[0m"
 	}
 
 	return in
 }
 
-func redFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[0;31m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func greenFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[0;32m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func yellowFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[0;33m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func boldFg(in string) string {
+func bold(in string) string {
 	if alpmConf.Options&alpm.ConfColor > 0 {
 		return "\x1b[1m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-func boldGreenFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[1;32m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func boldYellowFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[1;33m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func boldBlueFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[1;34m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func boldCyanFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[1;36m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func boldWhiteFg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[1;37m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func redFgBlackBg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[0;31;40m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func greenFgBlackBg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[0;32;40m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func whiteFgBlackBg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[0;37;40m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func boldRedFgBlackBg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[1;31;40m" + in + "\x1b[0m"
-	}
-
-	return in
-}
-
-func boldYellowFgBlackBg(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
-		return "\x1b[1;33;40m" + in + "\x1b[0m"
 	}
 
 	return in
@@ -426,5 +371,5 @@ func colourHash(name string) (output string) {
 	for i := 0; i < len(name); i++ {
 		hash = int(name[i]) + ((hash << 5) + (hash))
 	}
-	return fmt.Sprintf("\x1b[1;%dm%s\x1b[0m", hash%6+31, name)
+	return fmt.Sprintf("\x1b[%dm%s\x1b[0m", hash%6+31, name)
 }

--- a/query.go
+++ b/query.go
@@ -266,7 +266,7 @@ func hangingPackages() (hanging []string, err error) {
 		requiredby := pkg.ComputeRequiredBy()
 		if len(requiredby) == 0 {
 			hanging = append(hanging, pkg.Name())
-			fmt.Println(pkg.Name() + ": " + yellow(human(pkg.ISize())))
+			fmt.Println(pkg.Name() + ": " + magenta(human(pkg.ISize())))
 
 		}
 		return nil
@@ -378,25 +378,25 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	}
 
 	if len(missing) > 0 {
-		fmt.Print(bold(red(blackBg(arrow + " Missing AUR Packages:"))))
+		fmt.Print(bold(red(arrow + " Missing AUR Packages:")))
 		for _, name := range missing {
-			fmt.Print(" " + bold(yellow(blackBg(name))))
+			fmt.Print(" " + bold(magenta(name)))
 		}
 		fmt.Println()
 	}
 
 	if len(orphans) > 0 {
-		fmt.Print(bold(red(blackBg(arrow + " Orphaned AUR Packages:"))))
+		fmt.Print(bold(red(arrow + " Orphaned AUR Packages:")))
 		for _, name := range orphans {
-			fmt.Print(" " + bold(yellow(blackBg(name))))
+			fmt.Print(" " + bold(magenta(name)))
 		}
 		fmt.Println()
 	}
 
 	if len(outOfDate) > 0 {
-		fmt.Print(bold(red(blackBg(arrow + " Out Of Date AUR Packages:"))))
+		fmt.Print(bold(red(arrow + " Out Of Date AUR Packages:")))
 		for _, name := range outOfDate {
-			fmt.Print(" " + bold(yellow(blackBg(name))))
+			fmt.Print(" " + bold(magenta(name)))
 		}
 		fmt.Println()
 	}

--- a/query.go
+++ b/query.go
@@ -266,7 +266,7 @@ func hangingPackages() (hanging []string, err error) {
 		requiredby := pkg.ComputeRequiredBy()
 		if len(requiredby) == 0 {
 			hanging = append(hanging, pkg.Name())
-			fmt.Println(pkg.Name() + ": " + yellowFg(human(pkg.ISize())))
+			fmt.Println(pkg.Name() + ": " + yellow(human(pkg.ISize())))
 
 		}
 		return nil
@@ -378,25 +378,25 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	}
 
 	if len(missing) > 0 {
-		fmt.Print(boldRedFgBlackBg(arrow + " Missing AUR Packages:"))
+		fmt.Print(bold(red(blackBg(arrow + " Missing AUR Packages:"))))
 		for _, name := range missing {
-			fmt.Print(" " + boldYellowFgBlackBg(name))
+			fmt.Print(" " + bold(yellow(blackBg(name))))
 		}
 		fmt.Println()
 	}
 
 	if len(orphans) > 0 {
-		fmt.Print(boldRedFgBlackBg(arrow + " Orphaned AUR Packages:"))
+		fmt.Print(bold(red(blackBg(arrow + " Orphaned AUR Packages:"))))
 		for _, name := range orphans {
-			fmt.Print(" " + boldYellowFgBlackBg(name))
+			fmt.Print(" " + bold(yellow(blackBg(name))))
 		}
 		fmt.Println()
 	}
 
 	if len(outOfDate) > 0 {
-		fmt.Print(boldRedFgBlackBg(arrow + " Out Of Date AUR Packages:"))
+		fmt.Print(bold(red(blackBg(arrow + " Out Of Date AUR Packages:"))))
 		for _, name := range outOfDate {
-			fmt.Print(" " + boldYellowFgBlackBg(name))
+			fmt.Print(" " + bold(yellow(blackBg(name))))
 		}
 		fmt.Println()
 	}

--- a/upgrade.go
+++ b/upgrade.go
@@ -85,18 +85,8 @@ func (u upSlice) Print(start int) {
 	for k, i := range u {
 		left, right := getVersionDiff(i.LocalVersion, i.RemoteVersion)
 
-		f := func(name string) (output string) {
-			if alpmConf.Options&alpm.ConfColor == 0 {
-				return name
-			}
-			var hash = 5381
-			for i := 0; i < len(name); i++ {
-				hash = int(name[i]) + ((hash << 5) + (hash))
-			}
-			return fmt.Sprintf("\x1b[1;%dm%s\x1b[0m", hash%6+31, name)
-		}
 		fmt.Print(yellowFg(fmt.Sprintf("%2d ", len(u)+start-k-1)))
-		fmt.Print(f(i.Repository), "/", boldWhiteFg(i.Name))
+		fmt.Print(colourHash(i.Repository), "/", boldWhiteFg(i.Name))
 
 		w := 70 - len(i.Repository) - len(i.Name) + len(left)
 		fmt.Printf(fmt.Sprintf("%%%ds", w),

--- a/upgrade.go
+++ b/upgrade.go
@@ -61,19 +61,19 @@ func getVersionDiff(oldVersion, newversion string) (left, right string) {
 	new, errNew := pkgb.NewCompleteVersion(newversion)
 
 	if errOld != nil {
-		left = redFg("Invalid Version")
+		left = red("Invalid Version")
 	}
 	if errNew != nil {
-		right = redFg("Invalid Version")
+		right = red("Invalid Version")
 	}
 
 	if errOld == nil && errNew == nil {
 		if old.Version == new.Version {
-			left = string(old.Version) + "-" + redFg(string(old.Pkgrel))
-			right = string(new.Version) + "-" + greenFg(string(new.Pkgrel))
+			left = string(old.Version) + "-" + red(string(old.Pkgrel))
+			right = string(new.Version) + "-" + green(string(new.Pkgrel))
 		} else {
-			left = redFg(string(old.Version)) + "-" + string(old.Pkgrel)
-			right = boldGreenFg(string(new.Version)) + "-" + string(new.Pkgrel)
+			left = red(string(old.Version)) + "-" + string(old.Pkgrel)
+			right = bold(green(string(new.Version))) + "-" + string(new.Pkgrel)
 		}
 	}
 
@@ -85,8 +85,8 @@ func (u upSlice) Print(start int) {
 	for k, i := range u {
 		left, right := getVersionDiff(i.LocalVersion, i.RemoteVersion)
 
-		fmt.Print(yellowFg(fmt.Sprintf("%2d ", len(u)+start-k-1)))
-		fmt.Print(colourHash(i.Repository), "/", boldWhiteFg(i.Name))
+		fmt.Print(yellow(fmt.Sprintf("%2d ", len(u)+start-k-1)))
+		fmt.Print(bold(colourHash(i.Repository)), "/", bold(white(i.Name)))
 
 		w := 70 - len(i.Repository) - len(i.Name) + len(left)
 		fmt.Printf(fmt.Sprintf("%%%ds", w),
@@ -105,14 +105,14 @@ func upList(dt *depTree) (aurUp upSlice, repoUp upSlice, err error) {
 	aurC := make(chan upSlice)
 	errC := make(chan error)
 
-	fmt.Println(boldCyanFg("::"), boldFg("Searching databases for updates..."))
+	fmt.Println(bold(cyan("::") + " Searching databases for updates..."))
 	go func() {
 		repoUpList, err := upRepo(local)
 		errC <- err
 		repoC <- repoUpList
 	}()
 
-	fmt.Println(boldCyanFg("::"), boldFg("Searching AUR for updates..."))
+	fmt.Println(bold(cyan("::") + " Searching AUR for updates..."))
 	go func() {
 		aurUpList, err := upAUR(remote, remoteNames, dt)
 		errC <- err
@@ -156,7 +156,7 @@ func upDevel(remote []alpm.Package, packageC chan upgrade, done chan bool) {
 			}
 			if found {
 				if pkg.ShouldIgnore() {
-					fmt.Print(yellowFg("Warning: "))
+					fmt.Print(yellow("Warning: "))
 					fmt.Printf("%s ignoring package upgrade (%s => %s)\n", pkg.Name(), pkg.Version(), "git")
 				} else {
 					packageC <- upgrade{e.Package, "devel", pkg.Version(), "commit-" + e.SHA[0:6]}
@@ -181,7 +181,7 @@ func upAUR(remote []alpm.Package, remoteNames []string, dt *depTree) (toUpgrade 
 	if config.Devel {
 		routines++
 		go upDevel(remote, packageC, done)
-		fmt.Println(boldCyanFg("::"), boldFg("Checking development packages..."))
+		fmt.Println(bold(cyan("::") +  "Checking development packages..."))
 	}
 
 	routines++
@@ -196,7 +196,7 @@ func upAUR(remote []alpm.Package, remoteNames []string, dt *depTree) (toUpgrade 
 				(alpm.VerCmp(pkg.Version(), aurPkg.Version) < 0) {
 				if pkg.ShouldIgnore() {
 					left, right := getVersionDiff(pkg.Version(), aurPkg.Version)
-					fmt.Print(yellowFg("Warning: "))
+					fmt.Print(yellow("Warning: "))
 					fmt.Printf("%s ignoring package upgrade (%s => %s)\n", pkg.Name(), left, right)
 				} else {
 					packageC <- upgrade{aurPkg.Name, "aur", pkg.Version(), aurPkg.Version}
@@ -245,7 +245,7 @@ func upRepo(local []alpm.Package) (upSlice, error) {
 		newPkg := pkg.NewVersion(dbList)
 		if newPkg != nil {
 			if pkg.ShouldIgnore() {
-				fmt.Print(yellowFg("Warning: "))
+				fmt.Print(yellow("Warning: "))
 				fmt.Printf("%s ignoring package upgrade (%s => %s)\n", pkg.Name(), pkg.Version(), newPkg.Version())
 			} else {
 				slice = append(slice, upgrade{pkg.Name(), newPkg.DB().Name(), pkg.Version(), newPkg.Version()})
@@ -293,13 +293,13 @@ func upgradePkgs(dt *depTree) (stringSet, stringSet, error) {
 	}
 
 	sort.Sort(repoUp)
-	fmt.Println(boldBlueFg("::"), len(aurUp)+len(repoUp), boldWhiteFg("Packages to upgrade."))
+	fmt.Println(bold(blue("::")), len(aurUp)+len(repoUp), bold(white("Packages to upgrade.")))
 	repoUp.Print(len(aurUp) + 1)
 	aurUp.Print(1)
 
 	if !config.NoConfirm {
-		fmt.Println(boldGreenFg(arrow) + greenFg(" Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)"))
-		fmt.Print(boldGreenFg(arrow + " "))
+		fmt.Println(bold(green(arrow)) + green(" Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)"))
+		fmt.Print(bold(green(arrow + " ")))
 		reader := bufio.NewReader(os.Stdin)
 
 		numberBuf, overflow, err := reader.ReadLine()

--- a/upgrade.go
+++ b/upgrade.go
@@ -85,8 +85,8 @@ func (u upSlice) Print(start int) {
 	for k, i := range u {
 		left, right := getVersionDiff(i.LocalVersion, i.RemoteVersion)
 
-		fmt.Print(yellow(fmt.Sprintf("%2d ", len(u)+start-k-1)))
-		fmt.Print(bold(colourHash(i.Repository)), "/", bold(white(i.Name)))
+		fmt.Print(magenta(fmt.Sprintf("%2d ", len(u)+start-k-1)))
+		fmt.Print(bold(colourHash(i.Repository)), "/", cyan(i.Name))
 
 		w := 70 - len(i.Repository) - len(i.Name) + len(left)
 		fmt.Printf(fmt.Sprintf("%%%ds", w),
@@ -156,8 +156,8 @@ func upDevel(remote []alpm.Package, packageC chan upgrade, done chan bool) {
 			}
 			if found {
 				if pkg.ShouldIgnore() {
-					fmt.Print(yellow("Warning: "))
-					fmt.Printf("%s ignoring package upgrade (%s => %s)\n", pkg.Name(), pkg.Version(), "git")
+					fmt.Print(magenta("Warning: "))
+					fmt.Printf("%s ignoring package upgrade (%s => %s)\n", cyan(pkg.Name()), pkg.Version(), "git")
 				} else {
 					packageC <- upgrade{e.Package, "devel", pkg.Version(), "commit-" + e.SHA[0:6]}
 				}
@@ -181,7 +181,7 @@ func upAUR(remote []alpm.Package, remoteNames []string, dt *depTree) (toUpgrade 
 	if config.Devel {
 		routines++
 		go upDevel(remote, packageC, done)
-		fmt.Println(bold(cyan("::") +  "Checking development packages..."))
+		fmt.Println(bold(cyan("::") + "Checking development packages..."))
 	}
 
 	routines++
@@ -196,8 +196,8 @@ func upAUR(remote []alpm.Package, remoteNames []string, dt *depTree) (toUpgrade 
 				(alpm.VerCmp(pkg.Version(), aurPkg.Version) < 0) {
 				if pkg.ShouldIgnore() {
 					left, right := getVersionDiff(pkg.Version(), aurPkg.Version)
-					fmt.Print(yellow("Warning: "))
-					fmt.Printf("%s ignoring package upgrade (%s => %s)\n", pkg.Name(), left, right)
+					fmt.Print(magenta("Warning: "))
+					fmt.Printf("%s ignoring package upgrade (%s => %s)\n", cyan(pkg.Name()), left, right)
 				} else {
 					packageC <- upgrade{aurPkg.Name, "aur", pkg.Version(), aurPkg.Version}
 				}
@@ -245,7 +245,7 @@ func upRepo(local []alpm.Package) (upSlice, error) {
 		newPkg := pkg.NewVersion(dbList)
 		if newPkg != nil {
 			if pkg.ShouldIgnore() {
-				fmt.Print(yellow("Warning: "))
+				fmt.Print(magenta("Warning: "))
 				fmt.Printf("%s ignoring package upgrade (%s => %s)\n", pkg.Name(), pkg.Version(), newPkg.Version())
 			} else {
 				slice = append(slice, upgrade{pkg.Name(), newPkg.DB().Name(), pkg.Version(), newPkg.Version()})
@@ -293,12 +293,12 @@ func upgradePkgs(dt *depTree) (stringSet, stringSet, error) {
 	}
 
 	sort.Sort(repoUp)
-	fmt.Println(bold(blue("::")), len(aurUp)+len(repoUp), bold(white("Packages to upgrade.")))
+	fmt.Println(bold(blue("::")), len(aurUp)+len(repoUp), bold("Packages to upgrade."))
 	repoUp.Print(len(aurUp) + 1)
 	aurUp.Print(1)
 
 	if !config.NoConfirm {
-		fmt.Println(bold(green(arrow)) + green(" Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)"))
+		fmt.Println(bold(green(arrow + " Packages to not upgrade (eg: 1 2 3, 1-3 or ^4)")))
 		fmt.Print(bold(green(arrow + " ")))
 		reader := bufio.NewReader(os.Stdin)
 


### PR DESCRIPTION
Refactoring and general improvements to printing and specific improvements for light themes.
For more information see commits.

Before light:
![image](https://user-images.githubusercontent.com/16593899/36885668-49cbb494-1de0-11e8-9e30-a28c1d01e839.png)
After light:
![image](https://user-images.githubusercontent.com/16593899/36885677-5b0c8fd0-1de0-11e8-82e8-5dfb5ae15ad4.png)
Before dark:
![image](https://user-images.githubusercontent.com/16593899/36885792-012cf382-1de1-11e8-8f82-31a97980f257.png)
After dark:
![image](https://user-images.githubusercontent.com/16593899/36885809-12ba6d82-1de1-11e8-9940-7b7627fb277c.png)

Do forgive the awful fonts. The pictures were takes with totally unconfigured terminals.

This should fix #128. Stuff like colours is highly opinion based, feedback would be great. Especially from @Jguer @ijanos @samosaara @heyitswither seems as you took intrest in the issue. I really dislike light themes myself so I would appreciate opinions from people who actually use them. 
