### PR TITLE
 Support flags when using the editor

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -261,6 +261,8 @@ func handleConfig(option, value string) bool {
 		config.BuildDir = value
 	case "editor":
 		config.Editor = value
+	case "editorflags":
+		config.EditorFlags = value
 	case "makepkg":
 		config.MakepkgBin = value
 	case "pacman":

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	alpm "github.com/jguer/go-alpm"
 )
@@ -28,6 +29,7 @@ const (
 type Configuration struct {
 	BuildDir      string `json:"buildDir"`
 	Editor        string `json:"editor"`
+	EditorFlags   string `json:"editorflags"`
 	MakepkgBin    string `json:"makepkgbin"`
 	PacmanBin     string `json:"pacmanbin"`
 	PacmanConf    string `json:"pacmanconf"`
@@ -131,6 +133,7 @@ func defaultSettings(config *Configuration) {
 	config.BuildDir = cacheHome + "/"
 	config.CleanAfter = false
 	config.Editor = ""
+	config.EditorFlags = ""
 	config.Devel = false
 	config.MakepkgBin = "makepkg"
 	config.NoConfirm = false
@@ -154,30 +157,32 @@ func defaultSettings(config *Configuration) {
 }
 
 // Editor returns the preferred system editor.
-func editor() string {
+func editor() (string, []string) {
 	switch {
 	case config.Editor != "":
 		editor, err := exec.LookPath(config.Editor)
 		if err != nil {
 			fmt.Println(err)
 		} else {
-			return editor
+			return editor, strings.Fields(config.EditorFlags)
 		}
 		fallthrough
 	case os.Getenv("EDITOR") != "":
-		editor, err := exec.LookPath(os.Getenv("EDITOR"))
+		editorArgs := strings.Fields(os.Getenv("EDITOR"))
+		editor, err := exec.LookPath(editorArgs[0])
 		if err != nil {
 			fmt.Println(err)
 		} else {
-			return editor
+			return editor, editorArgs[1:]
 		}
 		fallthrough
 	case os.Getenv("VISUAL") != "":
-		editor, err := exec.LookPath(os.Getenv("VISUAL"))
+		editorArgs := strings.Fields(os.Getenv("VISUAL"))
+		editor, err := exec.LookPath(editorArgs[0])
 		if err != nil {
 			fmt.Println(err)
 		} else {
-			return editor
+			return editor, editorArgs[1:]
 		}
 		fallthrough
 	default:
@@ -187,19 +192,20 @@ func editor() string {
 
 	editorLoop:
 		fmt.Print(green("Edit PKGBUILD with:"))
-		var editorInput string
-		_, err := fmt.Scanln(&editorInput)
+		editorInput, err := getInput("")
 		if err != nil {
 			fmt.Println(err)
 			goto editorLoop
 		}
 
-		editor, err := exec.LookPath(editorInput)
+		editorArgs := strings.Fields(editorInput)
+
+		editor, err := exec.LookPath(editorArgs[0])
 		if err != nil {
 			fmt.Println(err)
 			goto editorLoop
 		}
-		return editor
+		return editor, editorArgs[1:]
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -186,26 +186,27 @@ func editor() (string, []string) {
 		}
 		fallthrough
 	default:
-		fmt.Println(bold(red("Warning:")),
-			bold(magenta("$EDITOR")), "is not set")
-		fmt.Println("Please add $EDITOR or to your environment variables.")
+		fmt.Println()
+		fmt.Println(bold(red(arrow) + " Warning:"), cyan("$EDITOR"), "is not set")
+		fmt.Println(bold(arrow) + " Please add " + cyan("$EDITOR") + " or " + cyan("$VISUAL") + " to your environment variables.")
 
-	editorLoop:
-		fmt.Print(green("Edit PKGBUILD with:"))
-		editorInput, err := getInput("")
-		if err != nil {
-			fmt.Println(err)
-			goto editorLoop
+		for {
+			fmt.Print(green(bold(arrow)) + green(" Edit PKGBUILD with: "))
+			editorInput, err := getInput("")
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+
+			editorArgs := strings.Fields(editorInput)
+
+			editor, err := exec.LookPath(editorArgs[0])
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+			return editor, editorArgs[1:]
 		}
-
-		editorArgs := strings.Fields(editorInput)
-
-		editor, err := exec.LookPath(editorArgs[0])
-		if err != nil {
-			fmt.Println(err)
-			goto editorLoop
-		}
-		return editor, editorArgs[1:]
 	}
 }
 

--- a/install.go
+++ b/install.go
@@ -462,7 +462,9 @@ func editPkgBuilds(pkgs []*rpc.Pkg) error {
 		pkgbuilds = append(pkgbuilds, dir+"PKGBUILD")
 	}
 
-	editcmd := exec.Command(editor(), pkgbuilds...)
+	editor, editorArgs := editor()
+	editorArgs = append(editorArgs, pkgbuilds...)
+	editcmd := exec.Command(editor, editorArgs...)
 	editcmd.Stdin, editcmd.Stdout, editcmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	err := editcmd.Run()
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -433,6 +433,8 @@ func hasParam(arg string) bool {
 		return true
 	case "editor":
 		return true
+	case "editorflags":
+		return true
 	case "makepkg":
 		return true
 	case "pacman":


### PR DESCRIPTION
Added `--editorflags` alongside `--editor`
`$VISUAL` and `$EDITOR` are split on whitespace

Fixes #343