### PR TITLE
Localizing Yay take two

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ _cgo_defun.c
 _cgo_gotypes.go
 _cgo_export.*
 
+*.mo
+*.pot
+
 *.exe
 *.test
 *.prof

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,6 +9,15 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/leonelquinteros/gotext"
+  packages = [
+    ".",
+    "plurals"
+  ]
+  revision = "7c73cc29758589140bf2190547aae1ee72ebe554"
+
+[[projects]]
+  branch = "master"
   name = "github.com/mikkeloscar/aur"
   packages = ["."]
   revision = "837b260b8e90895c45737e2e72313fe5bce6f2c4"
@@ -22,6 +31,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "456465ee334310996a51a2282bf4cfe9f6269db508479c962474d61a4ce0a08c"
+  inputs-digest = "4ea067c2c824630934353c154c78050f96f61c120522783412c80d23ea4a24b3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,3 +14,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/mikkeloscar/gopkgbuild"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/leonelquinteros/gotext"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: all default install uninstall test build release clean
-
 PREFIX := /usr
 DESTDIR :=
+LOCALEDIR := locale
+SYSTEMLOCALEPATH := $(DESTDIR)$(PREFIX)/share/locale
 
 ifndef VERSION
 MAJORVERSION := 6
@@ -9,26 +9,38 @@ MINORVERSION ?= $(shell git rev-list --count master)
 endif
 VERSION := ${MAJORVERSION}.${MINORVERSION}
 
-LDFLAGS := -ldflags '-s -w -X main.version=${VERSION}'
+LDFLAGS := -ldflags '-s -w -X main.version=${VERSION} -X main.localePath=${SYSTEMLOCALEPATH}'
 GOFILES := $(shell ls *.go | grep -v /vendor/)
 ARCH := $(shell uname -m)
 PKGNAME := yay
 BINNAME := yay
 PACKAGE := ${PKGNAME}_${VERSION}_${ARCH}
 
+LANGS := fr
+POTFILE := ${PKGNAME}.pot
+POFILES := $(addprefix $(LOCALEDIR)/,$(addsuffix .po,$(LANGS)))
+MOFILES := $(POFILES:.po=.mo)
+
 export GOPATH=$(shell pwd)/.go
 export GOROOT=/usr/lib/go
 
-default: build
+.PHONY: all default install uninstall test build release clean locale
+.PRECIOUS: ${LOCALEDIR}/%.po
+
+default: build ${MOFILES}
 
 all: | clean package
 
-install:
+install: build ${MOFILES}
 	install -Dm755 ${BINNAME} $(DESTDIR)$(PREFIX)/bin/${BINNAME}
 	install -Dm644 doc/${PKGNAME}.8 $(DESTDIR)$(PREFIX)/share/man/man8/${PKGNAME}.8
 	install -Dm644 completions/bash $(DESTDIR)$(PREFIX)/share/bash-completion/completions/${PKGNAME}
 	install -Dm644 completions/zsh $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_${PKGNAME}
 	install -Dm644 completions/fish $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/${PKGNAME}.fish
+
+	for lang in ${LANGS}; do \
+		install -Dm644 ${LOCALEDIR}/$${lang}.mo $(DESTDIR)$(PREFIX)/share/locale/$$lang/LC_MESSAGES/${PKGNAME}.mo; \
+	done
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/${BINNAME}
@@ -36,6 +48,10 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/share/bash-completion/completions/${PKGNAME}
 	rm -f $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_${PKGNAME}
 	rm -f $(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/${PKGNAME}.fish
+
+	for lang in ${LANGS}; do \
+		rm -f $(DESTDIR)$(PREFIX)/share/locale/$$lang/LC_MESSAGES/${PKGNAME}.mo; \
+	done
 
 test:
 	gofmt -l *.go
@@ -46,17 +62,34 @@ test:
 build:
 	go build -v ${LDFLAGS} -o ${BINNAME}
 
-release: | test build
+release: | test build ${MOFILES}
 	mkdir ${PACKAGE}
 	cp ./${BINNAME} ${PACKAGE}/
 	cp ./doc/${PKGNAME}.8 ${PACKAGE}/
 	cp ./completions/zsh ${PACKAGE}/
 	cp ./completions/fish ${PACKAGE}/
 	cp ./completions/bash ${PACKAGE}/
+	cp  ${MOFILES} ${PACKAGE}/
 
 package: release
 	tar -czvf ${PACKAGE}.tar.gz ${PACKAGE}
+
 clean:
 	rm -rf ${PKGNAME}_*
 	rm -f ${BINNAME}
+	rm -f ${POTFILE}
+	rm -f ${MOFILES}
+
+locale: ${MOFILES}
+
+${LOCALEDIR}/${POTFILE}: ${GOFILES}
+	xgettext --from-code=UTF-8 -Lc -sc -d ${PKGNAME} -kGet -o locale/${PKGNAME}.pot ${GOFILES}
+
+${LOCALEDIR}/%.po: ${LOCALEDIR}/${POTFILE}
+	test -f $@ || msginit -l $* -i $< -o $@
+	msgmerge -U $@ $<
+	touch $@
+
+${LOCALEDIR}/%.mo: ${LOCALEDIR}/%.po
+	msgfmt $< -o $@
 

--- a/completions.go
+++ b/completions.go
@@ -14,7 +14,7 @@ import (
 
 //CreateAURList creates a new completion file
 func createAURList(out *os.File, shell string) (err error) {
-	resp, err := http.Get("https://aur.archlinux.org/packages.gz")
+	resp, err := http.Get(filepath.Join(baseURL, "packages.gz"))
 	if err != nil {
 		return err
 	}

--- a/config.go
+++ b/config.go
@@ -69,6 +69,8 @@ type Configuration struct {
 
 var version = "5.688"
 
+var localePath = "/usr/share/locale"
+
 // configFileName holds the name of the config file.
 const configFileName string = "config.json"
 

--- a/config.go
+++ b/config.go
@@ -77,8 +77,11 @@ const configFileName string = "config.json"
 // vcsFileName holds the name of the vcs file.
 const vcsFileName string = "vcs.json"
 
-// baseURL givers the AUR default address.
+// baseURL gives the AUR default address.
 const baseURL string = "https://aur.archlinux.org"
+
+// news URL gives the Arch news RSS feed.
+const newsURL string = "https://archlinux.org/feeds/news"
 
 // useColor enables/disables colored printing
 var useColor bool

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -1,0 +1,26 @@
+# French translations for PACKAGE package.
+# Copyright (C) 2018 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#  <morganamilo@gmail.com>, 2018.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-04-09 13:30+0100\n"
+"PO-Revision-Date: 2018-04-09 13:30+0100\n"
+"Last-Translator:  <morganamilo@gmail.com>\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ASCII\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: main.go:177
+msgid "Please avoid running yay as root/sudo."
+msgstr "This but in french"
+
+#: completions.go:17
+msgid "https://aur.archlinux.org/packages.gz"
+msgstr ""

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-09 13:30+0100\n"
+"POT-Creation-Date: 2018-06-03 17:36+0100\n"
 "PO-Revision-Date: 2018-04-09 13:30+0100\n"
 "Last-Translator:  <morganamilo@gmail.com>\n"
 "Language-Team: French\n"
@@ -17,10 +17,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: main.go:177
+#: main.go:184
 msgid "Please avoid running yay as root/sudo."
 msgstr "This but in french"
-
-#: completions.go:17
-msgid "https://aur.archlinux.org/packages.gz"
-msgstr ""

--- a/main.go
+++ b/main.go
@@ -170,15 +170,15 @@ func initAlpm() (err error) {
 	return
 }
 
-func initGoText() {
-	gotext.Configure("locale", "en_UK", "yay")
+func initGotext() {
+	gotext.Configure(localePath, os.Getenv("LANG"), "yay")
 }
 
 func main() {
 	var status int
 	var err error
 
-	initGoText()
+	initGotext()
 
 	if 0 == os.Geteuid() {
 		fmt.Println(gotext.Get("Please avoid running yay as root/sudo."))

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	alpm "github.com/jguer/go-alpm"
+	gotext "github.com/leonelquinteros/gotext"
 )
 
 func initPaths() {
@@ -169,12 +170,18 @@ func initAlpm() (err error) {
 	return
 }
 
+func initGoText() {
+	gotext.Configure("locale", "en_UK", "yay")
+}
+
 func main() {
 	var status int
 	var err error
 
+	initGoText()
+
 	if 0 == os.Geteuid() {
-		fmt.Println("Please avoid running yay as root/sudo.")
+		fmt.Println(gotext.Get("Please avoid running yay as root/sudo."))
 	}
 
 	err = cmdArgs.parseCommandLine()

--- a/print.go
+++ b/print.go
@@ -471,7 +471,7 @@ type rss struct {
 }
 
 func printNewsFeed() error {
-	resp, err := http.Get("https://archlinux.org/feeds/news")
+	resp, err := http.Get(newsURL)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/leonelquinteros/gotext/LICENSE
+++ b/vendor/github.com/leonelquinteros/gotext/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Leonel Quinteros
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/leonelquinteros/gotext/gotext.go
+++ b/vendor/github.com/leonelquinteros/gotext/gotext.go
@@ -1,0 +1,217 @@
+/*
+Package gotext implements GNU gettext utilities.
+
+For quick/simple translations you can use the package level functions directly.
+
+    import (
+	    "fmt"
+	    "github.com/leonelquinteros/gotext"
+    )
+
+    func main() {
+        // Configure package
+        gotext.Configure("/path/to/locales/root/dir", "en_UK", "domain-name")
+
+        // Translate text from default domain
+        fmt.Println(gotext.Get("My text on 'domain-name' domain"))
+
+        // Translate text from a different domain without reconfigure
+        fmt.Println(gotext.GetD("domain2", "Another text on a different domain"))
+    }
+
+*/
+package gotext
+
+import (
+	"sync"
+)
+
+// Global environment variables
+type config struct {
+	sync.RWMutex
+
+	// Default domain to look at when no domain is specified. Used by package level functions.
+	domain string
+
+	// Language set.
+	language string
+
+	// Path to library directory where all locale directories and Translation files are.
+	library string
+
+	// Storage for package level methods
+	storage *Locale
+}
+
+var globalConfig *config
+
+// Init default configuration
+func init() {
+	globalConfig = &config{
+		domain:   "default",
+		language: "en_US",
+		library:  "/usr/local/share/locale",
+		storage:  nil,
+	}
+}
+
+// loadStorage creates a new Locale object at package level based on the Global variables settings.
+// It's called automatically when trying to use Get or GetD methods.
+func loadStorage(force bool) {
+	globalConfig.Lock()
+
+	if globalConfig.storage == nil || force {
+		globalConfig.storage = NewLocale(globalConfig.library, globalConfig.language)
+	}
+
+	if _, ok := globalConfig.storage.Domains[globalConfig.domain]; !ok || force {
+		globalConfig.storage.AddDomain(globalConfig.domain)
+	}
+	globalConfig.storage.SetDomain(globalConfig.domain)
+
+	globalConfig.Unlock()
+}
+
+// GetDomain is the domain getter for the package configuration
+func GetDomain() string {
+	var dom string
+	globalConfig.RLock()
+	if globalConfig.storage != nil {
+		dom = globalConfig.storage.GetDomain()
+	}
+	if dom == "" {
+		dom = globalConfig.domain
+	}
+	globalConfig.RUnlock()
+
+	return dom
+}
+
+// SetDomain sets the name for the domain to be used at package level.
+// It reloads the corresponding Translation file.
+func SetDomain(dom string) {
+	globalConfig.Lock()
+	globalConfig.domain = dom
+	if globalConfig.storage != nil {
+		globalConfig.storage.SetDomain(dom)
+	}
+	globalConfig.Unlock()
+
+	loadStorage(true)
+}
+
+// GetLanguage is the language getter for the package configuration
+func GetLanguage() string {
+	globalConfig.RLock()
+	lang := globalConfig.language
+	globalConfig.RUnlock()
+
+	return lang
+}
+
+// SetLanguage sets the language code to be used at package level.
+// It reloads the corresponding Translation file.
+func SetLanguage(lang string) {
+	globalConfig.Lock()
+	globalConfig.language = SimplifiedLocale(lang)
+	globalConfig.Unlock()
+
+	loadStorage(true)
+}
+
+// GetLibrary is the library getter for the package configuration
+func GetLibrary() string {
+	globalConfig.RLock()
+	lib := globalConfig.library
+	globalConfig.RUnlock()
+
+	return lib
+}
+
+// SetLibrary sets the root path for the loale directories and files to be used at package level.
+// It reloads the corresponding Translation file.
+func SetLibrary(lib string) {
+	globalConfig.Lock()
+	globalConfig.library = lib
+	globalConfig.Unlock()
+
+	loadStorage(true)
+}
+
+// Configure sets all configuration variables to be used at package level and reloads the corresponding Translation file.
+// It receives the library path, language code and domain name.
+// This function is recommended to be used when changing more than one setting,
+// as using each setter will introduce a I/O overhead because the Translation file will be loaded after each set.
+func Configure(lib, lang, dom string) {
+	globalConfig.Lock()
+	globalConfig.library = lib
+	globalConfig.language = SimplifiedLocale(lang)
+	globalConfig.domain = dom
+	globalConfig.Unlock()
+
+	loadStorage(true)
+}
+
+// Get uses the default domain globally set to return the corresponding Translation of a given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func Get(str string, vars ...interface{}) string {
+	return GetD(GetDomain(), str, vars...)
+}
+
+// GetN retrieves the (N)th plural form of Translation for the given string in the default domain.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetN(str, plural string, n int, vars ...interface{}) string {
+	return GetND(GetDomain(), str, plural, n, vars...)
+}
+
+// GetD returns the corresponding Translation in the given domain for a given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetD(dom, str string, vars ...interface{}) string {
+	return GetND(dom, str, str, 1, vars...)
+}
+
+// GetND retrieves the (N)th plural form of Translation in the given domain for a given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetND(dom, str, plural string, n int, vars ...interface{}) string {
+	// Try to load default package Locale storage
+	loadStorage(false)
+
+	// Return Translation
+	globalConfig.RLock()
+	tr := globalConfig.storage.GetND(dom, str, plural, n, vars...)
+	globalConfig.RUnlock()
+
+	return tr
+}
+
+// GetC uses the default domain globally set to return the corresponding Translation of the given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetC(str, ctx string, vars ...interface{}) string {
+	return GetDC(GetDomain(), str, ctx, vars...)
+}
+
+// GetNC retrieves the (N)th plural form of Translation for the given string in the given context in the default domain.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+	return GetNDC(GetDomain(), str, plural, n, ctx, vars...)
+}
+
+// GetDC returns the corresponding Translation in the given domain for the given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetDC(dom, str, ctx string, vars ...interface{}) string {
+	return GetNDC(dom, str, str, 1, ctx, vars...)
+}
+
+// GetNDC retrieves the (N)th plural form of Translation in the given domain for a given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func GetNDC(dom, str, plural string, n int, ctx string, vars ...interface{}) string {
+	// Try to load default package Locale storage
+	loadStorage(false)
+
+	// Return Translation
+	globalConfig.RLock()
+	tr := globalConfig.storage.GetNDC(dom, str, plural, n, ctx, vars...)
+	globalConfig.RUnlock()
+
+	return tr
+}

--- a/vendor/github.com/leonelquinteros/gotext/helper.go
+++ b/vendor/github.com/leonelquinteros/gotext/helper.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package gotext
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var re = regexp.MustCompile(`%\(([a-zA-Z0-9_]+)\)[.0-9]*[svTtbcdoqXxUeEfFgGp]`)
+
+// SimplifiedLocale simplified locale like " en_US"/"de_DE "/en_US.UTF-8/zh_CN/zh_TW/el_GR@euro/... to en_US, de_DE, zh_CN, el_GR...
+func SimplifiedLocale(lang string) string {
+	// en_US/en_US.UTF-8/zh_CN/zh_TW/el_GR@euro/...
+	if idx := strings.Index(lang, ":"); idx != -1 {
+		lang = lang[:idx]
+	}
+	if idx := strings.Index(lang, "@"); idx != -1 {
+		lang = lang[:idx]
+	}
+	if idx := strings.Index(lang, "."); idx != -1 {
+		lang = lang[:idx]
+	}
+	return strings.TrimSpace(lang)
+}
+
+// Printf applies text formatting only when needed to parse variables.
+func Printf(str string, vars ...interface{}) string {
+	if len(vars) > 0 {
+		return fmt.Sprintf(str, vars...)
+	}
+
+	return str
+}
+
+// NPrintf support named format
+// NPrintf("%(name)s is Type %(type)s", map[string]interface{}{"name": "Gotext", "type": "struct"})
+func NPrintf(format string, params map[string]interface{}) {
+	f, p := parseSprintf(format, params)
+	fmt.Printf(f, p...)
+}
+
+// Sprintf support named format
+//      Sprintf("%(name)s is Type %(type)s", map[string]interface{}{"name": "Gotext", "type": "struct"})
+func Sprintf(format string, params map[string]interface{}) string {
+	f, p := parseSprintf(format, params)
+	return fmt.Sprintf(f, p...)
+}
+
+func parseSprintf(format string, params map[string]interface{}) (string, []interface{}) {
+	f, n := reformatSprintf(format)
+	var p []interface{}
+	for _, v := range n {
+		p = append(p, params[v])
+	}
+	return f, p
+}
+
+func reformatSprintf(f string) (string, []string) {
+	m := re.FindAllStringSubmatch(f, -1)
+	i := re.FindAllStringSubmatchIndex(f, -1)
+
+	ord := []string{}
+	for _, v := range m {
+		ord = append(ord, v[1])
+	}
+
+	pair := []int{0}
+	for _, v := range i {
+		pair = append(pair, v[2]-1)
+		pair = append(pair, v[3]+1)
+	}
+	pair = append(pair, len(f))
+	plen := len(pair)
+
+	out := ""
+	for n := 0; n < plen; n += 2 {
+		out += f[pair[n]:pair[n+1]]
+	}
+
+	return out, ord
+}

--- a/vendor/github.com/leonelquinteros/gotext/locale.go
+++ b/vendor/github.com/leonelquinteros/gotext/locale.go
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package gotext
+
+import (
+	"os"
+	"path"
+	"sync"
+)
+
+/*
+Locale wraps the entire i18n collection for a single language (locale)
+It's used by the package functions, but it can also be used independently to handle
+multiple languages at the same time by working with this object.
+
+Example:
+
+    import (
+	    "fmt"
+	    "github.com/leonelquinteros/gotext"
+    )
+
+    func main() {
+        // Create Locale with library path and language code
+        l := gotext.NewLocale("/path/to/i18n/dir", "en_US")
+
+        // Load domain '/path/to/i18n/dir/en_US/LC_MESSAGES/default.{po,mo}'
+        l.AddDomain("default")
+
+        // Translate text from default domain
+        fmt.Println(l.Get("Translate this"))
+
+        // Load different domain ('/path/to/i18n/dir/en_US/LC_MESSAGES/extras.{po,mo}')
+        l.AddDomain("extras")
+
+        // Translate text from domain
+        fmt.Println(l.GetD("extras", "Translate this"))
+    }
+
+*/
+type Locale struct {
+	// Path to locale files.
+	path string
+
+	// Language for this Locale
+	lang string
+
+	// List of available Domains for this locale.
+	Domains map[string]Translator
+
+	// First AddDomain is default Domain
+	defaultDomain string
+
+	// Sync Mutex
+	sync.RWMutex
+}
+
+// NewLocale creates and initializes a new Locale object for a given language.
+// It receives a path for the i18n files directory (p) and a language code to use (l).
+func NewLocale(p, l string) *Locale {
+	return &Locale{
+		path:    p,
+		lang:    SimplifiedLocale(l),
+		Domains: make(map[string]Translator),
+	}
+}
+
+func (l *Locale) findExt(dom, ext string) string {
+	filename := path.Join(l.path, l.lang, "LC_MESSAGES", dom+"."+ext)
+	if _, err := os.Stat(filename); err == nil {
+		return filename
+	}
+
+	if len(l.lang) > 2 {
+		filename = path.Join(l.path, l.lang[:2], "LC_MESSAGES", dom+"."+ext)
+		if _, err := os.Stat(filename); err == nil {
+			return filename
+		}
+	}
+
+	filename = path.Join(l.path, l.lang, dom+"."+ext)
+	if _, err := os.Stat(filename); err == nil {
+		return filename
+	}
+
+	if len(l.lang) > 2 {
+		filename = path.Join(l.path, l.lang[:2], dom+"."+ext)
+		if _, err := os.Stat(filename); err == nil {
+			return filename
+		}
+	}
+
+	return ""
+}
+
+// AddDomain creates a new domain for a given locale object and initializes the Po object.
+// If the domain exists, it gets reloaded.
+func (l *Locale) AddDomain(dom string) {
+	var poObj Translator
+
+	file := l.findExt(dom, "po")
+	if file != "" {
+		poObj = new(Po)
+		// Parse file.
+		poObj.ParseFile(file)
+	} else {
+		file = l.findExt(dom, "mo")
+		if file != "" {
+			poObj = new(Mo)
+			// Parse file.
+			poObj.ParseFile(file)
+		} else {
+			// fallback return if no file found with
+			return
+		}
+	}
+
+	// Save new domain
+	l.Lock()
+
+	if l.Domains == nil {
+		l.Domains = make(map[string]Translator)
+	}
+	if l.defaultDomain == "" {
+		l.defaultDomain = dom
+	}
+	l.Domains[dom] = poObj
+
+	// Unlock "Save new domain"
+	l.Unlock()
+}
+
+// GetDomain is the domain getter for the package configuration
+func (l *Locale) GetDomain() string {
+	l.RLock()
+	dom := l.defaultDomain
+	l.RUnlock()
+	return dom
+}
+
+// SetDomain sets the name for the domain to be used at package level.
+// It reloads the corresponding Translation file.
+func (l *Locale) SetDomain(dom string) {
+	l.Lock()
+	l.defaultDomain = dom
+	l.Unlock()
+}
+
+// Get uses a domain "default" to return the corresponding Translation of a given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) Get(str string, vars ...interface{}) string {
+	return l.GetD(l.GetDomain(), str, vars...)
+}
+
+// GetN retrieves the (N)th plural form of Translation for the given string in the "default" domain.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetN(str, plural string, n int, vars ...interface{}) string {
+	return l.GetND(l.GetDomain(), str, plural, n, vars...)
+}
+
+// GetD returns the corresponding Translation in the given domain for the given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetD(dom, str string, vars ...interface{}) string {
+	return l.GetND(dom, str, str, 1, vars...)
+}
+
+// GetND retrieves the (N)th plural form of Translation in the given domain for the given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetND(dom, str, plural string, n int, vars ...interface{}) string {
+	// Sync read
+	l.RLock()
+	defer l.RUnlock()
+
+	if l.Domains != nil {
+		if _, ok := l.Domains[dom]; ok {
+			if l.Domains[dom] != nil {
+				return l.Domains[dom].GetN(str, plural, n, vars...)
+			}
+		}
+	}
+
+	// Return the same we received by default
+	return Printf(plural, vars...)
+}
+
+// GetC uses a domain "default" to return the corresponding Translation of the given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetC(str, ctx string, vars ...interface{}) string {
+	return l.GetDC(l.GetDomain(), str, ctx, vars...)
+}
+
+// GetNC retrieves the (N)th plural form of Translation for the given string in the given context in the "default" domain.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+	return l.GetNDC(l.GetDomain(), str, plural, n, ctx, vars...)
+}
+
+// GetDC returns the corresponding Translation in the given domain for the given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetDC(dom, str, ctx string, vars ...interface{}) string {
+	return l.GetNDC(dom, str, str, 1, ctx, vars...)
+}
+
+// GetNDC retrieves the (N)th plural form of Translation in the given domain for the given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (l *Locale) GetNDC(dom, str, plural string, n int, ctx string, vars ...interface{}) string {
+	// Sync read
+	l.RLock()
+	defer l.RUnlock()
+
+	if l.Domains != nil {
+		if _, ok := l.Domains[dom]; ok {
+			if l.Domains[dom] != nil {
+				return l.Domains[dom].GetNC(str, plural, n, ctx, vars...)
+			}
+		}
+	}
+
+	// Return the same we received by default
+	return Printf(plural, vars...)
+}

--- a/vendor/github.com/leonelquinteros/gotext/mo.go
+++ b/vendor/github.com/leonelquinteros/gotext/mo.go
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package gotext
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"io/ioutil"
+	"net/textproto"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/leonelquinteros/gotext/plurals"
+)
+
+const (
+	MoMagicLittleEndian = 0x950412de // MoMagicLittleEndian encoding
+	MoMagicBigEndian    = 0xde120495 // MoMagicBigEndian encoding
+
+	EotSeparator = "\x04" // msgctxt and msgid separator
+	NulSeparator = "\x00" // msgid and msgstr separator
+)
+
+/*
+Mo parses the content of any MO file and provides all the Translation functions needed.
+It's the base object used by all package methods.
+And it's safe for concurrent use by multiple goroutines by using the sync package for locking.
+
+Example:
+
+	import (
+		"fmt"
+		"github.com/leonelquinteros/gotext"
+	)
+
+	func main() {
+		// Create po object
+		po := gotext.NewMoTranslator()
+
+		// Parse .po file
+		po.ParseFile("/path/to/po/file/translations.mo")
+
+		// Get Translation
+		fmt.Println(po.Get("Translate this"))
+	}
+
+*/
+type Mo struct {
+	// Headers storage
+	Headers textproto.MIMEHeader
+
+	// Language header
+	Language string
+
+	// Plural-Forms header
+	PluralForms string
+
+	// Parsed Plural-Forms header values
+	nplurals    int
+	plural      string
+	pluralforms plurals.Expression
+
+	// Storage
+	translations map[string]*Translation
+	contexts     map[string]map[string]*Translation
+
+	// Sync Mutex
+	sync.RWMutex
+
+	// Parsing buffers
+	trBuffer  *Translation
+	ctxBuffer string
+}
+
+// NewMoTranslator creates a new Mo object with the Translator interface
+func NewMoTranslator() Translator {
+	return new(Mo)
+}
+
+// ParseFile tries to read the file by its provided path (f) and parse its content as a .po file.
+func (mo *Mo) ParseFile(f string) {
+	// Check if file exists
+	info, err := os.Stat(f)
+	if err != nil {
+		return
+	}
+
+	// Check that isn't a directory
+	if info.IsDir() {
+		return
+	}
+
+	// Parse file content
+	data, err := ioutil.ReadFile(f)
+	if err != nil {
+		return
+	}
+
+	mo.Parse(data)
+}
+
+// Parse loads the translations specified in the provided string (str)
+func (mo *Mo) Parse(buf []byte) {
+	// Lock while parsing
+	mo.Lock()
+
+	// Init storage
+	if mo.translations == nil {
+		mo.translations = make(map[string]*Translation)
+		mo.contexts = make(map[string]map[string]*Translation)
+	}
+
+	r := bytes.NewReader(buf)
+
+	var magicNumber uint32
+	if err := binary.Read(r, binary.LittleEndian, &magicNumber); err != nil {
+		return
+		// return fmt.Errorf("gettext: %v", err)
+	}
+	var bo binary.ByteOrder
+	switch magicNumber {
+	case MoMagicLittleEndian:
+		bo = binary.LittleEndian
+	case MoMagicBigEndian:
+		bo = binary.BigEndian
+	default:
+		return
+		// return fmt.Errorf("gettext: %v", "invalid magic number")
+	}
+
+	var header struct {
+		MajorVersion uint16
+		MinorVersion uint16
+		MsgIDCount   uint32
+		MsgIDOffset  uint32
+		MsgStrOffset uint32
+		HashSize     uint32
+		HashOffset   uint32
+	}
+	if err := binary.Read(r, bo, &header); err != nil {
+		return
+		// return fmt.Errorf("gettext: %v", err)
+	}
+	if v := header.MajorVersion; v != 0 && v != 1 {
+		return
+		// return fmt.Errorf("gettext: %v", "invalid version number")
+	}
+	if v := header.MinorVersion; v != 0 && v != 1 {
+		return
+		// return fmt.Errorf("gettext: %v", "invalid version number")
+	}
+
+	msgIDStart := make([]uint32, header.MsgIDCount)
+	msgIDLen := make([]uint32, header.MsgIDCount)
+	if _, err := r.Seek(int64(header.MsgIDOffset), 0); err != nil {
+		return
+		// return fmt.Errorf("gettext: %v", err)
+	}
+	for i := 0; i < int(header.MsgIDCount); i++ {
+		if err := binary.Read(r, bo, &msgIDLen[i]); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+		if err := binary.Read(r, bo, &msgIDStart[i]); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+	}
+
+	msgStrStart := make([]int32, header.MsgIDCount)
+	msgStrLen := make([]int32, header.MsgIDCount)
+	if _, err := r.Seek(int64(header.MsgStrOffset), 0); err != nil {
+		return
+		// return fmt.Errorf("gettext: %v", err)
+	}
+	for i := 0; i < int(header.MsgIDCount); i++ {
+		if err := binary.Read(r, bo, &msgStrLen[i]); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+		if err := binary.Read(r, bo, &msgStrStart[i]); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+	}
+
+	for i := 0; i < int(header.MsgIDCount); i++ {
+		if _, err := r.Seek(int64(msgIDStart[i]), 0); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+		msgIdData := make([]byte, msgIDLen[i])
+		if _, err := r.Read(msgIdData); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+
+		if _, err := r.Seek(int64(msgStrStart[i]), 0); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+		msgStrData := make([]byte, msgStrLen[i])
+		if _, err := r.Read(msgStrData); err != nil {
+			return
+			// return fmt.Errorf("gettext: %v", err)
+		}
+
+		if len(msgIdData) == 0 {
+			mo.addTranslation(msgIdData, msgStrData)
+		} else {
+			mo.addTranslation(msgIdData, msgStrData)
+		}
+	}
+
+	// Unlock to parse headers
+	mo.Unlock()
+
+	// Parse headers
+	mo.parseHeaders()
+	return
+	// return nil
+}
+
+func (mo *Mo) addTranslation(msgid, msgstr []byte) {
+	translation := NewTranslation()
+	var msgctxt []byte
+	var msgidPlural []byte
+
+	d := bytes.Split(msgid, []byte(EotSeparator))
+	if len(d) == 1 {
+		msgid = d[0]
+	} else {
+		msgid, msgctxt = d[1], d[0]
+	}
+
+	dd := bytes.Split(msgid, []byte(NulSeparator))
+	if len(dd) > 1 {
+		msgid = dd[0]
+		dd = dd[1:]
+	}
+
+	translation.ID = string(msgid)
+
+	msgidPlural = bytes.Join(dd, []byte(NulSeparator))
+	if len(msgidPlural) > 0 {
+		translation.PluralID = string(msgidPlural)
+	}
+
+	ddd := bytes.Split(msgstr, []byte(NulSeparator))
+	if len(ddd) > 0 {
+		for i, s := range ddd {
+			translation.Trs[i] = string(s)
+		}
+	}
+
+	if len(msgctxt) > 0 {
+		// With context...
+		if _, ok := mo.contexts[string(msgctxt)]; !ok {
+			mo.contexts[string(msgctxt)] = make(map[string]*Translation)
+		}
+		mo.contexts[string(msgctxt)][translation.ID] = translation
+	} else {
+		mo.translations[translation.ID] = translation
+	}
+}
+
+// parseHeaders retrieves data from previously parsed headers
+func (mo *Mo) parseHeaders() {
+	// Make sure we end with 2 carriage returns.
+	raw := mo.Get("") + "\n\n"
+
+	// Read
+	reader := bufio.NewReader(strings.NewReader(raw))
+	tp := textproto.NewReader(reader)
+
+	var err error
+
+	// Sync Headers write.
+	mo.Lock()
+	defer mo.Unlock()
+
+	mo.Headers, err = tp.ReadMIMEHeader()
+	if err != nil {
+		return
+	}
+
+	// Get/save needed headers
+	mo.Language = mo.Headers.Get("Language")
+	mo.PluralForms = mo.Headers.Get("Plural-Forms")
+
+	// Parse Plural-Forms formula
+	if mo.PluralForms == "" {
+		return
+	}
+
+	// Split plural form header value
+	pfs := strings.Split(mo.PluralForms, ";")
+
+	// Parse values
+	for _, i := range pfs {
+		vs := strings.SplitN(i, "=", 2)
+		if len(vs) != 2 {
+			continue
+		}
+
+		switch strings.TrimSpace(vs[0]) {
+		case "nplurals":
+			mo.nplurals, _ = strconv.Atoi(vs[1])
+
+		case "plural":
+			mo.plural = vs[1]
+
+			if expr, err := plurals.Compile(mo.plural); err == nil {
+				mo.pluralforms = expr
+			}
+
+		}
+	}
+}
+
+// pluralForm calculates the plural form index corresponding to n.
+// Returns 0 on error
+func (mo *Mo) pluralForm(n int) int {
+	mo.RLock()
+	defer mo.RUnlock()
+
+	// Failure fallback
+	if mo.pluralforms == nil {
+		/* Use the Germanic plural rule.  */
+		if n == 1 {
+			return 0
+		}
+		return 1
+
+	}
+	return mo.pluralforms.Eval(uint32(n))
+}
+
+// Get retrieves the corresponding Translation for the given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (mo *Mo) Get(str string, vars ...interface{}) string {
+	// Sync read
+	mo.RLock()
+	defer mo.RUnlock()
+
+	if mo.translations != nil {
+		if _, ok := mo.translations[str]; ok {
+			return Printf(mo.translations[str].Get(), vars...)
+		}
+	}
+
+	// Return the same we received by default
+	return Printf(str, vars...)
+}
+
+// GetN retrieves the (N)th plural form of Translation for the given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (mo *Mo) GetN(str, plural string, n int, vars ...interface{}) string {
+	// Sync read
+	mo.RLock()
+	defer mo.RUnlock()
+
+	if mo.translations != nil {
+		if _, ok := mo.translations[str]; ok {
+			return Printf(mo.translations[str].GetN(mo.pluralForm(n)), vars...)
+		}
+	}
+
+	if n == 1 {
+		return Printf(str, vars...)
+	}
+	return Printf(plural, vars...)
+}
+
+// GetC retrieves the corresponding Translation for a given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (mo *Mo) GetC(str, ctx string, vars ...interface{}) string {
+	// Sync read
+	mo.RLock()
+	defer mo.RUnlock()
+
+	if mo.contexts != nil {
+		if _, ok := mo.contexts[ctx]; ok {
+			if mo.contexts[ctx] != nil {
+				if _, ok := mo.contexts[ctx][str]; ok {
+					return Printf(mo.contexts[ctx][str].Get(), vars...)
+				}
+			}
+		}
+	}
+
+	// Return the string we received by default
+	return Printf(str, vars...)
+}
+
+// GetNC retrieves the (N)th plural form of Translation for the given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (mo *Mo) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+	// Sync read
+	mo.RLock()
+	defer mo.RUnlock()
+
+	if mo.contexts != nil {
+		if _, ok := mo.contexts[ctx]; ok {
+			if mo.contexts[ctx] != nil {
+				if _, ok := mo.contexts[ctx][str]; ok {
+					return Printf(mo.contexts[ctx][str].GetN(mo.pluralForm(n)), vars...)
+				}
+			}
+		}
+	}
+
+	if n == 1 {
+		return Printf(str, vars...)
+	}
+	return Printf(plural, vars...)
+}

--- a/vendor/github.com/leonelquinteros/gotext/plurals/compiler.go
+++ b/vendor/github.com/leonelquinteros/gotext/plurals/compiler.go
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+/*
+ Package plurals is the pluralform compiler to get the correct translation id of the plural string
+*/
+package plurals
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type match struct {
+	openPos  int
+	closePos int
+}
+
+var pat = regexp.MustCompile(`(\?|:|\|\||&&|==|!=|>=|>|<=|<|%|\d+|n)`)
+
+type testToken interface {
+	compile(tokens []string) (test test, err error)
+}
+
+type cmpTestBuilder func(val uint32, flipped bool) test
+type logicTestBuild func(left test, right test) test
+
+var ternaryToken ternaryStruct
+
+type ternaryStruct struct{}
+
+func (ternaryStruct) compile(tokens []string) (expr Expression, err error) {
+	main, err := splitTokens(tokens, "?")
+	if err != nil {
+		return expr, err
+	}
+	test, err := compileTest(strings.Join(main.Left, ""))
+	if err != nil {
+		return expr, err
+	}
+	actions, err := splitTokens(main.Right, ":")
+	if err != nil {
+		return expr, err
+	}
+	trueAction, err := compileExpression(strings.Join(actions.Left, ""))
+	if err != nil {
+		return expr, err
+	}
+	falseAction, err := compileExpression(strings.Join(actions.Right, ""))
+	if err != nil {
+		return expr, nil
+	}
+	return ternary{
+		test:      test,
+		trueExpr:  trueAction,
+		falseExpr: falseAction,
+	}, nil
+}
+
+var constToken constValStruct
+
+type constValStruct struct{}
+
+func (constValStruct) compile(tokens []string) (expr Expression, err error) {
+	if len(tokens) == 0 {
+		return expr, errors.New("got nothing instead of constant")
+	}
+	if len(tokens) != 1 {
+		return expr, fmt.Errorf("invalid constant: %s", strings.Join(tokens, ""))
+	}
+	i, err := strconv.Atoi(tokens[0])
+	if err != nil {
+		return expr, err
+	}
+	return constValue{value: i}, nil
+}
+
+func compileLogicTest(tokens []string, sep string, builder logicTestBuild) (test test, err error) {
+	split, err := splitTokens(tokens, sep)
+	if err != nil {
+		return test, err
+	}
+	left, err := compileTest(strings.Join(split.Left, ""))
+	if err != nil {
+		return test, err
+	}
+	right, err := compileTest(strings.Join(split.Right, ""))
+	if err != nil {
+		return test, err
+	}
+	return builder(left, right), nil
+}
+
+var orToken orStruct
+
+type orStruct struct{}
+
+func (orStruct) compile(tokens []string) (test test, err error) {
+	return compileLogicTest(tokens, "||", buildOr)
+}
+func buildOr(left test, right test) test {
+	return or{left: left, right: right}
+}
+
+var andToken andStruct
+
+type andStruct struct{}
+
+func (andStruct) compile(tokens []string) (test test, err error) {
+	return compileLogicTest(tokens, "&&", buildAnd)
+}
+func buildAnd(left test, right test) test {
+	return and{left: left, right: right}
+}
+
+func compileMod(tokens []string) (math math, err error) {
+	split, err := splitTokens(tokens, "%")
+	if err != nil {
+		return math, err
+	}
+	if len(split.Left) != 1 || split.Left[0] != "n" {
+		return math, errors.New("Modulus operation requires 'n' as left operand")
+	}
+	if len(split.Right) != 1 {
+		return math, errors.New("Modulus operation requires simple integer as right operand")
+	}
+	i, err := parseUint32(split.Right[0])
+	if err != nil {
+		return math, err
+	}
+	return mod{value: uint32(i)}, nil
+}
+
+func subPipe(modTokens []string, actionTokens []string, builder cmpTestBuilder, flipped bool) (test test, err error) {
+	modifier, err := compileMod(modTokens)
+	if err != nil {
+		return test, err
+	}
+	if len(actionTokens) != 1 {
+		return test, errors.New("can only get modulus of integer")
+	}
+	i, err := parseUint32(actionTokens[0])
+	if err != nil {
+		return test, err
+	}
+	action := builder(uint32(i), flipped)
+	return pipe{
+		modifier: modifier,
+		action:   action,
+	}, nil
+}
+
+func compileEquality(tokens []string, sep string, builder cmpTestBuilder) (test test, err error) {
+	split, err := splitTokens(tokens, sep)
+	if err != nil {
+		return test, err
+	}
+	if len(split.Left) == 1 && split.Left[0] == "n" {
+		if len(split.Right) != 1 {
+			return test, errors.New("test can only compare n to integers")
+		}
+		i, err := parseUint32(split.Right[0])
+		if err != nil {
+			return test, err
+		}
+		return builder(i, false), nil
+	} else if len(split.Right) == 1 && split.Right[0] == "n" {
+		if len(split.Left) != 1 {
+			return test, errors.New("test can only compare n to integers")
+		}
+		i, err := parseUint32(split.Left[0])
+		if err != nil {
+			return test, err
+		}
+		return builder(i, true), nil
+	} else if contains(split.Left, "n") && contains(split.Left, "%") {
+		return subPipe(split.Left, split.Right, builder, false)
+	}
+	return test, errors.New("equality test must have 'n' as one of the two tests")
+
+}
+
+var eqToken eqStruct
+
+type eqStruct struct{}
+
+func (eqStruct) compile(tokens []string) (test test, err error) {
+	return compileEquality(tokens, "==", buildEq)
+}
+func buildEq(val uint32, flipped bool) test {
+	return equal{value: val}
+}
+
+var neqToken neqStruct
+
+type neqStruct struct{}
+
+func (neqStruct) compile(tokens []string) (test test, err error) {
+	return compileEquality(tokens, "!=", buildNeq)
+}
+func buildNeq(val uint32, flipped bool) test {
+	return notequal{value: val}
+}
+
+var gtToken gtStruct
+
+type gtStruct struct{}
+
+func (gtStruct) compile(tokens []string) (test test, err error) {
+	return compileEquality(tokens, ">", buildGt)
+}
+func buildGt(val uint32, flipped bool) test {
+	return gt{value: val, flipped: flipped}
+}
+
+var gteToken gteStruct
+
+type gteStruct struct{}
+
+func (gteStruct) compile(tokens []string) (test test, err error) {
+	return compileEquality(tokens, ">=", buildGte)
+}
+func buildGte(val uint32, flipped bool) test {
+	return gte{value: val, flipped: flipped}
+}
+
+var ltToken ltStruct
+
+type ltStruct struct{}
+
+func (ltStruct) compile(tokens []string) (test test, err error) {
+	return compileEquality(tokens, "<", buildLt)
+}
+func buildLt(val uint32, flipped bool) test {
+	return lt{value: val, flipped: flipped}
+}
+
+var lteToken lteStruct
+
+type lteStruct struct{}
+
+func (lteStruct) compile(tokens []string) (test test, err error) {
+	return compileEquality(tokens, "<=", buildLte)
+}
+func buildLte(val uint32, flipped bool) test {
+	return lte{value: val, flipped: flipped}
+}
+
+type testTokenDef struct {
+	op    string
+	token testToken
+}
+
+var precedence = []testTokenDef{
+	{op: "||", token: orToken},
+	{op: "&&", token: andToken},
+	{op: "==", token: eqToken},
+	{op: "!=", token: neqToken},
+	{op: ">=", token: gteToken},
+	{op: ">", token: gtToken},
+	{op: "<=", token: lteToken},
+	{op: "<", token: ltToken},
+}
+
+type splitted struct {
+	Left  []string
+	Right []string
+}
+
+// Find index of token in list of tokens
+func index(tokens []string, sep string) int {
+	for index, token := range tokens {
+		if token == sep {
+			return index
+		}
+	}
+	return -1
+}
+
+// Split a list of tokens by a token into a splitted struct holding the tokens
+// before and after the token to be split by.
+func splitTokens(tokens []string, sep string) (s splitted, err error) {
+	index := index(tokens, sep)
+	if index == -1 {
+		return s, fmt.Errorf("'%s' not found in ['%s']", sep, strings.Join(tokens, "','"))
+	}
+	return splitted{
+		Left:  tokens[:index],
+		Right: tokens[index+1:],
+	}, nil
+}
+
+// Scan a string for parenthesis
+func scan(s string) <-chan match {
+	ch := make(chan match)
+	go func() {
+		depth := 0
+		opener := 0
+		for index, char := range s {
+			switch char {
+			case '(':
+				if depth == 0 {
+					opener = index
+				}
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					ch <- match{
+						openPos:  opener,
+						closePos: index + 1,
+					}
+				}
+			}
+
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+// Split the string into tokens
+func split(s string) <-chan string {
+	ch := make(chan string)
+	go func() {
+		s = strings.Replace(s, " ", "", -1)
+		if !strings.Contains(s, "(") {
+			ch <- s
+		} else {
+			last := 0
+			end := len(s)
+			for info := range scan(s) {
+				if last != info.openPos {
+					ch <- s[last:info.openPos]
+				}
+				ch <- s[info.openPos:info.closePos]
+				last = info.closePos
+			}
+			if last != end {
+				ch <- s[last:]
+			}
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+// Tokenizes a string into a list of strings, tokens grouped by parenthesis are
+// not split! If the string starts with ( and ends in ), those are stripped.
+func tokenize(s string) []string {
+	/*
+		TODO: Properly detect if the string starts with a ( and ends with a )
+		and that those two form a matching pair.
+
+		Eg: (foo) -> true; (foo)(bar) -> false;
+	*/
+	if s[0] == '(' && s[len(s)-1] == ')' {
+		s = s[1 : len(s)-1]
+	}
+	ret := []string{}
+	for chunk := range split(s) {
+		if len(chunk) != 0 {
+			if chunk[0] == '(' && chunk[len(chunk)-1] == ')' {
+				ret = append(ret, chunk)
+			} else {
+				for _, token := range pat.FindAllStringSubmatch(chunk, -1) {
+					ret = append(ret, token[0])
+				}
+			}
+		} else {
+			fmt.Printf("Empty chunk in string '%s'\n", s)
+		}
+	}
+	return ret
+}
+
+// Compile a string containing a plural form expression to a Expression object.
+func Compile(s string) (expr Expression, err error) {
+	if s == "0" {
+		return constValue{value: 0}, nil
+	}
+	if !strings.Contains(s, "?") {
+		s += "?1:0"
+	}
+	return compileExpression(s)
+}
+
+// Check if a token is in a slice of strings
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// Compiles an expression (ternary or constant)
+func compileExpression(s string) (expr Expression, err error) {
+	tokens := tokenize(s)
+	if contains(tokens, "?") {
+		return ternaryToken.compile(tokens)
+	}
+	return constToken.compile(tokens)
+}
+
+// Compiles a test (comparison)
+func compileTest(s string) (test test, err error) {
+	tokens := tokenize(s)
+	for _, tokenDef := range precedence {
+		if contains(tokens, tokenDef.op) {
+			return tokenDef.token.compile(tokens)
+		}
+	}
+	return test, errors.New("cannot compile")
+}
+
+func parseUint32(s string) (ui uint32, err error) {
+	i, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return ui, err
+	}
+	return uint32(i), nil
+}

--- a/vendor/github.com/leonelquinteros/gotext/plurals/expression.go
+++ b/vendor/github.com/leonelquinteros/gotext/plurals/expression.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package plurals
+
+// Expression is a plurals expression. Eval evaluates the expression for
+// a given n value. Use plurals.Compile to generate Expression instances.
+type Expression interface {
+	Eval(n uint32) int
+}
+
+type constValue struct {
+	value int
+}
+
+func (c constValue) Eval(n uint32) int {
+	return c.value
+}
+
+type test interface {
+	test(n uint32) bool
+}
+
+type ternary struct {
+	test      test
+	trueExpr  Expression
+	falseExpr Expression
+}
+
+func (t ternary) Eval(n uint32) int {
+	if t.test.test(n) {
+		if t.trueExpr == nil {
+			return -1
+		}
+		return t.trueExpr.Eval(n)
+	}
+	if t.falseExpr == nil {
+		return -1
+	}
+	return t.falseExpr.Eval(n)
+}

--- a/vendor/github.com/leonelquinteros/gotext/plurals/math.go
+++ b/vendor/github.com/leonelquinteros/gotext/plurals/math.go
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package plurals
+
+type math interface {
+	calc(n uint32) uint32
+}
+
+type mod struct {
+	value uint32
+}
+
+func (m mod) calc(n uint32) uint32 {
+	return n % m.value
+}

--- a/vendor/github.com/leonelquinteros/gotext/plurals/tests.go
+++ b/vendor/github.com/leonelquinteros/gotext/plurals/tests.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package plurals
+
+type equal struct {
+	value uint32
+}
+
+func (e equal) test(n uint32) bool {
+	return n == e.value
+}
+
+type notequal struct {
+	value uint32
+}
+
+func (e notequal) test(n uint32) bool {
+	return n != e.value
+}
+
+type gt struct {
+	value   uint32
+	flipped bool
+}
+
+func (e gt) test(n uint32) bool {
+	if e.flipped {
+		return e.value > n
+	} else {
+		return n > e.value
+	}
+}
+
+type lt struct {
+	value   uint32
+	flipped bool
+}
+
+func (e lt) test(n uint32) bool {
+	if e.flipped {
+		return e.value < n
+	}
+	return n < e.value
+}
+
+type gte struct {
+	value   uint32
+	flipped bool
+}
+
+func (e gte) test(n uint32) bool {
+	if e.flipped {
+		return e.value >= n
+	}
+	return n >= e.value
+}
+
+type lte struct {
+	value   uint32
+	flipped bool
+}
+
+func (e lte) test(n uint32) bool {
+	if e.flipped {
+		return e.value <= n
+	}
+	return n <= e.value
+}
+
+type and struct {
+	left  test
+	right test
+}
+
+func (e and) test(n uint32) bool {
+	if !e.left.test(n) {
+		return false
+	}
+	return e.right.test(n)
+}
+
+type or struct {
+	left  test
+	right test
+}
+
+func (e or) test(n uint32) bool {
+	if e.left.test(n) {
+		return true
+	}
+	return e.right.test(n)
+}
+
+type pipe struct {
+	modifier math
+	action   test
+}
+
+func (e pipe) test(n uint32) bool {
+	return e.action.test(e.modifier.calc(n))
+}

--- a/vendor/github.com/leonelquinteros/gotext/po.go
+++ b/vendor/github.com/leonelquinteros/gotext/po.go
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package gotext
+
+import (
+	"bufio"
+	"io/ioutil"
+	"net/textproto"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/leonelquinteros/gotext/plurals"
+)
+
+/*
+Po parses the content of any PO file and provides all the Translation functions needed.
+It's the base object used by all package methods.
+And it's safe for concurrent use by multiple goroutines by using the sync package for locking.
+
+Example:
+
+	import (
+		"fmt"
+		"github.com/leonelquinteros/gotext"
+	)
+
+	func main() {
+		// Create po object
+		po := gotext.NewPoTranslator()
+
+		// Parse .po file
+		po.ParseFile("/path/to/po/file/translations.po")
+
+		// Get Translation
+		fmt.Println(po.Get("Translate this"))
+	}
+
+*/
+type Po struct {
+	// Headers storage
+	Headers textproto.MIMEHeader
+
+	// Language header
+	Language string
+
+	// Plural-Forms header
+	PluralForms string
+
+	// Parsed Plural-Forms header values
+	nplurals    int
+	plural      string
+	pluralforms plurals.Expression
+
+	// Storage
+	translations map[string]*Translation
+	contexts     map[string]map[string]*Translation
+
+	// Sync Mutex
+	sync.RWMutex
+
+	// Parsing buffers
+	trBuffer  *Translation
+	ctxBuffer string
+}
+
+type parseState int
+
+const (
+	head parseState = iota
+	msgCtxt
+	msgID
+	msgIDPlural
+	msgStr
+)
+
+// NewPoTranslator creates a new Po object with the Translator interface
+func NewPoTranslator() Translator {
+	return new(Po)
+}
+
+// ParseFile tries to read the file by its provided path (f) and parse its content as a .po file.
+func (po *Po) ParseFile(f string) {
+	// Check if file exists
+	info, err := os.Stat(f)
+	if err != nil {
+		return
+	}
+
+	// Check that isn't a directory
+	if info.IsDir() {
+		return
+	}
+
+	// Parse file content
+	data, err := ioutil.ReadFile(f)
+	if err != nil {
+		return
+	}
+
+	po.Parse(data)
+}
+
+// Parse loads the translations specified in the provided string (str)
+func (po *Po) Parse(buf []byte) {
+	// Lock while parsing
+	po.Lock()
+
+	// Init storage
+	if po.translations == nil {
+		po.translations = make(map[string]*Translation)
+		po.contexts = make(map[string]map[string]*Translation)
+	}
+
+	// Get lines
+	lines := strings.Split(string(buf), "\n")
+
+	// Init buffer
+	po.trBuffer = NewTranslation()
+	po.ctxBuffer = ""
+
+	state := head
+	for _, l := range lines {
+		// Trim spaces
+		l = strings.TrimSpace(l)
+
+		// Skip invalid lines
+		if !po.isValidLine(l) {
+			continue
+		}
+
+		// Buffer context and continue
+		if strings.HasPrefix(l, "msgctxt") {
+			po.parseContext(l)
+			state = msgCtxt
+			continue
+		}
+
+		// Buffer msgid and continue
+		if strings.HasPrefix(l, "msgid") && !strings.HasPrefix(l, "msgid_plural") {
+			po.parseID(l)
+			state = msgID
+			continue
+		}
+
+		// Check for plural form
+		if strings.HasPrefix(l, "msgid_plural") {
+			po.parsePluralID(l)
+			state = msgIDPlural
+			continue
+		}
+
+		// Save Translation
+		if strings.HasPrefix(l, "msgstr") {
+			po.parseMessage(l)
+			state = msgStr
+			continue
+		}
+
+		// Multi line strings and headers
+		if strings.HasPrefix(l, "\"") && strings.HasSuffix(l, "\"") {
+			po.parseString(l, state)
+			continue
+		}
+	}
+
+	// Save last Translation buffer.
+	po.saveBuffer()
+
+	// Unlock to parse headers
+	po.Unlock()
+
+	// Parse headers
+	po.parseHeaders()
+}
+
+// saveBuffer takes the context and Translation buffers
+// and saves it on the translations collection
+func (po *Po) saveBuffer() {
+	// With no context...
+	if po.ctxBuffer == "" {
+		po.translations[po.trBuffer.ID] = po.trBuffer
+	} else {
+		// With context...
+		if _, ok := po.contexts[po.ctxBuffer]; !ok {
+			po.contexts[po.ctxBuffer] = make(map[string]*Translation)
+		}
+		po.contexts[po.ctxBuffer][po.trBuffer.ID] = po.trBuffer
+
+		// Cleanup current context buffer if needed
+		if po.trBuffer.ID != "" {
+			po.ctxBuffer = ""
+		}
+	}
+
+	// Flush Translation buffer
+	po.trBuffer = NewTranslation()
+}
+
+// parseContext takes a line starting with "msgctxt",
+// saves the current Translation buffer and creates a new context.
+func (po *Po) parseContext(l string) {
+	// Save current Translation buffer.
+	po.saveBuffer()
+
+	// Buffer context
+	po.ctxBuffer, _ = strconv.Unquote(strings.TrimSpace(strings.TrimPrefix(l, "msgctxt")))
+}
+
+// parseID takes a line starting with "msgid",
+// saves the current Translation and creates a new msgid buffer.
+func (po *Po) parseID(l string) {
+	// Save current Translation buffer.
+	po.saveBuffer()
+
+	// Set id
+	po.trBuffer.ID, _ = strconv.Unquote(strings.TrimSpace(strings.TrimPrefix(l, "msgid")))
+}
+
+// parsePluralID saves the plural id buffer from a line starting with "msgid_plural"
+func (po *Po) parsePluralID(l string) {
+	po.trBuffer.PluralID, _ = strconv.Unquote(strings.TrimSpace(strings.TrimPrefix(l, "msgid_plural")))
+}
+
+// parseMessage takes a line starting with "msgstr" and saves it into the current buffer.
+func (po *Po) parseMessage(l string) {
+	l = strings.TrimSpace(strings.TrimPrefix(l, "msgstr"))
+
+	// Check for indexed Translation forms
+	if strings.HasPrefix(l, "[") {
+		idx := strings.Index(l, "]")
+		if idx == -1 {
+			// Skip wrong index formatting
+			return
+		}
+
+		// Parse index
+		i, err := strconv.Atoi(l[1:idx])
+		if err != nil {
+			// Skip wrong index formatting
+			return
+		}
+
+		// Parse Translation string
+		po.trBuffer.Trs[i], _ = strconv.Unquote(strings.TrimSpace(l[idx+1:]))
+
+		// Loop
+		return
+	}
+
+	// Save single Translation form under 0 index
+	po.trBuffer.Trs[0], _ = strconv.Unquote(l)
+}
+
+// parseString takes a well formatted string without prefix
+// and creates headers or attach multi-line strings when corresponding
+func (po *Po) parseString(l string, state parseState) {
+	clean, _ := strconv.Unquote(l)
+
+	switch state {
+	case msgStr:
+		// Append to last Translation found
+		po.trBuffer.Trs[len(po.trBuffer.Trs)-1] += clean
+
+	case msgID:
+		// Multiline msgid - Append to current id
+		po.trBuffer.ID += clean
+
+	case msgIDPlural:
+		// Multiline msgid - Append to current id
+		po.trBuffer.PluralID += clean
+
+	case msgCtxt:
+		// Multiline context - Append to current context
+		po.ctxBuffer += clean
+
+	}
+}
+
+// isValidLine checks for line prefixes to detect valid syntax.
+func (po *Po) isValidLine(l string) bool {
+	// Check prefix
+	valid := []string{
+		"\"",
+		"msgctxt",
+		"msgid",
+		"msgid_plural",
+		"msgstr",
+	}
+
+	for _, v := range valid {
+		if strings.HasPrefix(l, v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseHeaders retrieves data from previously parsed headers
+func (po *Po) parseHeaders() {
+	// Make sure we end with 2 carriage returns.
+	raw := po.Get("") + "\n\n"
+
+	// Read
+	reader := bufio.NewReader(strings.NewReader(raw))
+	tp := textproto.NewReader(reader)
+
+	var err error
+
+	// Sync Headers write.
+	po.Lock()
+	defer po.Unlock()
+
+	po.Headers, err = tp.ReadMIMEHeader()
+	if err != nil {
+		return
+	}
+
+	// Get/save needed headers
+	po.Language = po.Headers.Get("Language")
+	po.PluralForms = po.Headers.Get("Plural-Forms")
+
+	// Parse Plural-Forms formula
+	if po.PluralForms == "" {
+		return
+	}
+
+	// Split plural form header value
+	pfs := strings.Split(po.PluralForms, ";")
+
+	// Parse values
+	for _, i := range pfs {
+		vs := strings.SplitN(i, "=", 2)
+		if len(vs) != 2 {
+			continue
+		}
+
+		switch strings.TrimSpace(vs[0]) {
+		case "nplurals":
+			po.nplurals, _ = strconv.Atoi(vs[1])
+
+		case "plural":
+			po.plural = vs[1]
+
+			if expr, err := plurals.Compile(po.plural); err == nil {
+				po.pluralforms = expr
+			}
+
+		}
+	}
+}
+
+// pluralForm calculates the plural form index corresponding to n.
+// Returns 0 on error
+func (po *Po) pluralForm(n int) int {
+	po.RLock()
+	defer po.RUnlock()
+
+	// Failure fallback
+	if po.pluralforms == nil {
+		/* Use the Germanic plural rule.  */
+		if n == 1 {
+			return 0
+		} else {
+			return 1
+		}
+	}
+	return po.pluralforms.Eval(uint32(n))
+}
+
+// Get retrieves the corresponding Translation for the given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (po *Po) Get(str string, vars ...interface{}) string {
+	// Sync read
+	po.RLock()
+	defer po.RUnlock()
+
+	if po.translations != nil {
+		if _, ok := po.translations[str]; ok {
+			return Printf(po.translations[str].Get(), vars...)
+		}
+	}
+
+	// Return the same we received by default
+	return Printf(str, vars...)
+}
+
+// GetN retrieves the (N)th plural form of Translation for the given string.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (po *Po) GetN(str, plural string, n int, vars ...interface{}) string {
+	// Sync read
+	po.RLock()
+	defer po.RUnlock()
+
+	if po.translations != nil {
+		if _, ok := po.translations[str]; ok {
+			return Printf(po.translations[str].GetN(po.pluralForm(n)), vars...)
+		}
+	}
+
+	if n == 1 {
+		return Printf(str, vars...)
+	}
+	return Printf(plural, vars...)
+}
+
+// GetC retrieves the corresponding Translation for a given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (po *Po) GetC(str, ctx string, vars ...interface{}) string {
+	// Sync read
+	po.RLock()
+	defer po.RUnlock()
+
+	if po.contexts != nil {
+		if _, ok := po.contexts[ctx]; ok {
+			if po.contexts[ctx] != nil {
+				if _, ok := po.contexts[ctx][str]; ok {
+					return Printf(po.contexts[ctx][str].Get(), vars...)
+				}
+			}
+		}
+	}
+
+	// Return the string we received by default
+	return Printf(str, vars...)
+}
+
+// GetNC retrieves the (N)th plural form of Translation for the given string in the given context.
+// Supports optional parameters (vars... interface{}) to be inserted on the formatted string using the fmt.Printf syntax.
+func (po *Po) GetNC(str, plural string, n int, ctx string, vars ...interface{}) string {
+	// Sync read
+	po.RLock()
+	defer po.RUnlock()
+
+	if po.contexts != nil {
+		if _, ok := po.contexts[ctx]; ok {
+			if po.contexts[ctx] != nil {
+				if _, ok := po.contexts[ctx][str]; ok {
+					return Printf(po.contexts[ctx][str].GetN(po.pluralForm(n)), vars...)
+				}
+			}
+		}
+	}
+
+	if n == 1 {
+		return Printf(str, vars...)
+	}
+	return Printf(plural, vars...)
+}

--- a/vendor/github.com/leonelquinteros/gotext/translation.go
+++ b/vendor/github.com/leonelquinteros/gotext/translation.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package gotext
+
+// Translation is the struct for the Translations parsed via Po or Mo files and all coming parsers
+type Translation struct {
+	ID       string
+	PluralID string
+	Trs      map[int]string
+}
+
+// NewTranslation returns the Translation object and initialized it.
+func NewTranslation() *Translation {
+	tr := new(Translation)
+	tr.Trs = make(map[int]string)
+
+	return tr
+}
+
+// Get returns the string of the translation
+func (t *Translation) Get() string {
+	// Look for Translation index 0
+	if _, ok := t.Trs[0]; ok {
+		if t.Trs[0] != "" {
+			return t.Trs[0]
+		}
+	}
+
+	// Return untranslated id by default
+	return t.ID
+}
+
+// Get returns the string of the plural translation
+func (t *Translation) GetN(n int) string {
+	// Look for Translation index
+	if _, ok := t.Trs[n]; ok {
+		if t.Trs[n] != "" {
+			return t.Trs[n]
+		}
+	}
+
+	// Return untranslated singular if corresponding
+	if n == 0 {
+		return t.ID
+	}
+
+	// Return untranslated plural by default
+	return t.PluralID
+}

--- a/vendor/github.com/leonelquinteros/gotext/translator.go
+++ b/vendor/github.com/leonelquinteros/gotext/translator.go
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 DeineAgentur UG https://www.deineagentur.com. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+package gotext
+
+type Translator interface {
+	ParseFile(f string)
+	Parse(buf []byte)
+	Get(str string, vars ...interface{}) string
+	GetN(str, plural string, n int, vars ...interface{}) string
+	GetC(str, ctx string, vars ...interface{}) string
+	GetNC(str, plural string, n int, ctx string, vars ...interface{}) string
+}


### PR DESCRIPTION
This is a working example of localization. This mostly focuses on the framework, no actual translation has been done.

The only string that has been translated is the warning to not run Yay as root. Even then it's not a real translation, just a dud for testing.

It should be noted that Yay looks for .mo files in its install prefix so running `make && ./yay` will not work. Instead you should install Yay `make PREFIX=/usr/local install` then use the installed binary.

![image](https://user-images.githubusercontent.com/16593899/38499168-a0faa040-3bfe-11e8-8d28-0103698c35eb.png)

TODO:
- [ ] Get a fully working template that includes all strings
- [x] Ignore things that should not be translated such as `http.Get()`