### PR TITLE
Fix Yay showing AUR prompts when it shouldnt

### DIFF
--- a/install.go
+++ b/install.go
@@ -116,6 +116,7 @@ func install(parser *arguments) error {
 
 	if hasAur {
 		printDepCatagories(dc)
+		hasAur = len(dc.Aur) != 0
 		fmt.Println()
 	}
 


### PR DESCRIPTION
In a very specific case where the user runs `yay -Syu` then uses the
number menu to ignore all AUR upgrades after the Repo install the user
will still be prompted to install and download packages.