### PR TITLE
Add support for db/name

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -574,10 +574,10 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 		}
 
 		if isInclude && include.get(target) {
-			arguments.addTarget(pkg.Name())
+			arguments.addTarget(pkg.DB().Name() + "/" + pkg.Name())
 		}
 		if !isInclude && !exclude.get(target) {
-			arguments.addTarget(pkg.Name())
+			arguments.addTarget(pkg.DB().Name() + "/" + pkg.Name())
 		}
 	}
 
@@ -588,10 +588,10 @@ func numberMenu(pkgS []string, flags []string) (err error) {
 		}
 
 		if isInclude && include.get(target) {
-			arguments.addTarget(pkg.Name)
+			arguments.addTarget("aur/" + pkg.Name)
 		}
 		if !isInclude && !exclude.get(target) {
-			arguments.addTarget(pkg.Name)
+			arguments.addTarget("aur/" + pkg.Name)
 		}
 	}
 

--- a/dependencies.go
+++ b/dependencies.go
@@ -50,6 +50,17 @@ func getNameFromDep(dep string) string {
 	})[0]
 }
 
+//split apart db/package to db and package
+func splitDbFromName(pkg string) (string, string) {
+	split := strings.SplitN(pkg, "/", 2)
+
+	if len(split) == 2 {
+		return split[0], split[1]
+	} else {
+		return "", split[0]
+	}
+}
+
 // Step two of dependency resolving. We already have all the information on the
 // packages we need, now it's just about ordering them correctly.
 // pkgs is a list of targets, the packages we want to install. Dependencies are
@@ -94,7 +105,8 @@ func getDepCatagories(pkgs []string, dt *depTree) (*depCatagories, error) {
 	}
 
 	for _, pkg := range pkgs {
-		dep := getNameFromDep(pkg)
+		_, name := splitDbFromName(pkg)
+		dep := getNameFromDep(name)
 		alpmpkg, exists := dt.Repo[dep]
 		if exists {
 			repoDepCatagoriesRecursive(alpmpkg, dc, dt, false)
@@ -258,10 +270,13 @@ func getDepTree(pkgs []string) (*depTree, error) {
 			continue
 		}//*/
 
+		db, name := splitDbFromName(pkg)
+
 		// Check the repos for a matching dep
-		repoPkg, inRepos := syncDb.FindSatisfier(pkg)
-		if inRepos == nil {
-			repoTreeRecursive(repoPkg, dt, localDb, syncDb)
+		foundPkg, errdb := syncDb.FindSatisfier(name)
+		found := errdb == nil && (foundPkg.DB().Name() == db || db == "")
+		if found {
+			repoTreeRecursive(foundPkg, dt, localDb, syncDb)
 			continue
 		}
 
@@ -270,7 +285,11 @@ func getDepTree(pkgs []string) (*depTree, error) {
 			continue
 		}
 
-		dt.ToProcess.set(pkg)
+		if db == "" || db == "aur" {
+			dt.ToProcess.set(name)
+		} else {
+			dt.Missing.set(pkg)
+		}
 	}
 
 	err = depTreeRecursive(dt, localDb, syncDb, false)

--- a/install.go
+++ b/install.go
@@ -17,16 +17,14 @@ import (
 // Install handles package installs
 func install(parser *arguments) error {
 	removeMake := false
-	aurTargets, repoTargets, err := packageSlices(parser.targets.toSlice())
+	requestTargets := parser.targets.toSlice()
+	aurTargets, repoTargets, err := packageSlices(requestTargets)
 	if err != nil {
 		return err
 	}
 
 	srcinfos := make(map[string]*gopkg.PKGBUILD)
 	var dc *depCatagories
-
-	//fmt.Println(green(arrow), green("Resolving Dependencies"))
-	requestTargets := append(aurTargets, repoTargets...)
 
 	//remotenames: names of all non repo packages on the system
 	_, _, _, remoteNames, err := filterPackages()
@@ -106,9 +104,9 @@ func install(parser *arguments) error {
 		arguments.addTarget(pkg.Name())
 	}
 
-	for _, pkg := range repoTargets {
-		arguments.addTarget(pkg)
-	}
+	//for _, pkg := range repoTargets {
+	//	arguments.addTarget(pkg)
+	//}
 
 	if len(dc.Aur) == 0 && len(arguments.targets) == 0 {
 		fmt.Println("There is nothing to do")

--- a/query.go
+++ b/query.go
@@ -228,13 +228,10 @@ func packageSlices(toCheck []string) (aur []string, repo []string, err error) {
 	}
 
 	for _, _pkg := range toCheck {
-		if i := strings.Index(_pkg, "/"); i != -1 {
-			_pkg = _pkg[i+1:]
-		}
-		pkg := getNameFromDep(_pkg)
+		db, name := splitDbFromName(_pkg)
 
-		_, errdb := dbList.FindSatisfier(_pkg)
-		found := errdb == nil
+		foundPkg, errdb := dbList.FindSatisfier(name)
+		found := errdb == nil && (foundPkg.DB().Name() == db || db == "")
 
 		if !found {
 			_, errdb = dbList.PkgCachebyGroup(_pkg)
@@ -242,9 +239,9 @@ func packageSlices(toCheck []string) (aur []string, repo []string, err error) {
 		}
 
 		if found {
-			repo = append(repo, pkg)
+			repo = append(repo, _pkg)
 		} else {
-			aur = append(aur, pkg)
+			aur = append(aur, _pkg)
 		}
 	}
 


### PR DESCRIPTION
Adds the ability to pick which database to install a package from. This
is extended to also support for AUR packages. For example `extra/git`
and `aur/yay` should both work`. When not explicitly requesting
a database repo packages will be choosen over the AUR.

This features extends to yogurt mode, listings where a package shows up
in multiple database/the AUR is now handled.

The aur does not have a real pacman databse like core, extra ect. But
can be accessed as if was one with `aur/name`. Using Yay with a pacman
repository named "aur" is undefined.

fixes #228