### PR TITLE
Repect --answer* flags when --noconfirm is set

### DIFF
--- a/config.go
+++ b/config.go
@@ -233,7 +233,7 @@ func continueTask(s string, def string) (cont bool) {
 }
 
 func getInput(defaultValue string) (string, error) {
-	if defaultValue != "" {
+	if defaultValue != "" || config.NoConfirm {
 		fmt.Println(defaultValue)
 		return defaultValue, nil
 	}

--- a/install.go
+++ b/install.go
@@ -216,9 +216,12 @@ func install(parser *arguments) error {
 			}
 		}
 	} else if hasAur {
+		oldValue := config.NoConfirm
+		config.NoConfirm = false
 		if len(toEdit) > 0 && !continueTask("Proceed with install?", "nN") {
 			return fmt.Errorf("Aborting due to user")
 		}
+		config.NoConfirm = oldValue
 	}
 
 	if hasAur {
@@ -315,10 +318,6 @@ func cleanEditNumberMenu(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg, installed
 
 	toClean := make([]*rpc.Pkg, 0)
 	toEdit := make([]*rpc.Pkg, 0)
-
-	if config.NoConfirm {
-		return toClean, toEdit, nil
-	}
 
 	for n, pkg := range pkgs {
 		dir := config.BuildDir + pkg.PackageBase + "/"

--- a/upgrade.go
+++ b/upgrade.go
@@ -277,13 +277,6 @@ func upgradePkgs(aurUp, repoUp upSlice) (stringSet, stringSet, error) {
 	repoUp.Print(len(aurUp) + 1)
 	aurUp.Print(1)
 
-	if config.NoConfirm {
-		for _, up := range aurUp {
-			aurNames.set(up.Name)
-		}
-		return ignore, aurNames, nil
-	}
-
 	fmt.Println(bold(green(arrow + " Packages to not upgrade (eg: 1 2 3, 1-3, ^4 or repo name)")))
 	fmt.Print(bold(green(arrow + " ")))
 


### PR DESCRIPTION
This means that menus are now printed in noconfirm mode, I don't see
this as a problem because Pacman still prints its questions during
noconfirm.

When the user has edited pkgbuilds Yay will prompt if they want to
continue with the intall. This prompt is also enabled during noconfirm
to ensure the user is happy with the pkgbuilds.