### PR TITLE
Fix formatting on upgrade menu

### DIFF
--- a/print.go
+++ b/print.go
@@ -118,6 +118,21 @@ func formatPkgbase(pkg *rpc.Pkg, bases map[string][]*rpc.Pkg) string {
 	return str
 }
 
+// Print prints the details of the packages to upgrade.
+func (u upSlice) Print(start int) {
+	for k, i := range u {
+		left, right := getVersionDiff(i.LocalVersion, i.RemoteVersion)
+
+		fmt.Print(magenta(fmt.Sprintf("%3d ", len(u)+start-k-1)))
+		fmt.Print(bold(colourHash(i.Repository)), "/", cyan(i.Name))
+
+		w := 70 - len(i.Repository) - len(i.Name)
+		padding := fmt.Sprintf("%%%ds", w)
+		fmt.Printf(padding, left)
+		fmt.Printf(" -> %s\n", right)
+	}
+}
+
 // printDownloadsFromRepo prints repository packages to be downloaded
 func printDepCatagories(dc *depCatagories) {
 	repo := ""

--- a/upgrade.go
+++ b/upgrade.go
@@ -80,20 +80,6 @@ func getVersionDiff(oldVersion, newversion string) (left, right string) {
 	return
 }
 
-// Print prints the details of the packages to upgrade.
-func (u upSlice) Print(start int) {
-	for k, i := range u {
-		left, right := getVersionDiff(i.LocalVersion, i.RemoteVersion)
-
-		fmt.Print(magenta(fmt.Sprintf("%2d ", len(u)+start-k-1)))
-		fmt.Print(bold(colourHash(i.Repository)), "/", cyan(i.Name))
-
-		w := 70 - len(i.Repository) - len(i.Name) + len(left)
-		fmt.Printf(fmt.Sprintf("%%%ds", w),
-			fmt.Sprintf("%s -> %s\n", left, right))
-	}
-}
-
 // upList returns lists of packages to upgrade from each source.
 func upList(dt *depTree) (aurUp upSlice, repoUp upSlice, err error) {
 	local, remote, _, remoteNames, err := filterPackages()


### PR DESCRIPTION
commit 5286f385 broke the alignment on -> in the upgrade menu.

This commit moves the function responsable for printing the upgrade menu
from upgrade.go to print.go, fixes the formating to how it was before
and changes the padding on the number to three digits instead of two.
This allows proper alignment on numbers >100 which is not unheard of.