### PR TITLE
Only pass needed upgrades to deptree

### DIFF
--- a/print.go
+++ b/print.go
@@ -288,9 +288,7 @@ func printNumberOfUpdates() error {
 	//todo
 	old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
-	_, _, localNames, remoteNames, err := filterPackages()
-	dt, _ := getDepTree(append(localNames, remoteNames...))
-	aurUp, repoUp, err := upList(dt)
+	aurUp, repoUp, err := upList()
 	os.Stdout = old // restoring the real stdout
 	if err != nil {
 		return err
@@ -302,13 +300,11 @@ func printNumberOfUpdates() error {
 
 //TODO: Make it less hacky
 func printUpdateList(parser *arguments) error {
-	old := os.Stdout // Keep backup of the real stdout
+	old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
 	_, _, localNames, remoteNames, err := filterPackages()
-	dt, _ := getDepTree(append(localNames, remoteNames...))
-	aurUp, repoUp, err := upList(dt)
-
-	os.Stdout = old // Restoring the real stdout
+	aurUp, repoUp, err := upList()
+	os.Stdout = old // restoring the real stdout
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To know what AUR packages need updating a rpc request is needed for all
packages. The dep tree is designed to cache everything to minimize the
amount of rpc requests. The downside of this is the dep tree ends up
with all sorts of packages in cache that it doesn't need. Then the
deptree tries to resolve deps for all of thoes packages.

By spliting the sysupgrade from the dep tree this stops this from
happening, it uses one more rpc request but also may lower the amount of
total rpc requests needed lated on.

This causes a couple of tiny bugs such as triggering providers prompts
and printing AUR out of date messages for packages that are not going
to be installed.

This also fixes another display bug where repo packages from -u would
not apear when printing the packages to be installed.

fixes #287