### PR TITLE
Skip SRCINFOs that cannot be parsed during gendb

### DIFF
--- a/install.go
+++ b/install.go
@@ -72,7 +72,6 @@ func install(parser *arguments) error {
 		parser.targets.set(name)
 	}
 
-
 	requestTargets = parser.targets.toSlice()
 
 	if len(dt.Missing) > 0 {
@@ -491,6 +490,23 @@ func parseSRCINFOFiles(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, bas
 	}
 
 	return nil
+}
+
+func tryParsesrcinfosFile(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, bases map[string][]*rpc.Pkg) {
+	for k, pkg := range pkgs {
+		dir := config.BuildDir + pkg.PackageBase + "/"
+
+		str := bold(cyan("::") + " Parsing SRCINFO (%d/%d): %s\n")
+		fmt.Printf(str, k+1, len(pkgs), formatPkgbase(pkg, bases))
+
+		pkgbuild, err := gopkg.ParseSRCINFO(dir + ".SRCINFO")
+		if err != nil {
+			fmt.Printf("cannot parse %s skipping: %s\n", pkg.Name, err)
+			continue
+		}
+
+		srcinfos[pkg.PackageBase] = pkgbuild
+	}
 }
 
 func parseSRCINFOGenerate(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, bases map[string][]*rpc.Pkg) error {

--- a/vcs.go
+++ b/vcs.go
@@ -44,10 +44,13 @@ func createDevelDB() error {
 	bases := getBases(infoMap)
 
 	downloadPkgBuilds(info, sliceToStringSet(remoteNames), bases)
-	err = parseSRCINFOFiles(info, srcinfosStale, bases)
+	tryParsesrcinfosFile(info, srcinfosStale, bases)
 
 	for _, pkg := range info {
-		pkgbuild := srcinfosStale[pkg.PackageBase]
+		pkgbuild, ok := srcinfosStale[pkg.PackageBase]
+		if !ok {
+			continue
+		}
 
 		for _, pkg := range bases[pkg.PackageBase] {
 			updateVCSData(pkg.Name, pkgbuild.Source)


### PR DESCRIPTION
Install will still abort if a SRCINFO cannot be parsed.

fixes #310 