### PR TITLE
Support --aur and --repo flags

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -300,6 +300,10 @@ func handleConfig(option, value string) bool {
 		config.Provides = true
 	case "noprovides":
 		config.Provides = false
+	case "a", "aur":
+		mode = ModeAUR
+	case "repo":
+		mode = ModeRepo
 	default:
 		return false
 	}

--- a/config.go
+++ b/config.go
@@ -25,6 +25,14 @@ const (
 	TopDown
 )
 
+type targetMode int
+
+const (
+	ModeAUR targetMode = iota
+	ModeRepo
+	ModeAny
+)
+
 // Configuration stores yay's config.
 type Configuration struct {
 	BuildDir      string `json:"buildDir"`
@@ -97,6 +105,9 @@ var alpmConf alpm.PacmanConfig
 
 // AlpmHandle is the alpm handle used by yay.
 var alpmHandle *alpm.Handle
+
+// Mode is used to restrict yay to AUR or repo only modes
+var mode targetMode = ModeAny
 
 func readAlpmConfig(pacmanconf string) (conf alpm.PacmanConfig, err error) {
 	file, err := os.Open(pacmanconf)

--- a/depPool.go
+++ b/depPool.go
@@ -101,9 +101,14 @@ func (dp *depPool) ResolveTargets(pkgs []string) error {
 		var singleDb *alpm.Db
 
 		// aur/ prefix means we only check the aur
-		if target.Db == "aur" {
+		if target.Db == "aur" || (target.Db == "" && mode == ModeAUR) {
 			dp.Targets = append(dp.Targets, target)
 			aurTargets.set(target.DepString())
+			continue
+		}
+
+		if mode == ModeAUR {
+			dp.Targets = append(dp.Targets, target)
 			continue
 		}
 
@@ -151,7 +156,7 @@ func (dp *depPool) ResolveTargets(pkgs []string) error {
 		dp.Targets = append(dp.Targets, target)
 	}
 
-	if len(aurTargets) > 0 {
+	if len(aurTargets) > 0 && (mode == ModeAny || mode == ModeAUR) {
 		return dp.resolveAURPackages(aurTargets, true)
 	}
 

--- a/install.go
+++ b/install.go
@@ -49,6 +49,10 @@ func install(parser *arguments) error {
 	arguments.op = "S"
 	arguments.targets = make(stringSet)
 
+	if mode == ModeAUR {
+		arguments.delArg("u", "sysupgrade")
+	}
+
 	//if we are doing -u also request all packages needing update
 	if parser.existsArg("u", "sysupgrade") {
 		aurUp, repoUp, err = upList(warnings)
@@ -125,7 +129,7 @@ func install(parser *arguments) error {
 		arguments.addTarget(pkg)
 	}
 
-	if len(do.Aur) == 0 && len(arguments.targets) == 0 && !parser.existsArg("u", "sysupgrade") {
+	if len(do.Aur) == 0 && len(arguments.targets) == 0 && (!parser.existsArg("u", "sysupgrade") || mode == ModeAUR) {
 		fmt.Println("There is nothing to do")
 		return nil
 	}

--- a/query.go
+++ b/query.go
@@ -220,8 +220,8 @@ func syncInfo(pkgS []string) (err error) {
 		}
 	}
 
-	if len(aurS) != len(info) {
-		return fmt.Errorf("Could not find all required packages")
+	if len(repoS)+len(aurS) != len(pkgS) {
+		return fmt.Errorf("Could not find all packages")
 	}
 
 	return
@@ -288,10 +288,14 @@ func packageSlices(toCheck []string) (aur []string, repo []string, err error) {
 		db, name := splitDbFromName(_pkg)
 		found := false
 
-		if db == "aur" {
+		if db == "aur" || (mode == ModeAUR && db != "") {
+			continue
+		}
+
+		if db == "aur" || (mode == ModeAUR && db == "") {
 			aur = append(aur, _pkg)
 			continue
-		} else if db != "" {
+		} else if db != "" || mode == ModeRepo {
 			repo = append(repo, _pkg)
 			continue
 		}

--- a/upgrade.go
+++ b/upgrade.go
@@ -140,27 +140,31 @@ func upList(warnings *aurWarnings) (aurUp upSlice, repoUp upSlice, err error) {
 
 	pkgdata := make(map[string]*rpc.Pkg)
 
-	fmt.Println(bold(cyan("::") + bold(" Searching databases for updates...")))
-	wg.Add(1)
-	go func() {
-		repoUp, repoErr = upRepo(local)
-		wg.Done()
-	}()
-
-	fmt.Println(bold(cyan("::") + bold(" Searching AUR for updates...")))
-	wg.Add(1)
-	go func() {
-		aurUp, aurErr = upAUR(remote, remoteNames, pkgdata, warnings)
-		wg.Done()
-	}()
-
-	if config.Devel {
-		fmt.Println(bold(cyan("::") + bold(" Checking development packages...")))
+	if mode == ModeAny || mode == ModeRepo {
+		fmt.Println(bold(cyan("::") + bold(" Searching databases for updates...")))
 		wg.Add(1)
 		go func() {
-			develUp, develErr = upDevel(remote)
+			repoUp, repoErr = upRepo(local)
 			wg.Done()
 		}()
+	}
+
+	if mode == ModeAny || mode == ModeAUR {
+		fmt.Println(bold(cyan("::") + bold(" Searching AUR for updates...")))
+		wg.Add(1)
+		go func() {
+			aurUp, aurErr = upAUR(remote, remoteNames, pkgdata, warnings)
+			wg.Done()
+		}()
+
+		if config.Devel {
+			fmt.Println(bold(cyan("::") + bold(" Checking development packages...")))
+			wg.Add(1)
+			go func() {
+				develUp, develErr = upDevel(remote)
+				wg.Done()
+			}()
+		}
 	}
 
 	wg.Wait()


### PR DESCRIPTION
These flags limit operations to only check the repos or only check the
AUR. These flags apply to -S, -Si and -Su.

-a may also be used as a short option for --aur. --repo has no short
option as -r is taken.

Finally closes #74 and its duplicate #311 