### PR TITLE
 Add --rebuild flag

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -397,6 +397,14 @@ func handleConfig(option, value string) bool {
 		config.ReDownload = "all"
 	case "noredownload":
 		config.ReDownload = "no"
+	case "rebuild":
+		config.ReBuild = "yes"
+	case "rebuildall":
+		config.ReBuild = "all"
+	case "rebuildtree":
+		config.ReBuild = "tree"
+	case "norebuild":
+		config.ReBuild = "no"
 	case "mflags":
 		config.MFlags = value
 	case "builddir":

--- a/cmd.go
+++ b/cmd.go
@@ -61,6 +61,10 @@ Permanent configuration options:
     --redownload         Always download pkgbuilds of targets
     --redownloadall      Always download pkgbuilds of all AUR packages
     --noredownload       Skip pkgbuild download if in cache and up to date
+    --rebuild            Always build target packages
+    --rebuildall         Always build all AUR packages
+    --rebuildtree       Always build all AUR packages even if installed
+    --norebuild          Skip package build if in cache and up to date
     --mflags <flags>     Pass arguments to makepkg
     --sudoloop           Loop sudo calls in the background to avoid timeout
     --nosudoloop         Do not loop sudo calls in the background

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Configuration struct {
 	PacmanConf    string `json:"pacmanconf"`
 	TarBin        string `json:"tarbin"`
 	ReDownload    string `json:"redownload"`
+	ReBuild       string `json:"rebuild"`
 	GitBin        string `json:"gitbin"`
 	GpgBin        string `json:"gpgbin"`
 	MFlags        string `json:"mflags"`
@@ -135,6 +136,7 @@ func defaultSettings(config *Configuration) {
 	config.TimeUpdate = false
 	config.RequestSplitN = 150
 	config.ReDownload = "no"
+	config.ReBuild = "no"
 }
 
 // Editor returns the preferred system editor.

--- a/dependencies.go
+++ b/dependencies.go
@@ -412,13 +412,17 @@ func depTreeRecursive(dt *depTree, localDb *alpm.Db, syncDb alpm.DbList, isMake 
 
 				// Check if already installed.
 				_, isInstalled := localDb.PkgCache().FindSatisfier(versionedDep)
-				if isInstalled == nil {
+				if isInstalled == nil && config.ReBuild != "tree" {
 					continue
 				}
 
 				// Check the repos for a matching dep.
 				repoPkg, inRepos := syncDb.FindSatisfier(versionedDep)
 				if inRepos == nil {
+					if isInstalled == nil && config.ReBuild == "tree" {
+						continue
+					}
+
 					repoTreeRecursive(repoPkg, dt, localDb, syncDb)
 					continue
 				}

--- a/install.go
+++ b/install.go
@@ -622,15 +622,19 @@ func buildInstallPkgBuilds(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD,
 		srcinfo := srcinfos[pkg.PackageBase]
 		version := srcinfo.CompleteVersion()
 
-		for _, split := range bases[pkg.PackageBase] {
-			file, err := completeFileName(dir, split.Name+"-"+version.String())
-			if err != nil {
-				return err
-			}
+		if config.ReBuild == "no" || (config.ReBuild == "yes" && !targets.get(pkg.Name)) {
+			for _, split := range bases[pkg.PackageBase] {
+				file, err := completeFileName(dir, split.Name+"-"+version.String())
+				if err != nil {
+					return err
+				}
 
-			if file == "" {
-				built = false
+				if file == "" {
+					built = false
+				}
 			}
+		} else {
+			built = false
 		}
 
 		if built {

--- a/yay.8
+++ b/yay.8
@@ -224,6 +224,31 @@ When downloading pkgbuilds if the pkgbuild is found in cache and is equal or
 newer than the AUR's version use that instead of downloading a new one\&.
 .RE
 .PP
+\fB\-\-rebuild\fR
+.RS 4
+Always build target packages even when a copy is available in cache\&.
+.RE
+.PP
+\fB\-\-rebuildall\fR
+.RS 4
+Always build all AUR packages even when a copy is available
+in cache\&.
+.RE
+.PP
+\fB\-\-rebuildtree\fR
+.RS 4
+When installing an AUR package rebuild and reinstall all of its AUR
+dependencies recursivley, even the ones already installed. This flag allows
+you to easily rebuild packages against your current system's libraries if they
+have become incompatible.
+.RE
+.PP
+\fB\-\-norebuild\fR
+.RS 4
+When building packages if the package is found in cache and is an equal version
+to the one wanted skip the package build and use the existing package\&.
+.RE
+.PP
 \fB\-\-mflags <flags>\fR
 .RS 4
 Passes arguments to makepkg\&. These flags get passed to every instance where


### PR DESCRIPTION
Similar to the --redownload flag, when specifed targets will be rebuilt
even if an up to date version is cached. --rebuildall can be used to
ensure uninstalled dependencies are rebuilt as well.

Additionally, unlike --redownload there is also --rebuildtree. This
causes a rebuild and reinstall of a package and all of it's dependencies
recursivley. This is designed for when a libary updae, breaks an
installed AUR package due to a partial upgrade. polybar is a common
example

--rebuild allows you to easily skip the cache and rebuild against a newer
libary version. --rebuildtree is a more nuclear option where you can
rebuild the whole dependency tree.

This is my purposed fix for #87 It does not really do what the issue asks because that would be a project in itself. These flags should provide an easier way to mange such things manually though.