### PR TITLE
Fix updating of vsc packages

### DIFF
--- a/install.go
+++ b/install.go
@@ -209,17 +209,17 @@ func install(parser *arguments) error {
 			return nil
 		}
 
-		err = parsesrcinfosGenerate(dc.Aur, srcinfos, dc.Bases)
-		if err != nil {
-			return err
-		}
-
-		err = checkPgpKeys(dc.Aur, srcinfos, dc.Bases, nil)
+		err = checkPgpKeys(dc.Aur, dc.Bases, nil)
 		if err != nil {
 			return err
 		}
 
 		err = downloadPkgBuildsSources(dc.Aur, dc.Bases)
+		if err != nil {
+			return err
+		}
+
+		err = parsesrcinfosGenerate(dc.Aur, srcinfos, dc.Bases)
 		if err != nil {
 			return err
 		}

--- a/keys.go
+++ b/keys.go
@@ -43,7 +43,7 @@ func (set pgpKeySet) get(key string) bool {
 // asks the user whether yay should try to import them. gpgExtraArgs are extra
 // parameters to pass to gpg, in order to facilitate testing, such as using a
 // different keyring. It can be nil.
-func checkPgpKeys(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, bases map[string][]*rpc.Pkg, gpgExtraArgs []string) error {
+func checkPgpKeys(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg, gpgExtraArgs []string) error {
 	// Let's check the keys individually, and then we can offer to import
 	// the problematic ones.
 	problematic := make(pgpKeySet)
@@ -51,7 +51,13 @@ func checkPgpKeys(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, bases ma
 
 	// Mapping all the keys.
 	for _, pkg := range pkgs {
-		for _, key := range srcinfos[pkg.PackageBase].Validpgpkeys {
+		dir := config.BuildDir + pkg.PackageBase + "/"
+		pkgbuild, err := gopkg.ParseSRCINFO(dir + ".SRCINFO")
+		if err != nil {
+			return fmt.Errorf("%s: %s", pkg.Name, err)
+		}
+
+		for _, key := range pkgbuild.Validpgpkeys {
 			// If key already marked as problematic, indicate the current
 			// PKGBUILD requires it.
 			if problematic.get(key) {


### PR DESCRIPTION
With the addition of pgp key checking in Yay, the srcinfo parsing was
moved to before the pkgver() bump, leading to outdated pkgbuild
information.

Srcinfo parsing must be done after the pkgver() bump
The pkgver() bump must be done after downloading sources
makepkg's PGP checking is done as the sources download
yays PGP importing requires the srcingo to be parsed

Quite the chicken and egg problem

It is possible to skip the integ checks after the sources download
then parse the srcinfo
do the yay PGP check
then run the integ checks

the problem here is that to generate the srcinfo `makepkg --printsrcingo` is ran
This causes the pkgbuild to be sourced which I am not comftable with
doing without the integ checks.

Instead we parse the on disk .SRRCINFO that downloads with the PKGBUILD
just for the PGP checking. Later on we parse a fresh srcinfo straight
from `makepkg --printsrcingo`. This is a little bit less efficient but
more secure than the other option.