### PR TITLE
Ensure targets are never listed as make depends

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -131,6 +131,10 @@ func getDepCatagories(pkgs []string, dt *depTree) (*depCatagories, error) {
 		})
 	}
 
+	for _, pkg := range pkgs {
+		dc.MakeOnly.remove(pkg)
+	}
+
 	dupes := make(map[*alpm.Package]struct{})
 	filteredRepo := make([]*alpm.Package, 0)
 


### PR DESCRIPTION
when doing `yay -S foo bar` where `bar` is a makedep of `foo` in rare
cases bar would be listed as [aur make] even thought it was explicitly
requested.