### PR TITLE
Highlight diff between old and new versions better

### DIFF
--- a/print.go
+++ b/print.go
@@ -362,60 +362,52 @@ func formatTime(i int) string {
 	return fmt.Sprintf("%d/%02d/%02d", t.Year(), int(t.Month()), t.Day())
 }
 
-func red(in string) string {
+const (
+	redCode     = "\x1b[31m"
+	greenCode   = "\x1b[32m"
+	yellowCode  = "\x1b[33m"
+	blueCode    = "\x1b[34m"
+	magentaCode = "\x1b[35m"
+	cyanCode    = "\x1b[36m"
+	boldCode    = "\x1b[1m"
+
+	resetCode = "\x1b[0m"
+)
+
+func stylize(startCode, in string) string {
 	if useColor {
-		return "\x1b[31m" + in + "\x1b[0m"
+		return startCode + in + resetCode
 	}
 
 	return in
+}
+
+func red(in string) string {
+	return stylize(redCode, in)
 }
 
 func green(in string) string {
-	if useColor {
-		return "\x1b[32m" + in + "\x1b[0m"
-	}
-
-	return in
+	return stylize(greenCode, in)
 }
 
 func yellow(in string) string {
-	if useColor {
-		return "\x1b[33m" + in + "\x1b[0m"
-	}
-
-	return in
+	return stylize(yellowCode, in)
 }
 
 func blue(in string) string {
-	if useColor {
-		return "\x1b[34m" + in + "\x1b[0m"
-	}
-
-	return in
+	return stylize(blueCode, in)
 }
 
 func cyan(in string) string {
-	if useColor {
-		return "\x1b[36m" + in + "\x1b[0m"
-	}
-
-	return in
+	return stylize(cyanCode, in)
 }
 
 func magenta(in string) string {
-	if useColor {
-		return "\x1b[35m" + in + "\x1b[0m"
-	}
-
-	return in
+	return stylize(magentaCode, in)
 }
 
 func bold(in string) string {
-	if useColor {
-		return "\x1b[1m" + in + "\x1b[0m"
-	}
-
-	return in
+	return stylize(boldCode, in)
 }
 
 // Colours text using a hashing algorithm. The same text will always produce the

--- a/upgrade.go
+++ b/upgrade.go
@@ -55,11 +55,11 @@ func (u upSlice) Less(i, j int) bool {
 
 	if found != nil {
 		return less
-	} else {
-		iRunes := []rune(u[i].Repository)
-		jRunes := []rune(u[j].Repository)
-		return lessRunes(iRunes, jRunes)
 	}
+
+	iRunes := []rune(u[i].Repository)
+	jRunes := []rune(u[j].Repository)
+	return lessRunes(iRunes, jRunes)
 
 }
 

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+func TestGetVersionDiff(t *testing.T) {
+	useColor = true
+
+	type versionPair struct {
+		Old string
+		New string
+	}
+
+	in := []versionPair{
+		{"1-1", "1-1"},
+		{"1-1", "2-1"},
+		{"2-1", "1-1"},
+		{"1-1", "1-2"},
+		{"1-2", "1-1"},
+		{"1.2.3-1", "1.2.4-1"},
+		{"1.8rc1+6+g0f377f94-1", "1.8rc1+1+g7e949283-1"},
+		{"1.8rc1+6+g0f377f94-1", "1.8rc2+1+g7e949283-1"},
+		{"1.8rc2", "1.9rc1"},
+		{"2.99.917+812+g75795523-1", "2.99.917+823+gd9bf46e4-1"},
+		{"1.2.9-1", "1.2.10-1"},
+		{"1.2.10-1", "1.2.9-1"},
+		{"1.2-1", "1.2.1-1"},
+		{"1.2.1-1", "1.2-1"},
+		{"0.7-4", "0.7+4+gd8d8c67-1"},
+	}
+
+	out := []versionPair{
+		{"1-1", "1-1"},
+		{red("1-1"), green("2-1")},
+		{red("2-1"), green("1-1")},
+		{"1-" + red("1"), "1-" + green("2")},
+		{"1-" + red("2"), "1-" + green("1")},
+		{"1.2." + red("3-1"), "1.2." + green("4-1")},
+		{"1.8rc1+" + red("6+g0f377f94-1"), "1.8rc1+" + green("1+g7e949283-1")},
+		{"1.8" + red("rc1+6+g0f377f94-1"), "1.8" + green("rc2+1+g7e949283-1")},
+		{"1." + red("8rc2"), "1." + green("9rc1")},
+		{"2.99.917+" + red("812+g75795523-1"), "2.99.917+" + green("823+gd9bf46e4-1")},
+		{"1.2." + red("9-1"), "1.2." + green("10-1")},
+		{"1.2." + red("10-1"), "1.2." + green("9-1")},
+		{"1.2" + red("-1"), "1.2" + green(".1-1")},
+		{"1.2" + red(".1-1"), "1.2" + green("-1")},
+		{"0.7" + red("-4"), "0.7" + green("+4+gd8d8c67-1")},
+	}
+
+	for i, pair := range in {
+		o, n := getVersionDiff(pair.Old, pair.New)
+
+		if o != out[i].Old || n != out[i].New {
+			t.Errorf("Test %d failed for update: (%s => %s) expected (%s => %s) got (%s => %s)", i+1, in[i].Old, in[i].New, out[i].Old, out[i].New, o, n)
+		}
+	}
+}


### PR DESCRIPTION
Split by dots, pluses, dashes, etc., not only `Version` and `Pkgrel`.

Don't make new version different bold.

Inspired by [`pikaur`](https://github.com/actionless/pikaur).

-----

Before:

![image](https://user-images.githubusercontent.com/6510020/38366006-120838f8-38e7-11e8-8545-de8eb0cd9172.png)

After:

![image](https://user-images.githubusercontent.com/6510020/38366018-1edba7c2-38e7-11e8-8134-d5d978740527.png)
