### PR TITLE
Add full support for reading from stdin

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -560,11 +560,21 @@ func (parser *arguments) parseCommandLine() (err error) {
 	}
 
 	if cmdArgs.existsArg("-") {
+		var file *os.File
 		err = cmdArgs.parseStdin()
+		cmdArgs.delArg("-")
 
 		if err != nil {
 			return
 		}
+
+		file, err = os.Open("/dev/tty")
+
+		if err != nil {
+			return
+		}
+
+		os.Stdin = file
 	}
 
 	return


### PR DESCRIPTION
Previosuly when reading from stdin we did not redirect back to the real
stdin afterwards so it was imposible to interact with y/n questions.

Now redirect back to "/dev/tty" just like pacman does.