### PR TITLE
Extend aur support for -Qu

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -342,19 +342,19 @@ func handleCmd() (err error) {
 	case "V", "version":
 		handleVersion()
 	case "D", "database":
-		passToPacman(cmdArgs)
+		err = passToPacman(cmdArgs)
 	case "F", "files":
-		passToPacman(cmdArgs)
+		err = passToPacman(cmdArgs)
 	case "Q", "query":
-		passToPacman(cmdArgs)
+		err = handleQuery()
 	case "R", "remove":
-		handleRemove()
+		err = handleRemove()
 	case "S", "sync":
 		err = handleSync()
 	case "T", "deptest":
-		passToPacman(cmdArgs)
+		err = passToPacman(cmdArgs)
 	case "U", "upgrade":
-		passToPacman(cmdArgs)
+		err =passToPacman(cmdArgs)
 	case "G", "getpkgbuild":
 		err = handleGetpkgbuild()
 	case "P", "print":
@@ -368,6 +368,18 @@ func handleCmd() (err error) {
 	}
 
 	return
+}
+
+func handleQuery() error {
+	var err error
+
+	if cmdArgs.existsArg("u", "upgrades") {
+		err = printUpdateList(cmdArgs)
+	} else {
+		err = passToPacman(cmdArgs)
+	}
+
+	return err
 }
 
 //this function should only set config options
@@ -461,7 +473,7 @@ func handlePrint() (err error) {
 	case cmdArgs.existsArg("n", "numberupgrades"):
 		err = printNumberOfUpdates()
 	case cmdArgs.existsArg("u", "upgrades"):
-		err = printUpdateList()
+		err = printUpdateList(cmdArgs)
 	case cmdArgs.existsArg("c", "complete"):
 		switch {
 		case cmdArgs.existsArg("f", "fish"):

--- a/print.go
+++ b/print.go
@@ -301,7 +301,7 @@ func printNumberOfUpdates() error {
 }
 
 //TODO: Make it less hacky
-func printUpdateList() error {
+func printUpdateList(parser *arguments) error {
 	old := os.Stdout // Keep backup of the real stdout
 	os.Stdout = nil
 	_, _, localNames, remoteNames, err := filterPackages()
@@ -312,12 +312,29 @@ func printUpdateList() error {
 	if err != nil {
 		return err
 	}
-	for _, pkg := range repoUp {
-		fmt.Println(pkg.Name)
+
+	noTargets := len(parser.targets) == 0
+
+	if !parser.existsArg("m", "foreigne") {
+		for _, pkg := range repoUp {
+			if noTargets || parser.targets.get(pkg.Name) {
+				fmt.Printf("%s %s -> %s\n", bold(pkg.Name), green(pkg.LocalVersion), green(pkg.RemoteVersion))
+				delete(parser.targets, pkg.Name)
+			}
+		}
 	}
 
-	for _, pkg := range aurUp {
-		fmt.Println(pkg.Name)
+	if !parser.existsArg("n", "native") {
+		for _, pkg := range aurUp {
+			if noTargets || parser.targets.get(pkg.Name) {
+				fmt.Printf("%s %s -> %s\n", bold(pkg.Name), green(pkg.LocalVersion), green(pkg.RemoteVersion))
+				delete(parser.targets, pkg.Name)
+			}
+		}
+	}
+
+	for pkg := range parser.targets {
+		fmt.Println(red(bold("error:")), "package '" + pkg + "' was not found")
 	}
 
 	return nil


### PR DESCRIPTION
-Qu now has AUR support, it functions identically to `-Pu` and may replace
it in the futre.

Aditionally the pacman options `-n` and `-m` are also supported to
filter out native and non native packages. Other flags are not supported
currently.

Using any other `-Q` will fallback to Pacman.