### PR TITLE
Make upgrade output as table

### DIFF
--- a/print.go
+++ b/print.go
@@ -153,18 +153,33 @@ func formatPkgbase(pkg *rpc.Pkg, bases map[string][]*rpc.Pkg) string {
 	return str
 }
 
+func (u upgrade) StylizedNameWithRepository() string {
+	return bold(colourHash(u.Repository)) + "/" + bold(u.Name)
+}
+
 // Print prints the details of the packages to upgrade.
-func (u upSlice) Print(start int) {
+func (u upSlice) Print() {
+	longestName, longestVersion := 0, 0
+	for _, pack := range u {
+		packNameLen := len(pack.StylizedNameWithRepository())
+		version, _ := getVersionDiff(pack.LocalVersion, pack.RemoteVersion)
+		packVersionLen := len(version)
+		longestName = max(packNameLen, longestName)
+		longestVersion = max(packVersionLen, longestVersion)
+	}
+
+	namePadding := fmt.Sprintf("%%-%ds  ", longestName)
+	versionPadding := fmt.Sprintf("%%-%ds", longestVersion)
+	numberPadding := fmt.Sprintf("%%%dd  ", len(fmt.Sprintf("%v", len(u))))
+
 	for k, i := range u {
 		left, right := getVersionDiff(i.LocalVersion, i.RemoteVersion)
 
-		fmt.Print(magenta(fmt.Sprintf("%3d ", len(u)+start-k-1)))
-		fmt.Print(bold(colourHash(i.Repository)), "/", bold(i.Name))
+		fmt.Print(magenta(fmt.Sprintf(numberPadding, len(u)-k)))
 
-		w := 70 - len(i.Repository) - len(i.Name)
-		padding := fmt.Sprintf("%%%ds", w)
-		fmt.Printf(padding, left)
-		fmt.Printf(" -> %s\n", right)
+		fmt.Printf(namePadding, i.StylizedNameWithRepository())
+
+		fmt.Printf("%s -> %s\n", fmt.Sprintf(versionPadding, left), right)
 	}
 }
 

--- a/upgrade.go
+++ b/upgrade.go
@@ -305,15 +305,16 @@ func upgradePkgs(aurUp, repoUp upSlice) (stringSet, stringSet, error) {
 	ignore := make(stringSet)
 	aurNames := make(stringSet)
 
-	if len(aurUp)+len(repoUp) == 0 {
+	allUpLen := len(repoUp) + len(aurUp)
+	if allUpLen == 0 {
 		return ignore, aurNames, nil
 	}
 
 	sort.Sort(repoUp)
 	sort.Sort(aurUp)
-	fmt.Printf("%s"+bold(" %d ")+"%s\n", bold(cyan("::")), len(aurUp)+len(repoUp), bold("Packages to upgrade."))
-	repoUp.Print(len(aurUp) + 1)
-	aurUp.Print(1)
+	allUp := append(repoUp, aurUp...)
+	fmt.Printf("%s"+bold(" %d ")+"%s\n", bold(cyan("::")), allUpLen, bold("Packages to upgrade."))
+	allUp.Print()
 
 	fmt.Println(bold(green(arrow + " Packages to not upgrade: (eg: 1 2 3, 1-3, ^4 or repo name)")))
 	fmt.Print(bold(green(arrow + " ")))


### PR DESCRIPTION
I'm not sure, but it's hard for me to read versions changes far to the right.

And I don't much care about repositories for eyes jumping while reading package names.

Before:
![image](https://user-images.githubusercontent.com/6510020/39534023-3d549ddc-4e39-11e8-8320-f688ea2492b9.png)

After:
![image](https://user-images.githubusercontent.com/6510020/39534073-63d5f884-4e39-11e8-8fd9-75a36de996cf.png)

Without repository and name splitting (code not pushed, but can be):
![image](https://user-images.githubusercontent.com/6510020/39534383-21f87094-4e3a-11e8-80c7-1d2bd764bed6.png)

