### PR TITLE
Use slices for targets instead of stringsets

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -369,22 +369,21 @@ func handleYay() (err error) {
 }
 
 func handleGetpkgbuild() (err error) {
-	err = getPkgbuilds(cmdArgs.formatTargets())
+	err = getPkgbuilds(cmdArgs.targets)
 	return
 }
 
 func handleYogurt() (err error) {
 	options := cmdArgs.formatArgs()
-	targets := cmdArgs.formatTargets()
 
 	config.SearchMode = NumberMenu
-	err = numberMenu(targets, options)
+	err = numberMenu(cmdArgs.targets, options)
 
 	return
 }
 
 func handleSync() (err error) {
-	targets := cmdArgs.formatTargets()
+	targets := cmdArgs.targets
 
 	if cmdArgs.existsArg("y", "refresh") {
 		arguments := cmdArgs.copy()
@@ -393,7 +392,7 @@ func handleSync() (err error) {
 		arguments.delArg("s", "search")
 		arguments.delArg("i", "info")
 		arguments.delArg("l", "list")
-		arguments.targets = make(stringSet)
+		arguments.clearTargets()
 		err = passToPacman(arguments)
 		if err != nil {
 			return
@@ -426,7 +425,7 @@ func handleSync() (err error) {
 }
 
 func handleRemove() (err error) {
-	removeVCSPackage(cmdArgs.formatTargets())
+	removeVCSPackage(cmdArgs.targets)
 	err = passToPacman(cmdArgs)
 	return
 }
@@ -531,7 +530,7 @@ func passToPacman(args *arguments) error {
 
 	argArr = append(argArr, "--")
 
-	argArr = append(argArr, args.formatTargets()...)
+	argArr = append(argArr, args.targets...)
 
 	cmd = exec.Command(argArr[0], argArr[1:]...)
 
@@ -563,7 +562,7 @@ func passToPacmanCapture(args *arguments) (string, string, error) {
 
 	argArr = append(argArr, "--")
 
-	argArr = append(argArr, args.formatTargets()...)
+	argArr = append(argArr, args.targets...)
 
 	cmd = exec.Command(argArr[0], argArr[1:]...)
 	cmd.Stdout = &outbuf

--- a/install.go
+++ b/install.go
@@ -15,7 +15,6 @@ import (
 
 // Install handles package installs
 func install(parser *arguments) error {
-	requestTargets := parser.targets.toSlice()
 	var err error
 	var incompatible stringSet
 	var do *depOrder
@@ -25,6 +24,7 @@ func install(parser *arguments) error {
 	var aurUp upSlice
 	var repoUp upSlice
 
+	requestTargets := parser.copy().targets
 	warnings := &aurWarnings{}
 
 	removeMake := false
@@ -47,7 +47,7 @@ func install(parser *arguments) error {
 	arguments.delArg("asdeps", "asdep")
 	arguments.delArg("asexplicit", "asexp")
 	arguments.op = "S"
-	arguments.targets = make(stringSet)
+	arguments.clearTargets()
 
 	if mode == ModeAUR {
 		arguments.delArg("u", "sysupgrade")
@@ -94,6 +94,8 @@ func install(parser *arguments) error {
 			parser.addTarget(pkg)
 		}
 	}
+
+	targets := sliceToStringSet(parser.targets)
 
 	dp, err := getDepPool(requestTargets, warnings)
 	if err != nil {
@@ -153,7 +155,7 @@ func install(parser *arguments) error {
 
 		cleanBuilds(toClean)
 
-		oldHashes, err := downloadPkgBuilds(do.Aur, parser.targets, do.Bases)
+		oldHashes, err := downloadPkgBuilds(do.Aur, targets, do.Bases)
 		if err != nil {
 			return err
 		}
@@ -724,7 +726,7 @@ func buildInstallPkgBuilds(dp *depPool, do *depOrder, srcinfos map[string]*gopkg
 		}
 
 		arguments := parser.copy()
-		arguments.targets = make(stringSet)
+		arguments.clearTargets()
 		arguments.op = "U"
 		arguments.delArg("confirm")
 		arguments.delArg("c", "clean")

--- a/parser.go
+++ b/parser.go
@@ -72,7 +72,7 @@ type arguments struct {
 	options map[string]string
 	globals map[string]string
 	doubles stringSet // Tracks args passed twice such as -yy and -dd
-	targets stringSet
+	targets []string
 }
 
 func makeArguments() *arguments {
@@ -81,7 +81,7 @@ func makeArguments() *arguments {
 		make(map[string]string),
 		make(map[string]string),
 		make(stringSet),
-		make(stringSet),
+		make([]string, 0),
 	}
 }
 
@@ -98,9 +98,8 @@ func (parser *arguments) copy() (cp *arguments) {
 		cp.globals[k] = v
 	}
 
-	for k, v := range parser.targets {
-		cp.targets[k] = v
-	}
+	cp.targets = make([]string, len(parser.targets))
+	copy(cp.targets, parser.targets)
 
 	for k, v := range parser.doubles {
 		cp.doubles[k] = v
@@ -268,15 +267,11 @@ func (parser *arguments) getArg(options ...string) (arg string, double bool, exi
 }
 
 func (parser *arguments) addTarget(targets ...string) {
-	for _, target := range targets {
-		parser.targets[target] = struct{}{}
-	}
+	parser.targets = append(parser.targets, targets...)
 }
 
-func (parser *arguments) delTarget(targets ...string) {
-	for _, target := range targets {
-		delete(parser.targets, target)
-	}
+func (parser *arguments) clearTargets() {
+	parser.targets = make([]string, 0)
 }
 
 // Multiple args acts as an OR operator
@@ -289,14 +284,6 @@ func (parser *arguments) existsDouble(options ...string) bool {
 	}
 
 	return false
-}
-
-func (parser *arguments) formatTargets() (args []string) {
-	for target := range parser.targets {
-		args = append(args, target)
-	}
-
-	return
 }
 
 func (parser *arguments) formatArgs() (args []string) {

--- a/print.go
+++ b/print.go
@@ -363,6 +363,7 @@ func printNumberOfUpdates() error {
 
 //TODO: Make it less hacky
 func printUpdateList(parser *arguments) error {
+	targets := sliceToStringSet(parser.targets)
 	warnings := &aurWarnings{}
 	old := os.Stdout // keep backup of the real stdout
 	os.Stdout = nil
@@ -377,22 +378,22 @@ func printUpdateList(parser *arguments) error {
 		return err
 	}
 
-	noTargets := len(parser.targets) == 0
+	noTargets := len(targets) == 0
 
 	if !parser.existsArg("m", "foreign") {
 		for _, pkg := range repoUp {
-			if noTargets || parser.targets.get(pkg.Name) {
+			if noTargets || targets.get(pkg.Name) {
 				fmt.Printf("%s %s -> %s\n", bold(pkg.Name), green(pkg.LocalVersion), green(pkg.RemoteVersion))
-				delete(parser.targets, pkg.Name)
+				delete(targets, pkg.Name)
 			}
 		}
 	}
 
 	if !parser.existsArg("n", "native") {
 		for _, pkg := range aurUp {
-			if noTargets || parser.targets.get(pkg.Name) {
+			if noTargets || targets.get(pkg.Name) {
 				fmt.Printf("%s %s -> %s\n", bold(pkg.Name), green(pkg.LocalVersion), green(pkg.RemoteVersion))
-				delete(parser.targets, pkg.Name)
+				delete(targets, pkg.Name)
 			}
 		}
 	}
@@ -400,7 +401,7 @@ func printUpdateList(parser *arguments) error {
 	missing := false
 
 outer:
-	for pkg := range parser.targets {
+	for pkg := range targets {
 		for _, name := range localNames {
 			if name == pkg {
 				continue outer

--- a/query.go
+++ b/query.go
@@ -209,7 +209,8 @@ func syncInfo(pkgS []string) (err error) {
 	// Repo always goes first
 	if len(repoS) != 0 {
 		arguments := cmdArgs.copy()
-		arguments.delTarget(aurS...)
+		arguments.clearTargets()
+		arguments.addTarget(repoS...)
 		err = passToPacman(arguments)
 
 		if err != nil {


### PR DESCRIPTION
The order of targets does somewhat matter. For example doing something
like 'pacman -S db1/foo db2/foo' should cause the second package to be
skipped.

The order of targets also effects in which order they are resolved. This
should make errors more reproducable if any ever occur.