### PR TITLE
Use git clone for pkgbuild downloading

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -253,10 +253,16 @@ func handleConfig(option, value string) bool {
 		config.AnswerUpgrade = value
 	case "noanswerupgrade":
 		config.AnswerUpgrade = ""
+	case "gitclone":
+		config.GitClone = true
+	case "nogitclone":
+		config.GitClone = false
 	case "gpgflags":
 		config.GpgFlags = value
 	case "mflags":
 		config.MFlags = value
+	case "gitflags":
+		config.GitFlags = value
 	case "builddir":
 		config.BuildDir = value
 	case "editor":

--- a/cmd.go
+++ b/cmd.go
@@ -563,3 +563,15 @@ func passToMakepkg(dir string, args ...string) (err error) {
 	}
 	return
 }
+
+func passToGit(dir string, _args ...string) (err error) {
+	gitflags := strings.Fields(config.GitFlags)
+	args := []string{"-C", dir}
+	args = append(args, gitflags...)
+	args = append(args, _args...)
+
+	cmd := exec.Command(config.GitBin, args...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	err = cmd.Run()
+	return
+}

--- a/config.go
+++ b/config.go
@@ -42,6 +42,7 @@ type Configuration struct {
 	GpgFlags      string `json:"gpgflags"`
 	MFlags        string `json:"mflags"`
 	SortBy        string `json:"sortby"`
+	GitFlags      string `json:"gitflags"`
 	RequestSplitN int    `json:"requestsplitn"`
 	SearchMode    int    `json:"-"`
 	SortMode      int    `json:"sortmode"`
@@ -50,6 +51,7 @@ type Configuration struct {
 	NoConfirm     bool   `json:"-"`
 	Devel         bool   `json:"devel"`
 	CleanAfter    bool   `json:"cleanAfter"`
+	GitClone      bool   `json:"gitclone"`
 }
 
 var version = "3.373"
@@ -138,6 +140,7 @@ func defaultSettings(config *Configuration) {
 	config.PacmanConf = "/etc/pacman.conf"
 	config.GpgFlags = ""
 	config.MFlags = ""
+	config.GitFlags = ""
 	config.SortMode = BottomUp
 	config.SortBy = "votes"
 	config.SudoLoop = false
@@ -151,6 +154,7 @@ func defaultSettings(config *Configuration) {
 	config.AnswerClean = ""
 	config.AnswerEdit = ""
 	config.AnswerUpgrade = ""
+	config.GitClone = true
 }
 
 // Editor returns the preferred system editor.

--- a/download.go
+++ b/download.go
@@ -6,8 +6,27 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
+
+// Decide what download method to use:
+// Use the config option when the destination does not already exits
+// If .git exists in the destination uer git
+// Otherwise use a tarrball
+func shouldUseGit(path string) bool {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return config.GitClone
+	}
+
+	_, err = os.Stat(filepath.Join(path, ".git"))
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
 
 func downloadFile(path string, url string) (err error) {
 	// Create the file
@@ -27,6 +46,37 @@ func downloadFile(path string, url string) (err error) {
 	// Writer the body to file
 	_, err = io.Copy(out, resp.Body)
 	return err
+}
+
+func gitDownload(url string, path string, name string) error {
+	_, err := os.Stat(filepath.Join(path, name, ".git"))
+	if os.IsNotExist(err) {
+		err = passToGit(path, "clone", url, name)
+		if err != nil {
+			return fmt.Errorf("error cloning %s", name)
+		}
+
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("error reading %s", filepath.Join(path, name, ".git"))
+	}
+
+	err = passToGit(filepath.Join(path, name), "fetch")
+	if err != nil {
+		return fmt.Errorf("error fetching %s", name)
+	}
+
+	err = passToGit(filepath.Join(path, name), "reset", "--hard", "HEAD")
+	if err != nil {
+		return fmt.Errorf("error reseting %s", name)
+	}
+
+	err = passToGit(filepath.Join(path, name), "merge", "--no-edit", "--ff")
+	if err != nil {
+		return fmt.Errorf("error merging %s", name)
+	}
+
+	return nil
 }
 
 // DownloadAndUnpack downloads url tgz and extracts to path.
@@ -129,8 +179,18 @@ func getPkgbuildsfromAUR(pkgs []string, dir string) (err error) {
 	}
 
 	for _, pkg := range aq {
-		downloadAndUnpack(baseURL+aq[0].URLPath, dir, false)
-		fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(magenta(pkg.Name)), bold(green("from AUR")))
+		var err error
+		if shouldUseGit(filepath.Join(dir, pkg.PackageBase)) {
+			err = gitDownload(baseURL+"/"+pkg.PackageBase+".git", dir, pkg.PackageBase)
+		} else {
+			err = downloadAndUnpack(baseURL+aq[0].URLPath, dir, false)
+		}
+
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(bold(green(arrow)), bold(green("Downloaded")), bold(magenta(pkg.Name)), bold(green("from AUR")))
+		}
 	}
 
 	return

--- a/install.go
+++ b/install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -556,7 +557,12 @@ func downloadPkgBuilds(pkgs []*rpc.Pkg, targets stringSet, bases map[string][]*r
 
 		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
 
-		err := downloadAndUnpack(baseURL+pkg.URLPath, config.BuildDir, false)
+		var err error
+		if shouldUseGit(filepath.Join(config.BuildDir, pkg.PackageBase)) {
+			err = gitDownload(baseURL+"/"+pkg.PackageBase+".git", config.BuildDir, pkg.PackageBase)
+		} else {
+			err = downloadAndUnpack(baseURL+pkg.URLPath, config.BuildDir, false)
+		}
 		if err != nil {
 			return err
 		}

--- a/parser.go
+++ b/parser.go
@@ -429,6 +429,8 @@ func hasParam(arg string) bool {
 		return true
 	case "gpgflags":
 		return true
+	case "gitflags":
+		return true
 	case "builddir":
 		return true
 	case "editor":


### PR DESCRIPTION
## Use git clone for pkgbuild downloading

This is a restart of #130 given that PR has not gone anywhere and @simon04 has still not answered any of my questions related to the PR such as:

>Also how does this handle migrating. If i have a package that I installed using the tarball method then switch to the git method will it handle it correctly?

I decided it was better to start over. This PR also uses some of the code from #130.

This PR in its current state is mainly for discussion on how to implement things. Currently all this PR does is replace the download method during `yay -S` to use `git`. This allows easy benchmarks, just checkout between the two versions and test for yourself.

## Testing
My testing was done against `ros-lunar-desktop-full` which on my machine wants to download 251 Aur packages.

Time taken to download all the packages assuming none exist in cache:
- Current tarball method: `3:26`
- git clone method: `1:43`

If all packages in cache and up to date then Yay will not try to redownload them but if using `--redownloadall` then the results are as follows:
- Current tarball method: `3:26` (The same download is done, the time does not change)
- git clone Method: `1:10` (it only needs to pull instead of clone)

This shows git to actually be faster than the tarball downloads.

## Features

The features I plan to implement before merging are:
- [x] Config setting for clone/tarball
- [x] Use git clone in -G for AUR
~~Use git clone in -G for ABS~~
- [x] Handle cached packages that come from tarball or git clone no matter the current config

Ideas that may be implemented:
 - [ ] `@` versioning: When installing AUR packages. For example `yay -S yay@1e01eaf` would build the package from that revision of the PKGBUILD.
 - [ ] `<>=` versioning: Pacman already supports using these during `-S` to ensure the package you want fits in the range you specify. What I purpose is slightly different. Yay will find the first latest commit that matches the version you specify. So `yay -S yay<4` will install the first PKGBUILD with a pkgver of less than 4.

## Discussion

This PR is mostly here for discussion on how to implement certain features.
### Migrating between tarball and git
My current idea of this is to only respect the config option if the cache does not already exist. If it does exist check for the .git directory. If that exists use the git method no matter the config. If it does not use tarball no matter the config.

### Updating the cache
When we have a cached package and the PKGBUILD updated how should we go about pulling changes? The tarball method is simple and just unpacks the tar into whats already there. Overwriting files that exist in the tar and in cache but leaving untracked files alone.

Doing a simple git pull could cause complications  if there are any user made changes. Currently this PR resets to head then pulls which will undo any user made changes. #130 uses a similar method where they fetch then reset to upsteam master. I do not know id there are any real differences between the two.

Alternatively we could just do a pull by itself. If there are merge conflicts it would be the user's job to resolve them.

### Pacman wrap
using `<>=` behaviour different to Pacman might be frowned upon.
maybe combine it with `@`
`yay -S yay@7655bd9`
`yay -S yay@=3.505`
`yay -S yay@<4`

### Optimisation
This implementation is very basic, there's a couple of possible tricks that could be done to speed things up or reduce disk space but I have not tested them.

`git gc` Should probably be run after every pull.

`--singlebranch` could be used to only clone master, although most AUR packages probably only have master, I am unsure if the AUR would even allow you to push a different branch.

`--depth 1` Is an obvious one but would not allow the user to then checkout specific commits if they wished to. Also possible features such as `@` and `<>=` versioning would not work with this. It might be possible to run `--depth 1` then run `--unshallow` when needed.