### PR TITLE
Remove duplicate cmd.Run()

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -156,11 +156,6 @@ func getCommit(url string, branch string, protocols []string) string {
 			continue
 		}
 
-		err = cmd.Run()
-		if err != nil {
-			continue
-		}
-
 		stdout := outbuf.String()
 		split := strings.Fields(stdout)
 


### PR DESCRIPTION
There was a duplicate cmd.Run() that somehow went unnoticed. It was also
missing an error check, so it was in the code but had no ill effects.
In 86bfacd the error check was added.
This caused it to fail every time sure to the cmd already being ran.

Remove the duplicate cmd.Run() altogether.