### PR TITLE
Exit code 1 when packages are missing from -Si and -G

### DIFF
--- a/download.go
+++ b/download.go
@@ -181,10 +181,6 @@ func getPkgbuildsfromAUR(pkgs []string, dir string) (err error) {
 		return err
 	}
 
-	if (len(aq) != len(pkgs)) {
-		return fmt.Errorf("Could not find all required packages");
-	}
-
 	for _, pkg := range aq {
 		var err error
 		if shouldUseGit(filepath.Join(dir, pkg.PackageBase)) {
@@ -198,6 +194,10 @@ func getPkgbuildsfromAUR(pkgs []string, dir string) (err error) {
 		} else {
 			fmt.Println(bold(yellow(arrow)), "Downloaded", cyan(pkg.PackageBase), "from AUR")
 		}
+	}
+
+	if len(aq) != len(pkgs) {
+		return fmt.Errorf("Could not find all required packages")
 	}
 
 	return

--- a/download.go
+++ b/download.go
@@ -181,6 +181,10 @@ func getPkgbuildsfromAUR(pkgs []string, dir string) (err error) {
 		return err
 	}
 
+	if (len(aq) != len(pkgs)) {
+		return fmt.Errorf("Could not find all required packages");
+	}
+
 	for _, pkg := range aq {
 		var err error
 		if shouldUseGit(filepath.Join(dir, pkg.PackageBase)) {

--- a/query.go
+++ b/query.go
@@ -214,10 +214,14 @@ func syncInfo(pkgS []string) (err error) {
 		}
 	}
 
-	if len(aurS) != 0 {
+	if len(info) != 0 {
 		for _, pkg := range info {
 			PrintInfo(pkg)
 		}
+	}
+
+	if len(aurS) != len(info) {
+		return fmt.Errorf("Could not find all required packages")
 	}
 
 	return


### PR DESCRIPTION
Fix #430 

Mainly for scripting purposes
`yay` will do everything it was instructed to packages that do exist but will return an exit code 1 in the end if there are missing packages.

Example:
```
$ yay -G gi-zsh-completion fwdf 0bin-git eewe
:: Querying AUR...
 -> Missing AUR Packages:  eewe  fwdf
Could not find all required packages
Exit code: 1
```