### PR TITLE
Respect --color

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	alpm "github.com/jguer/go-alpm"
 )
 
 var cmdArgs = makeArguments()
@@ -222,6 +224,15 @@ func initAlpm() (err error) {
 	if err != nil {
 		err = fmt.Errorf("Unable to CreateHandle: %s", err)
 		return
+	}
+
+	value, _, exists = cmdArgs.getArg("color")
+	if value == "always" || value == "auto" {
+		useColor = true
+	} else if value == "never" {
+		useColor = false
+	} else {
+		useColor = alpmConf.Options&alpm.ConfColor > 0
 	}
 
 	alpmHandle.SetQuestionCallback(questionCallback)

--- a/config.go
+++ b/config.go
@@ -61,6 +61,9 @@ const completionFilePrefix string = "aur_"
 // baseURL givers the AUR default address.
 const baseURL string = "https://aur.archlinux.org"
 
+// useColor enables/disables colored printing
+var useColor bool
+
 // configHome handles config directory home
 var configHome string
 

--- a/print.go
+++ b/print.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	alpm "github.com/jguer/go-alpm"
 	rpc "github.com/mikkeloscar/aur"
 )
 
@@ -347,7 +346,7 @@ func formatTime(i int) string {
 }
 
 func red(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
+	if useColor {
 		return "\x1b[31m" + in + "\x1b[0m"
 	}
 
@@ -355,7 +354,7 @@ func red(in string) string {
 }
 
 func green(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
+	if useColor {
 		return "\x1b[32m" + in + "\x1b[0m"
 	}
 
@@ -363,7 +362,7 @@ func green(in string) string {
 }
 
 func yellow(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
+	if useColor {
 		return "\x1b[33m" + in + "\x1b[0m"
 	}
 
@@ -371,7 +370,7 @@ func yellow(in string) string {
 }
 
 func blue(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
+	if useColor {
 		return "\x1b[34m" + in + "\x1b[0m"
 	}
 
@@ -379,7 +378,7 @@ func blue(in string) string {
 }
 
 func cyan(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
+	if useColor {
 		return "\x1b[36m" + in + "\x1b[0m"
 	}
 
@@ -387,7 +386,7 @@ func cyan(in string) string {
 }
 
 func magenta(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
+	if useColor {
 		return "\x1b[35m" + in + "\x1b[0m"
 	}
 
@@ -395,7 +394,7 @@ func magenta(in string) string {
 }
 
 func bold(in string) string {
-	if alpmConf.Options&alpm.ConfColor > 0 {
+	if useColor {
 		return "\x1b[1m" + in + "\x1b[0m"
 	}
 
@@ -405,7 +404,7 @@ func bold(in string) string {
 // Colours text using a hashing algorithm. The same text will always produce the
 // same colour while different text will produce a different colour.
 func colourHash(name string) (output string) {
-	if alpmConf.Options&alpm.ConfColor == 0 {
+	if !useColor {
 		return name
 	}
 	var hash = 5381


### PR DESCRIPTION
`--color auto` is the same as `--color always` until a suitable method
for auto has been decided.