### PR TITLE
Add support to skip pkgbuild downloads.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -46,6 +46,8 @@ Permanent configuration options:
     --noafterclean       Do not remove package sources after successful build
     --timeupdate         Check package's AUR page for changes during sysupgrade
     --notimeupdate       Do not checking of AUR page changes
+    --redownload         Always download pkgbuilds
+    --noredownload       Skip pkgbuild download if in cache and up to date
 
 Print specific options:
     -c --complete        Used for completions

--- a/cmd.go
+++ b/cmd.go
@@ -341,16 +341,6 @@ func handleConfig(option string) bool {
 		config.CleanAfter = true
 	case "noafterclean":
 		config.CleanAfter = false
-		//		case "gendb":
-		//			err = createDevelDB()
-		//			if err != nil {
-		//				fmt.Println(err)
-		//			}
-		//			err = saveVCSInfo()
-		//			if err != nil {
-		//				fmt.Println(err)
-		//			}
-		//			os.Exit(0)
 	case "devel":
 		config.Devel = true
 	case "nodevel":
@@ -363,14 +353,12 @@ func handleConfig(option string) bool {
 		config.SortMode = TopDown
 	case "bottomup":
 		config.SortMode = BottomUp
-		//		case "help":
-		//			usage()
-		//			os.Exit(0)
-		//		case "version":
-		//			fmt.Printf("yay v%s\n", version)
-		//			os.Exit(0)
 	case "noconfirm":
 		config.NoConfirm = true
+	case "redownload":
+		config.ReDownload = true
+	case "noredownload":
+		config.ReDownload = false
 	default:
 		return false
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -46,7 +46,8 @@ Permanent configuration options:
     --noafterclean       Do not remove package sources after successful build
     --timeupdate         Check package's AUR page for changes during sysupgrade
     --notimeupdate       Do not checking of AUR page changes
-    --redownload         Always download pkgbuilds
+    --redownload         Always download pkgbuilds of targets
+    --redownloadall      Always download pkgbuilds of all AUR packages
     --noredownload       Skip pkgbuild download if in cache and up to date
 
 Print specific options:
@@ -358,9 +359,11 @@ func handleConfig(option string) bool {
 	case "noconfirm":
 		config.NoConfirm = true
 	case "redownload":
-		config.ReDownload = true
+		config.ReDownload = "yes"
+	case "redownloadall":
+		config.ReDownload = "all"
 	case "noredownload":
-		config.ReDownload = false
+		config.ReDownload = "no"
 	default:
 		return false
 	}
@@ -370,6 +373,7 @@ func handleConfig(option string) bool {
 }
 
 func handleVersion() {
+	fmt.Print(config.ReDownload)
 	fmt.Printf("yay v%s\n", version)
 }
 

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type Configuration struct {
 	PacmanBin     string `json:"pacmanbin"`
 	PacmanConf    string `json:"pacmanconf"`
 	TarBin        string `json:"tarbin"`
+	ReDownload    string `json:"redownload"`
 	RequestSplitN int    `json:"requestsplitn"`
 	SearchMode    int    `json:"-"`
 	SortMode      int    `json:"sortmode"`
@@ -39,7 +40,6 @@ type Configuration struct {
 	NoConfirm     bool   `json:"-"`
 	Devel         bool   `json:"devel"`
 	CleanAfter    bool   `json:"cleanAfter"`
-	ReDownload    bool   `json:"redownload"`
 }
 
 var version = "3.373"
@@ -113,7 +113,7 @@ func defaultSettings(config *Configuration) {
 	config.TarBin = "/usr/bin/bsdtar"
 	config.TimeUpdate = false
 	config.RequestSplitN = 150
-	config.ReDownload = false
+	config.ReDownload = "no"
 }
 
 // Editor returns the preferred system editor.

--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ type Configuration struct {
 	NoConfirm     bool   `json:"-"`
 	Devel         bool   `json:"devel"`
 	CleanAfter    bool   `json:"cleanAfter"`
+	ReDownload    bool   `json:"redownload"`
 }
 
 var version = "3.373"
@@ -112,6 +113,7 @@ func defaultSettings(config *Configuration) {
 	config.TarBin = "/usr/bin/bsdtar"
 	config.TimeUpdate = false
 	config.RequestSplitN = 150
+	config.ReDownload = false
 }
 
 // Editor returns the preferred system editor.

--- a/install.go
+++ b/install.go
@@ -164,7 +164,7 @@ func install(parser *arguments) error {
 			return fmt.Errorf("Aborting due to user")
 		}
 
-		err = dowloadPkgBuilds(dc.Aur, dc.Bases)
+		err = downloadPkgBuilds(dc.Aur, parser.targets, dc.Bases)
 		if err != nil {
 			return err
 		}
@@ -399,9 +399,9 @@ func parsesrcinfosGenerate(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 	return nil
 }
 
-func dowloadPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg) error {
+func downloadPkgBuilds(pkgs []*rpc.Pkg, targets stringSet, bases map[string][]*rpc.Pkg) error {
 	for k, pkg := range pkgs {
-		if !config.ReDownload {
+		if config.ReDownload == "no" || (config.ReDownload == "yes" && !targets.get(pkg.Name)) {
 			dir := config.BuildDir + pkg.PackageBase + "/.SRCINFO"
 			pkgbuild, err := gopkg.ParseSRCINFO(dir)
 

--- a/yay.8
+++ b/yay.8
@@ -151,6 +151,17 @@ the last modification time of each package's AUR page\&.
 .RS 4
 Do not consider build times during sysupgrade\&.
 .RE
+.PP
+\fB\-\-redownload\fR
+.RS 4
+When downloading pkgbuilds if the pkgbuild is found in cache and is equal or
+newer than the AUR's version use that instead of downloading a new one\&.
+.RE
+.PP
+\fB\-\-noredownload\fR
+.RS 4
+Always download pkgbuilds even when a copy is avaliable in cache\&.
+.RE
 .SH "EXAMPLES"
 .PP
 yay \fIfoo\fR

--- a/yay.8
+++ b/yay.8
@@ -154,13 +154,19 @@ Do not consider build times during sysupgrade\&.
 .PP
 \fB\-\-redownload\fR
 .RS 4
-When downloading pkgbuilds if the pkgbuild is found in cache and is equal or
-newer than the AUR's version use that instead of downloading a new one\&.
+Always download pkgbuilds of targets even when a copy is avaliable in cache\&.
+.RE
+.PP
+\fB\-\-redownloadall\fR
+.RS 4
+Always download pkgbuilds of all AUR packages even when a copy is avaliable 
+in cache\&.
 .RE
 .PP
 \fB\-\-noredownload\fR
 .RS 4
-Always download pkgbuilds even when a copy is avaliable in cache\&.
+When downloading pkgbuilds if the pkgbuild is found in cache and is equal or
+newer than the AUR's version use that instead of downloading a new one\&.
 .RE
 .SH "EXAMPLES"
 .PP


### PR DESCRIPTION
If a pkgbuild is already in cache and matches the version on
the aur skip the download.

The version we check comes from the .SRCINFO file on disk which is never
updated. (updates through pkgver() edit the pkgbuild but do not effect
the .SRCINFO). Therefore if the the version of the .SRCINFO matches the
AUR's version there must not be  an update.

In the case of the on disk version being newer than the AUR version we
can assume user interaction and they probably do not want it overwitten
so in that case also skip the download.

Gonna update the docs tomorrow just making this PR now so you can get a look at it. And boy does `--gendb` sure go fast now.