### PR TITLE
Use goroutinuies for devel updates

### DIFF
--- a/query.go
+++ b/query.go
@@ -338,21 +338,18 @@ func aurInfo(names []string) ([]rpc.Pkg, error) {
 	outOfDate := make([]string, 0, len(names))
 
 	makeRequest := func(n, max int) {
+		defer wg.Done()
 		tempInfo, requestErr := rpc.Info(names[n:max])
 		if err != nil {
-			wg.Done()
 			return
 		}
 		if requestErr != nil {
-			//return info, err
 			err = requestErr
-			wg.Done()
 			return
 		}
 		mux.Lock()
 		info = append(info, tempInfo...)
 		mux.Unlock()
-		wg.Done()
 	}
 
 	for n := 0; n < len(names); n += config.RequestSplitN {

--- a/vcs.go
+++ b/vcs.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -143,25 +142,38 @@ func getCommit(url string, branch string, protocols []string) string {
 }
 
 func (infos shaInfos) needsUpdate() bool {
-	var wg sync.WaitGroup
-	hasUpdate := false
+	//used to signal we have gone through all sources and found nothing
+	finished := make(chan struct{})
+	alive := 0
+	
+	//if we find an update we use this to exit early and return true
+	hasUpdate := make(chan struct{})
 
 	checkHash := func(url string, info shaInfo) {
-		defer wg.Done()
 		hash := getCommit(url, info.Brach, info.Protocols)
 		if hash != "" && hash != info.SHA {
-			hasUpdate = true
+			hasUpdate <- struct{}{}
+		} else {
+			finished <- struct{}{}
 		}
 	}
 
 	for url, info := range infos {
-		wg.Add(1)
+		alive++
 		go checkHash(url, info)
 	}
 
-	wg.Wait()
-
-	return hasUpdate
+	for {
+		select {
+		case <- hasUpdate:
+			return true
+		case <- finished:
+			alive--
+			if alive == 0 {
+				return false
+			}
+		}
+	}
 }
 
 func inStore(pkgName string) shaInfos {


### PR DESCRIPTION
The update process was already partly parallel: repo, aur and devel
updates where each given their own goroutine.

This gives two further layers of parallelization. Firstly the
`needsUpdate()` function is now run in parallel for each package checked.
One package may have many vcs sources so `needsUpdate()` also checks all
of its sources in parallel.

This gives an aproxamte 3x speedup for `yay -Su --devel` timing from
when the command starts to when the number menu apears.

unfortunately git://bitbucket.org/volumesoffun/polyvox.git never
resolves on my machine for some reason so it always hits the 5 second
timout period.

It then moves on to http:/bitbucket.org/volumesoffun/polyvox.git/ which
does resolve as expected. I have not looked into it but I fear this
applies to all gitbucket repos. Luckly they are few and far between.