### PR TITLE
Stop prepare running twice

### DIFF
--- a/install.go
+++ b/install.go
@@ -597,7 +597,7 @@ func buildInstallPkgBuilds(dp *depPool, do *depOrder, srcinfos map[string]*gopkg
 
 		srcinfo := srcinfos[pkg.PackageBase]
 
-		args := []string{"--nobuild", "-fCc"}
+		args := []string{"--nobuild", "-fC"}
 
 		if incompatible.get(pkg.PackageBase) {
 			args = append(args, "--ignorearch")
@@ -636,7 +636,7 @@ func buildInstallPkgBuilds(dp *depPool, do *depOrder, srcinfos map[string]*gopkg
 			fmt.Println(bold(yellow(arrow)),
 				cyan(pkg.Name+"-"+pkg.Version)+bold(" Already made -- skipping build"))
 		} else {
-			args := []string{"-Ccf", "--noconfirm"}
+			args := []string{"-cf", "--noconfirm", "--noextract", "--noprepare", "--holdver"}
 
 			if incompatible.get(pkg.PackageBase) {
 				args = append(args, "--ignorearch")


### PR DESCRIPTION
Prepare ends up getting ran twice every time we install a package,
theres not problems with doing so apart from a little inefficiency.

Previously the install flow would be like this:
	downlod sources + verify
	prepare + pkgver bump
	full build (prepare included)

Now on the last point pass no extract to use the srcdir from the
previous command and pass noprepare and holdver because we allready did
these steps previously.