### PR TITLE
Implement diffs for pkgbuild viewing.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -304,6 +304,10 @@ func handleConfig(option, value string) bool {
 		config.PGPFetch = true
 	case "nopgpfetch":
 		config.PGPFetch = false
+	case "showdiffs":
+		config.ShowDiffs = true
+	case "noshowdiffs":
+		config.ShowDiffs = false
 	case "a", "aur":
 		mode = ModeAUR
 	case "repo":
@@ -603,7 +607,6 @@ func passToMakepkgCapture(dir string, args ...string) (string, string, error) {
 	args = append(args, mflags...)
 
 	cmd := exec.Command(config.MakepkgBin, args...)
-	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	cmd.Dir = dir
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
@@ -629,4 +632,23 @@ func passToGit(dir string, _args ...string) (err error) {
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	err = cmd.Run()
 	return
+}
+
+func passToGitCapture(dir string, _args ...string) (string, string, error) {
+	var outbuf, errbuf bytes.Buffer
+	gitflags := strings.Fields(config.GitFlags)
+	args := []string{"-C", dir}
+	args = append(args, gitflags...)
+	args = append(args, _args...)
+
+	cmd := exec.Command(config.GitBin, args...)
+	cmd.Dir = dir
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+
+	err := cmd.Run()
+	stdout := outbuf.String()
+	stderr := errbuf.String()
+
+	return stdout, stderr, err
 }

--- a/config.go
+++ b/config.go
@@ -64,6 +64,7 @@ type Configuration struct {
 	GitClone      bool   `json:"gitclone"`
 	Provides      bool   `json:"provides"`
 	PGPFetch      bool   `json:"pgpfetch"`
+	ShowDiffs     bool   `json:"showdifs"`
 }
 
 var version = "5.688"
@@ -167,6 +168,7 @@ func defaultSettings(config *Configuration) {
 	config.AnswerUpgrade = ""
 	config.GitClone = true
 	config.Provides = true
+	config.ShowDiffs = true
 }
 
 // Editor returns the preferred system editor.

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,8 @@ import (
 	"unicode"
 )
 
+const gitEmptyTree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
 type mapStringSet map[string]stringSet
 
 type intRange struct {


### PR DESCRIPTION
diff viewing can be toggled via --[no]showdiffs. When enabled diffs will
be shown for packages between the current HEAD and upstream's HEAD.
Packages downloaded via tarballs will just have their pkgbuilds printed.

git diff is used to show diffs. Therefore the pager for diffs can be
shown via the PAGER and GIT_PAGER enviroment variables.

Fixes #131 after all this time.