### PR TITLE
Mention config files in the man page

### DIFF
--- a/yay.8
+++ b/yay.8
@@ -283,6 +283,13 @@ yay --stats
 .RS 4
 Shows statistics for installed packages and system health\&.
 .RE
+.SH "FILES"
+.sp
+Yay's config files are stored in \fI$XDG_CONFIG_HOME/yay/\fR\&. You should not edit these files directly,
+instead use the options described in \fBPERMANENT CONFIGURATION SETTINGS\fR\&.
+.sp
+Yay also inherits options from \fBpacman\&.conf\fR(5), e\&.g\&. \fIcolor\fR\&.
+.RE
 .SH "SEE ALSO"
 .sp
 \fBmakepkg\fR(8)


### PR DESCRIPTION
Explicitly document the location of Yay's config files in
$XDG_CONFIG_HOME/yay and mention that the color option is inherited from
pacman.conf

This may help avoid user confusion from moving the color option to pacman.conf in #113, as discussed in #224.