### PR TITLE
Add missing err check

### DIFF
--- a/conflicts.go
+++ b/conflicts.go
@@ -314,6 +314,11 @@ func checkForAllConflicts(dc *depCatagories) error {
 	}()
 
 	wg.Wait()
+
+	if err != nil {
+		return err
+	}
+
 	if len(innerConflicts) != 0 {
 		fmt.Println(
 			red("\nInner conflicts found:"))


### PR DESCRIPTION
Weirdly enough the way I found this was by messing around with gcc-go. It threw this error on me:
```
./conflicts.go:298:6: error: ‘err’ declared and not used
./conflicts.go:298:6: error: ‘err’ declared and not used
  var err error
      ^
```
I think the standard go compiler should have caught this. Compiler bug?

Also while testing:
 - gccgpo creates a yay binary of size 1.5MB (probably because it links dynamically to alpm.so)
 - go creates a yay binary of size 4.7MB
 - gccgo has an install size of 149MB and download size of 22MB
 - gccgo has an install size of 330MB and download size of 67MB

Just thought that was intresting.