### PR TITLE
Suppress pacman error printing

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -465,7 +465,11 @@ func passToPacman(args *arguments) error {
 
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	err := cmd.Run()
-	return err
+
+	if err != nil {
+		return fmt.Errorf("")
+	}
+	return nil
 }
 
 //passToPacman but return the output instead of showing the user

--- a/main.go
+++ b/main.go
@@ -203,7 +203,10 @@ func main() {
 
 	err = handleCmd()
 	if err != nil {
-		fmt.Println(err)
+		if err.Error() != "" {
+			fmt.Println(err)
+		}
+
 		status = 1
 		goto cleanup
 	}

--- a/print.go
+++ b/print.go
@@ -333,8 +333,28 @@ func printUpdateList(parser *arguments) error {
 		}
 	}
 
+	missing := false
+
+outer:
 	for pkg := range parser.targets {
+		for _, name := range localNames {
+			if name == pkg {
+				continue outer
+			}
+		}
+
+		for _, name := range remoteNames {
+			if name == pkg {
+				continue outer
+			}
+		}
+
 		fmt.Println(red(bold("error:")), "package '"+pkg+"' was not found")
+		missing = true
+	}
+
+	if missing {
+		return fmt.Errorf("")
 	}
 
 	return nil


### PR DESCRIPTION
add22f59577ce2314fb9655dd0f2e4db9d61e8f1 added error checks to all the
passToPacman commands. This makes `yay -Q nonexistantpackage` return
non 0 as it should. Annoyingly it also made yay print `exit status = n`
which is the error string from passToPacman calls. This error doesn't
add much and is quite annoying, expecially when calling pacman commands
like `-Q` or `-Si` where yay should be kind of 'hidden' and print just
like pacman does.

Now set the error string to "" for pacman commands and don't print an
error if it == "" (avoids empty line printed).

Also behave more like pacman when using `yay -Qu`.