### PR TITLE
Add the feed to sync 

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -320,7 +320,7 @@ func handlePrint() (err error) {
 	case cmdArgs.existsArg("u", "upgrades"):
 		err = printUpdateList(cmdArgs)
 	case cmdArgs.existsArg("w", "news"):
-		err = printNewsFeed()
+		err = printNewsFeed(false)
 	case cmdArgs.existsArg("c", "complete"):
 		switch {
 		case cmdArgs.existsArg("f", "fish"):

--- a/config.go
+++ b/config.go
@@ -48,12 +48,14 @@ type Configuration struct {
 	RequestSplitN int    `json:"requestsplitn"`
 	SearchMode    int    `json:"-"`
 	SortMode      int    `json:"sortmode"`
+	FeedLimit     int    `json:"feedlimit"`
 	SudoLoop      bool   `json:"sudoloop"`
 	TimeUpdate    bool   `json:"timeupdate"`
 	NoConfirm     bool   `json:"-"`
 	Devel         bool   `json:"devel"`
 	CleanAfter    bool   `json:"cleanAfter"`
 	GitClone      bool   `json:"gitclone"`
+	SyncFeed      bool   `json:"syncfeed"`
 }
 
 var version = "5.688"
@@ -131,6 +133,7 @@ func defaultSettings(config *Configuration) {
 	config.Editor = ""
 	config.EditorFlags = ""
 	config.Devel = false
+	config.FeedLimit = 30
 	config.MakepkgBin = "makepkg"
 	config.NoConfirm = false
 	config.PacmanBin = "pacman"
@@ -141,6 +144,7 @@ func defaultSettings(config *Configuration) {
 	config.SortMode = BottomUp
 	config.SortBy = "votes"
 	config.SudoLoop = false
+	config.SyncFeed = true
 	config.TarBin = "bsdtar"
 	config.GitBin = "git"
 	config.GpgBin = "gpg"

--- a/install.go
+++ b/install.go
@@ -152,9 +152,11 @@ func install(parser *arguments) error {
 		return nil
 	}
 
-	fmt.Println(bold(cyan("::")), "Arch Linux news feed")
-	printNewsFeed(true)
-	fmt.Println()
+	if config.SyncFeed {
+		fmt.Println(bold(cyan("::")), "Arch Linux news feed")
+		printNewsFeed(true)
+		fmt.Println()
+	}
 
 	if hasAur {
 		hasAur = len(dc.Aur) != 0

--- a/install.go
+++ b/install.go
@@ -152,6 +152,10 @@ func install(parser *arguments) error {
 		return nil
 	}
 
+	fmt.Println(bold(cyan("::")), "Arch Linux news feed")
+	printNewsFeed(true)
+	fmt.Println()
+
 	if hasAur {
 		hasAur = len(dc.Aur) != 0
 

--- a/install.go
+++ b/install.go
@@ -154,7 +154,10 @@ func install(parser *arguments) error {
 
 	if config.SyncFeed {
 		fmt.Println(bold(cyan("::")), "Arch Linux news feed")
-		printNewsFeed(true)
+		err = printNewsFeed(true)
+		if err != nil {
+			return err
+		}
 		fmt.Println()
 	}
 

--- a/print.go
+++ b/print.go
@@ -430,7 +430,7 @@ func printNewsFeed(lastMonthOnly bool) error {
 		return err
 	}
 	now := time.Now().In(loc).Unix()
-
+	printed := false
 	for _, item := range archrss.Channel.Item {
 		date, err := time.Parse(time.RFC1123Z, item.PubDate)
 		if err != nil {
@@ -444,6 +444,11 @@ func printNewsFeed(lastMonthOnly bool) error {
 		fd := formatTime(int(date.Unix()))
 
 		fmt.Println(magenta(fd), strings.TrimSpace(item.Title))
+		printed = true
+	}
+
+	if !printed {
+		fmt.Printf(magenta("No news in the last %v days.\n"), config.FeedLimit)
 	}
 
 	return nil

--- a/print.go
+++ b/print.go
@@ -437,7 +437,7 @@ func printNewsFeed(lastMonthOnly bool) error {
 			return err
 		}
 
-		if lastMonthOnly && (now-date.Unix()) >= 2592000 {
+		if lastMonthOnly && now-date.Unix() >= int64(config.FeedLimit)*86400 {
 			continue
 		}
 


### PR DESCRIPTION
#384 also asked for the feed to be printed during upgrades. The sync feed is limited to printing the last 30 days by default but it can be adjusted by users as well as completely disabled. 