### PR TITLE
Disable git terminal prompt

### DIFF
--- a/download.go
+++ b/download.go
@@ -149,7 +149,7 @@ func getPkgbuilds(pkgs []string) error {
 }
 
 // GetPkgbuild downloads pkgbuild from the ABS.
-func getPkgbuildsfromABS(pkgs []string, path string) (missing bool,err error) {
+func getPkgbuildsfromABS(pkgs []string, path string) (missing bool, err error) {
 	dbList, err := alpmHandle.SyncDbs()
 	if err != nil {
 		return

--- a/vcs.go
+++ b/vcs.go
@@ -136,6 +136,7 @@ func getCommit(url string, branch string, protocols []string) string {
 
 		cmd := exec.Command(config.GitBin, "ls-remote", protocol+"://"+url, branch)
 		cmd.Stdout = &outbuf
+		cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 
 		err := cmd.Start()
 		if err != nil {


### PR DESCRIPTION
This allows requests that want authentication to fail instantly and
silently. Rather than delying the program and printing to the terminal.

Fixes #451 