### PR TITLE
Implement c29a80 properly

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -138,7 +138,11 @@ func cleanAUR(keepInstalled, keepCurrent, removeAll bool) error {
 	}
 
 	for _, pkg := range remotePackages {
-		installedBases.set(pkg.Base())
+		if pkg.Base() != "" {
+			installedBases.set(pkg.Base())
+		} else {
+			installedBases.set(pkg.Name())
+		}
 	}
 
 	for _, file := range files {


### PR DESCRIPTION
It seems the pkgbase is null for installed packages that are not part of
a split package. It was priviously assumed that if a package was not
part of a split package, pkgbase == pkgname would always be true.

Instead try to use pkgbase and if it does not exist fall back to
pkgname.