### PR TITLE
Fixes #417

### DIFF
--- a/install.go
+++ b/install.go
@@ -565,7 +565,7 @@ func downloadPkgBuilds(pkgs []*rpc.Pkg, targets stringSet, bases map[string][]*r
 		if shouldUseGit(filepath.Join(config.BuildDir, pkg.PackageBase)) {
 			err = gitDownload(baseURL+"/"+pkg.PackageBase+".git", config.BuildDir, pkg.PackageBase)
 		} else {
-			err = downloadAndUnpack(baseURL+pkg.URLPath, config.BuildDir, false)
+			err = downloadAndUnpack(baseURL+pkg.URLPath, config.BuildDir)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
- Ports `-G` to current state of imports
- Moves ABS logic away from a simple download and unpack utility
- Use `$CacheHome` to store downloaded archives and delete it in the end
- Uniform messages in `-G`
- Extra checks to avoid similar problems or directory clobbering