### PR TITLE
 Check versioned deps during the dep fetching process

### DIFF
--- a/install.go
+++ b/install.go
@@ -55,8 +55,13 @@ func install(parser *arguments) error {
 	//only error if direct targets or deps are missing
 	for missingName := range dt.Missing {
 		if !remoteNamesCache.get(missingName) {
-			return fmt.Errorf(bold(red(arrow+" Error: ")) +
-				"Could not find all required package")
+			str := bold(red(arrow+" Error: ")) + "Could not find all required packages:"
+
+			for name := range dt.Missing {
+				str += "\n\t" + name
+			}
+
+			return fmt.Errorf("%s", str)
 		}
 	}
 


### PR DESCRIPTION
Check versioned deps such as `foo>1` `foo=2` `foo<3`

depends on mikkeloscar/aur#3 and mikkeloscar/gopkgbuild#19

The latter being a pretty big addition so I wouldn't be surprised if it went through some changes that required this pr to change

Tested against `haskell-filestore` because it was the only package I could find with invalid version deps. If you know of any others I would like to know. Pacaur also supports this feature so you can use that to test against.