### PR TITLE
Fix versioned dep checking

### DIFF
--- a/install.go
+++ b/install.go
@@ -72,7 +72,6 @@ func install(parser *arguments) error {
 		parser.targets.set(name)
 	}
 
-
 	requestTargets = parser.targets.toSlice()
 
 	if len(dt.Missing) > 0 {


### PR DESCRIPTION
Before versioned deps with the same name would be combined into a single
version range.

For example:
`foo>1 foo>3 foo<4 foo<5` would be merged into the range `3<foo<4`

This was assumed to be fine because of course no package is going to
have conflicting dependencies `foo>3 foo<1` but what was not thought
about it that a package or packages could provide multiple versions of
a provider. Java being example, you could have 8 and 9 provided for at
the same time.

This then causes a problem when you try to install two packages at once,
one requiring `java<8` and the other `java>9` when combined this leads
to a range that can not be satisfied.

Instead we now never merge dependencies but check them all individually.

We also make sure to pull in all already installed providers. The reason
for this is, before if a package did not apear in the dep tree we
assumed it to be satisfied because of the .FindSatisfier in the dep
resolving. So if you installed a package that needs `foo=1` and you
already had a package providing that it would not be in the dep tree and
we assume it is fine. But if you install a package that needs `foo=1`
and install a package that prvoides `foo=2` then foo will all of
a sudden be in the dep tree but only version 2 will be there. For this
reason we also load all the already installed packages in so that the
`foo=1` will be there.

fixes #319 