### PR TITLE
Add GitBin and tweak defaults

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Configuration struct {
 	PacmanConf    string `json:"pacmanconf"`
 	TarBin        string `json:"tarbin"`
 	ReDownload    string `json:"redownload"`
+	GitBin        string `json:"gitbin"`
 	RequestSplitN int    `json:"requestsplitn"`
 	SearchMode    int    `json:"-"`
 	SortMode      int    `json:"sortmode"`
@@ -115,17 +116,18 @@ func (config *Configuration) saveConfig() error {
 }
 
 func defaultSettings(config *Configuration) {
-	config.BuildDir = fmt.Sprintf("%s/.cache/yay/", os.Getenv("HOME"))
+	config.BuildDir = cacheHome + "/"
 	config.CleanAfter = false
 	config.Editor = ""
 	config.Devel = false
-	config.MakepkgBin = "/usr/bin/makepkg"
+	config.MakepkgBin = "makepkg"
 	config.NoConfirm = false
-	config.PacmanBin = "/usr/bin/pacman"
+	config.PacmanBin = "pacman"
 	config.PacmanConf = "/etc/pacman.conf"
 	config.SortMode = BottomUp
 	config.SudoLoop = false
-	config.TarBin = "/usr/bin/bsdtar"
+	config.TarBin = "bsdtar"
+	config.GitBin = "git"
 	config.TimeUpdate = false
 	config.RequestSplitN = 150
 	config.ReDownload = "no"

--- a/vcs.go
+++ b/vcs.go
@@ -103,7 +103,7 @@ func getCommit(url string, branch string, protocols []string) string {
 	for _, protocol := range protocols {
 		var outbuf bytes.Buffer
 
-		cmd := exec.Command("git", "ls-remote", protocol+"://"+url, branch)
+		cmd := exec.Command(config.GitBin, "ls-remote", protocol+"://"+url, branch)
 		cmd.Stdout = &outbuf
 
 		err := cmd.Start()
@@ -144,7 +144,7 @@ func getCommit(url string, branch string, protocols []string) string {
 func (infos shaInfos) needsUpdate() bool {
 	for url, info := range infos {
 		hash := getCommit(url, info.Brach, info.Protocols)
-		if hash != info.SHA {
+		if hash != "" && hash != info.SHA {
 			return true
 		}
 	}


### PR DESCRIPTION
Use cacheHome for builddir instead of hardcoding ~/.cache
Use the command names in config.*Bin options.

For example PacmanBin is changed to just "pacman" this means yay will
call the pacman binary in PATH. If the user wants to use a different
binary they can still specify a full path in the config.