### PR TITLE
Add config option for pgp key fetching

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -300,6 +300,10 @@ func handleConfig(option, value string) bool {
 		config.Provides = true
 	case "noprovides":
 		config.Provides = false
+	case "pgpfetch":
+		config.PGPFetch = true
+	case "nopgpfetch":
+		config.PGPFetch = false
 	case "a", "aur":
 		mode = ModeAUR
 	case "repo":

--- a/config.go
+++ b/config.go
@@ -63,6 +63,7 @@ type Configuration struct {
 	CleanAfter    bool   `json:"cleanAfter"`
 	GitClone      bool   `json:"gitclone"`
 	Provides      bool   `json:"provides"`
+	PGPFetch      bool   `json:"pgpfetch"`
 }
 
 var version = "5.688"
@@ -146,6 +147,7 @@ func defaultSettings(config *Configuration) {
 	config.MakepkgBin = "makepkg"
 	config.NoConfirm = false
 	config.PacmanBin = "pacman"
+	config.PGPFetch = true
 	config.PacmanConf = "/etc/pacman.conf"
 	config.GpgFlags = ""
 	config.MFlags = ""

--- a/install.go
+++ b/install.go
@@ -183,9 +183,11 @@ func install(parser *arguments) error {
 			return err
 		}
 
-		err = checkPgpKeys(do.Aur, do.Bases, srcinfosStale)
-		if err != nil {
-			return err
+		if config.PGPFetch {
+			err = checkPgpKeys(do.Aur, do.Bases, srcinfosStale)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
You can now do something along the lines of `yay -S libc++ --nopgpfetch --mflags --skippgpcheck`. Quite a lot to write, but I wouldn't recommend it anyway.

Fixes #439 