### PR TITLE
Fix --ignore flag while skipping updates

### DIFF
--- a/install.go
+++ b/install.go
@@ -114,7 +114,13 @@ func install(parser *arguments) error {
 			requestTargets = append(requestTargets, up)
 		}
 
-		arguments.addParam("ignore", strings.Join(ignore.toSlice(), ","))
+		value, _, exists := cmdArgs.getArg("ignore")
+		ignoreStr := strings.Join(ignore.toSlice(), ",")
+		if exists {
+			ignoreStr += "," + value
+		}
+
+		arguments.options["ignore"] = ignoreStr
 		fmt.Println()
 
 		for pkg := range aurUp {


### PR DESCRIPTION
If --ignore was specified on the command line and the user skips
packages using the number menu, packages would not be properly skipped
because they the manual --ignore would overide the --ignore from the
menu.

Now correctly combine both --ignore flags into a single combined flag
when passing to pacman.