### PR TITLE
Fix and improve version checking

### DIFF
--- a/install.go
+++ b/install.go
@@ -54,7 +54,7 @@ func install(parser *arguments) error {
 
 	//only error if direct targets or deps are missing
 	for missingName := range dt.Missing {
-		if !remoteNamesCache.get(missingName) {
+		if !remoteNamesCache.get(missingName) || parser.targets.get(missingName) {
 			str := bold(red(arrow+" Error: ")) + "Could not find all required packages:"
 
 			for name := range dt.Missing {


### PR DESCRIPTION
Fix typo where adding to has instead of depStrings

Error correcly when missing packages

Also handle cases where a package is provided multiple times. If one
package provies `foo=1` and another provides `foo=2` before the latter
would just overide the former version. Now both versions will be checked
against.