### PR TITLE
Fix failing tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,30 +13,30 @@ import (
 func setPaths() error {
 	if _configHome, set := os.LookupEnv("XDG_CONFIG_HOME"); set {
 		if _configHome == "" {
-			fmt.Errorf("XDG_CONFIG_HOME set but empty")
+			return fmt.Errorf("XDG_CONFIG_HOME set but empty")
 		}
 		configHome = filepath.Join(_configHome, "yay")
 	} else if _configHome, set := os.LookupEnv("HOME"); set {
 		if _configHome == "" {
-			fmt.Errorf("HOME set but empty")
+			return fmt.Errorf("HOME set but empty")
 		}
 		configHome = filepath.Join(_configHome, ".config/yay")
 	} else {
-		fmt.Errorf("XDG_CONFIG_HOME and HOME unset")
+		return fmt.Errorf("XDG_CONFIG_HOME and HOME unset")
 	}
 
 	if _cacheHome, set := os.LookupEnv("XDG_CACHE_HOME"); set {
 		if _cacheHome == "" {
-			fmt.Errorf("XDG_CACHE_HOME set but empty")
+			return fmt.Errorf("XDG_CACHE_HOME set but empty")
 		}
 		cacheHome = filepath.Join(_cacheHome, "yay")
 	} else if _cacheHome, set := os.LookupEnv("HOME"); set {
 		if _cacheHome == "" {
-			fmt.Errorf("XDG_CACHE_HOME set but empty")
+			return fmt.Errorf("XDG_CACHE_HOME set but empty")
 		}
 		cacheHome = filepath.Join(_cacheHome, ".cache/yay")
 	} else {
-		fmt.Errorf("XDG_CACHE_HOME and HOME unset")
+		return fmt.Errorf("XDG_CACHE_HOME and HOME unset")
 	}
 
 	configFile = filepath.Join(configHome, configFileName)


### PR DESCRIPTION
There were several calls to fmt.Errorf in setPaths where the returned error was not
being used. This was indicated by ```make test``` as shown here:

```
make test
gofmt -l *.go
go vet
./main.go:16: result of fmt.Errorf call not used
./main.go:21: result of fmt.Errorf call not used
./main.go:25: result of fmt.Errorf call not used
./main.go:30: result of fmt.Errorf call not used
./main.go:35: result of fmt.Errorf call not used
./main.go:39: result of fmt.Errorf call not used
make: *** [Makefile:43: test] Error 2
```

With these changes the tests now all pass with no errors.