### PR TITLE
Support any PKGDEST and PKGEXT

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
-	"path/filepath"
-	"strings"
 	"unicode"
 )
 
@@ -57,25 +54,6 @@ func (mss mapStringSet) Add(n string, v string) {
 		mss[n] = make(stringSet)
 	}
 	mss[n].set(v)
-}
-
-func completeFileName(dir, name string) (string, error) {
-	files, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return "", err
-	}
-
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		if strings.HasPrefix(file.Name(), name) {
-			return filepath.Join(dir, file.Name()), nil
-		}
-	}
-
-	return "", nil
 }
 
 func lessRunes(iRunes, jRunes []rune) bool {


### PR DESCRIPTION
Pacman 5.1 removes the symlink to the current directory for built
packages. This causes Yay to break for people who have set an external
PKGDEST.

Pacman 5.1 also brings an improved --packagelist option. This makes
it much simpler to find where packages will be placed. Hence this fix
also simplifies the code.

Yay has an -Sc option to clear it's cache. If using an external PKGDEST
this is now mostly useful for clearing out old pkgbuilds and sources.
paccache should be used for cleaning build packages.

Fixes #434 