### PR TITLE
Fix -Sc sometimes cleaning split packages

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -138,7 +138,7 @@ func cleanAUR(keepInstalled, keepCurrent, removeAll bool) error {
 	}
 
 	for _, pkg := range remotePackages {
-		installedBases.set(pkg.Name())
+		installedBases.set(pkg.Base())
 	}
 
 	for _, file := range files {


### PR DESCRIPTION
If a split package was installed and there was no package that matched
the name of the package base Yay would remove it even though there could
be other packages installed under that base but with a different name.

Now only clean a package if there are no installed packages under the
packagebase.

fixes #389