### PR TITLE
Use a question callback for ignorepkg

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	alpm "github.com/jguer/go-alpm"
+)
+
+func QuestionCallback(question alpm.QuestionAny) {
+	q, err := question.QuestionInstallIgnorepkg()
+	if err == nil {
+		q.SetInstall(true)
+	}
+}

--- a/cmd.go
+++ b/cmd.go
@@ -223,6 +223,8 @@ func initAlpm() (err error) {
 		return
 	}
 
+	alpmHandle.SetQuestionCallback(QuestionCallback)
+
 	return
 }
 

--- a/install.go
+++ b/install.go
@@ -184,7 +184,7 @@ func install(parser *arguments) error {
 
 		//conflicts have been checked so answer y for them
 		ask, _ := strconv.Atoi(cmdArgs.globals["ask"])
-		uask := alpm.Question(ask) | alpm.QuestionConflictPkg
+		uask := alpm.QuestionType(ask) | alpm.QuestionTypeConflictPkg
 		cmdArgs.globals["ask"] = fmt.Sprint(uask)
 
 		//this downloads the package build sources but also causes


### PR DESCRIPTION
The callback is set to allways silently say yes, When passing to pacman
for the intall pacman will then ask the question giving the user
a chance to answer.

Fixes #245 
Relies on Jguer/go-alpm#8 (infact merging that pr without this will break the build so they really should be merged as close together as possible)