### PR TITLE
Don't mark repo upgrades as deps during sysupgrade

### DIFF
--- a/config.go
+++ b/config.go
@@ -187,7 +187,7 @@ func editor() (string, []string) {
 		fallthrough
 	default:
 		fmt.Println()
-		fmt.Println(bold(red(arrow) + " Warning:"), cyan("$EDITOR"), "is not set")
+		fmt.Println(bold(red(arrow)+" Warning:"), cyan("$EDITOR"), "is not set")
 		fmt.Println(bold(arrow) + " Please add " + cyan("$EDITOR") + " or " + cyan("$VISUAL") + " to your environment variables.")
 
 		for {


### PR DESCRIPTION
Before `yay -Syu` called `pacman -Sy <pkgs to upgrade>`
We then later switched to it calling `pacman -Syu` this lead to yay
seeing no targets to when it was upgrading a bunch of packages it
assumed they must be deps. Correct this by adding repo packages to the
targets list.

Also ensure we dont mark packages as dependencies if they are already
installed. For example we install `foo` which requires `bar>5` but we
only have `bar=4` installed. In this case installing `foo` will pull bar
in as a dependency but it should not be marked as such because it
already exists.