### PR TITLE
Use megacheck to lint project

### DIFF
--- a/download.go
+++ b/download.go
@@ -21,11 +21,7 @@ func shouldUseGit(path string) bool {
 	}
 
 	_, err = os.Stat(filepath.Join(path, ".git"))
-	if os.IsNotExist(err) {
-		return false
-	}
-
-	return true
+	return os.IsExist(err)
 }
 
 func downloadFile(path string, url string) (err error) {

--- a/keys_test.go
+++ b/keys_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -34,10 +35,6 @@ func init() {
 
 func newPkg(basename string) *rpc.Pkg {
 	return &rpc.Pkg{Name: basename, PackageBase: basename}
-}
-
-func newSplitPkg(basename, name string) *rpc.Pkg {
-	return &rpc.Pkg{Name: name, PackageBase: basename}
 }
 
 func getPgpKey(key string) string {
@@ -73,7 +70,7 @@ func TestImportKeys(t *testing.T) {
 	config.GpgFlags = fmt.Sprintf("--homedir %s --keyserver 127.0.0.1", keyringDir)
 
 	server := startPgpKeyServer()
-	defer server.Shutdown(nil)
+	defer server.Shutdown(context.TODO())
 
 	casetests := []struct {
 		keys      []string
@@ -138,7 +135,7 @@ func TestCheckPgpKeys(t *testing.T) {
 	config.GpgFlags = fmt.Sprintf("--homedir %s --keyserver 127.0.0.1", keyringDir)
 
 	server := startPgpKeyServer()
-	defer server.Shutdown(nil)
+	defer server.Shutdown(context.TODO())
 
 	casetests := []struct {
 		pkgs      []*rpc.Pkg

--- a/parser.go
+++ b/parser.go
@@ -220,7 +220,7 @@ func (parser *arguments) getArg(options ...string) (arg string, double bool, exi
 	existCount := 0
 
 	for _, option := range options {
-		arg, exists = parser.options[option]
+		_, exists = parser.options[option]
 
 		if exists {
 			existCount++
@@ -619,8 +619,8 @@ func (parser *arguments) parseCommandLine() (err error) {
 //of course the implementation is up to the caller, this function mearley parses
 //the input and organizes it
 func parseNumberMenu(input string) (intRanges, intRanges, stringSet, stringSet) {
-	include := make(intRanges, 0, 0)
-	exclude := make(intRanges, 0, 0)
+	include := make(intRanges, 0)
+	exclude := make(intRanges, 0)
 	otherInclude := make(stringSet)
 	otherExclude := make(stringSet)
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -19,7 +19,7 @@ func intRangesEqual(a, b intRanges) bool {
 		r1 := a[n]
 		r2 := b[n]
 
-		if r1.min != r1.min || r1.max != r2.max {
+		if r1.min != r2.min || r1.max != r2.max {
 			return false
 		}
 	}

--- a/print.go
+++ b/print.go
@@ -341,6 +341,10 @@ func printUpdateList(parser *arguments) error {
 	old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
 	_, _, localNames, remoteNames, err := filterPackages()
+	if err != nil {
+		return err
+	}
+
 	aurUp, repoUp, err := upList(warnings)
 	os.Stdout = old // restoring the real stdout
 	if err != nil {

--- a/query.go
+++ b/query.go
@@ -353,7 +353,7 @@ func hangingPackages(removeOptional bool) (hanging []string, err error) {
 
 	iterateAgain := true
 	processDependencies := func(pkg alpm.Package) error {
-		if state, _ := safePackages[pkg.Name()]; state == 0 || state == 2 {
+		if state := safePackages[pkg.Name()]; state == 0 || state == 2 {
 			return nil
 		}
 

--- a/upgrade.go
+++ b/upgrade.go
@@ -193,8 +193,8 @@ func upList(warnings *aurWarnings) (aurUp upSlice, repoUp upSlice, err error) {
 }
 
 func upDevel(remote []alpm.Package) (toUpgrade upSlice, err error) {
-	toUpdate := make([]alpm.Package, 0, 0)
-	toRemove := make([]string, 0, 0)
+	toUpdate := make([]alpm.Package, 0)
+	toRemove := make([]string, 0)
 
 	var mux1 sync.Mutex
 	var mux2 sync.Mutex

--- a/vcs.go
+++ b/vcs.go
@@ -205,10 +205,6 @@ func (infos shaInfos) needsUpdate() bool {
 	}
 }
 
-func inStore(pkgName string) shaInfos {
-	return savedInfo[pkgName]
-}
-
 func saveVCSInfo() error {
 	marshalledinfo, err := json.MarshalIndent(savedInfo, "", "\t")
 	if err != nil || string(marshalledinfo) == "null" {


### PR DESCRIPTION
Fixes
```
keys_test.go:76:24: do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use (SA1012)
keys_test.go:141:24: do not pass a nil Context, even if a function permits it; pass context.TODO if you are unsure about which Context to use (SA1012)
parser.go:223:3: this value of arg is never used (SA4006)
parser_test.go:22:6: identical expressions on the left and right side of the '!=' operator (SA4000)
print.go:343:33: this value of err is never used (SA4006)
download.go:24:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
parser.go:622:29: should use make(intRanges, 0) instead (S1019)
parser.go:623:29: should use make(intRanges, 0) instead (S1019)
query.go:356:6: should write state := safePackages[pkg.Name()] instead of state, _ := safePackages[pkg.Name()] (S1005)
upgrade.go:196:35: should use make([]alpm.Package, 0) instead (S1019)
upgrade.go:197:29: should use make([]string, 0) instead (S1019)
keys_test.go:39:6: func newSplitPkg is unused (U1000)
vcs.go:208:6: func inStore is unused (U1000)
```

@Morganamilo  `parser.go:223:3: this value of arg is never used (SA4006)` didn't go deep into this as I mostly close my eyes to parser issues (and laziness on this account may also contribute)  but could this be a problem?