### PR TITLE
 Add --save option

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -38,6 +38,9 @@ New operations:
     yay {-G --getpkgbuild} [package(s)]
 
 Permanent configuration options:
+    --save               Causes the following options to be saved back to the
+                         config file when used
+
     --topdown            Shows repository's packages first and then AUR's
     --bottomup           Shows AUR's packages first and then repository's
     --devel              Check development packages during sysupgrade

--- a/cmd.go
+++ b/cmd.go
@@ -248,15 +248,6 @@ cleanup:
 	//if we fail to save the configuration
 	//at least continue on and try clean up other parts
 
-	if changedConfig {
-		err = config.saveConfig()
-
-		if err != nil {
-			fmt.Println(err)
-			status = 1
-		}
-	}
-
 	if alpmHandle != nil {
 		err = alpmHandle.Release()
 		if err != nil {
@@ -306,6 +297,10 @@ func handleCmd() (err error) {
 		}
 	}
 
+	if shouldSaveConfig {
+		config.saveConfig()
+	}
+
 	if config.SudoLoop && cmdArgs.needRoot() {
 		sudoLoopBackground()
 	}
@@ -350,6 +345,8 @@ func handleCmd() (err error) {
 //e.g yay -Yg
 func handleConfig(option string) bool {
 	switch option {
+	case "save":
+		shouldSaveConfig = true
 	case "afterclean":
 		config.CleanAfter = true
 	case "noafterclean":
@@ -378,7 +375,6 @@ func handleConfig(option string) bool {
 		return false
 	}
 
-	changedConfig = true
 	return true
 }
 

--- a/config.go
+++ b/config.go
@@ -74,8 +74,8 @@ var vcsFile string
 // completion file
 var completionFile string
 
-// changedConfig holds whether or not the config has changed
-var changedConfig bool
+// shouldSaveConfig holds whether or not the config should be saved
+var shouldSaveConfig bool
 
 // YayConf holds the current config values for yay.
 var config Configuration
@@ -100,7 +100,6 @@ func readAlpmConfig(pacmanconf string) (conf alpm.PacmanConfig, err error) {
 
 // SaveConfig writes yay config to file.
 func (config *Configuration) saveConfig() error {
-	config.NoConfirm = false
 	marshalledinfo, _ := json.MarshalIndent(config, "", "\t")
 	in, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {

--- a/yay.8
+++ b/yay.8
@@ -108,7 +108,12 @@ a database refresh\&. Run \fByay -Sy\fR Before this for an up to date result\&.
 .PP
 .SH "PERMANENT CONFIGURATION SETTINGS"
 .PP
-These options will be saved to disk and reapplied next time Yay is ran\&.
+\fB\-\-save\fR
+.RS 4
+Causes the following options to be saved back to the config file\&. This
+provides an easy way to change config options without directly editing the
+file\&.
+.RE
 .PP
 \fB\-\-topdown\fR
 .RS 4
@@ -198,6 +203,11 @@ Gets information about package \fIfoo\fR from the repos or the \fBAUR\fR\&.
 yay -S \fIfoo\fR
 .RS 4
 Installs package \fIfoo\fR from the repos or the \fBAUR\fR\&.
+.RE
+.PP
+yay --devel --save
+.RS 4
+Sets devel to true in the config\&.
 .RE
 .PP
 yay --stats


### PR DESCRIPTION
Before setting options such as --topdown would be saved to the config
file automaticly when used. Now this is no longer done by default and
isntead the --save flag must be passed for this to happen.

If --save is passed the config is now saved as soon as the argument
parsing is finished apposed to before where it was saved when yay exits.
This means that config changes will now apply if the user does a ^C
before yay finishes.