### PR TITLE
Try each search term against RPC if one fails

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -362,7 +362,7 @@ func handleRemove() (err error) {
 func numberMenu(pkgS []string, flags []string) (err error) {
 	aurQ, err := narrowSearch(pkgS, true)
 	if err != nil {
-		fmt.Println("Error during AUR search:", err)
+		return fmt.Errorf("Error during AUR search: %s", err)
 	}
 	numaq := len(aurQ)
 	repoQ, numpq, err := queryRepo(pkgS)

--- a/query.go
+++ b/query.go
@@ -72,11 +72,22 @@ func filterPackages() (local []alpm.Package, remote []alpm.Package,
 
 // NarrowSearch searches AUR and narrows based on subarguments
 func narrowSearch(pkgS []string, sortS bool) (aurQuery, error) {
+	var r []rpc.Pkg
+	var err error
+	var usedIndex int
+
 	if len(pkgS) == 0 {
 		return nil, nil
 	}
 
-	r, err := rpc.Search(pkgS[0])
+	for i, word := range pkgS {
+		r, err = rpc.Search(word)
+		if err == nil {
+			usedIndex = i
+			break
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +104,11 @@ func narrowSearch(pkgS []string, sortS bool) (aurQuery, error) {
 
 	for _, res := range r {
 		match := true
-		for _, pkgN := range pkgS[1:] {
+		for i, pkgN := range pkgS {
+			if usedIndex == i {
+				continue
+			}
+
 			if !(strings.Contains(res.Name, pkgN) || strings.Contains(strings.ToLower(res.Description), pkgN)) {
 				match = false
 				break


### PR DESCRIPTION
Allows searching the RPC for words that may be too short or have
too many results as long as another word in the search will work.

If no words can be used without error then the last error will be
returned and the program will exit.

fixes #314 