### PR TITLE
 Print the descriptions of news item

### DIFF
--- a/print.go
+++ b/print.go
@@ -419,7 +419,13 @@ func (item Item) Print() error {
 
 	fd := formatTime(int(date.Unix()))
 
-	fmt.Println(magenta(fd), strings.TrimSpace(item.Title))
+	fmt.Println(bold(magenta(fd)), bold(strings.TrimSpace(item.Title)))
+	//fmt.Println(strings.TrimSpace(item.Link))
+
+	if !cmdArgs.existsArg("q", "quiet") {
+		desc := strings.TrimSpace(parseNews(item.Description))
+		fmt.Println(desc)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Print the full descriptions of each news item.

The description is formatted as html, basic parsing is done to display
it properly. -q/--quiet can be used to display title only.

Respect bottomup for -Pw

//cc @PeachIceTea 

@Jguer You asked for the news struct to be collapsed on the last PR, here it is extended again so that the Item struct could have its own `Print()` function.