### PR TITLE
Run yay as root but build as nobody

### DIFF
--- a/install.go
+++ b/install.go
@@ -114,9 +114,9 @@ func install(parser *arguments) error {
 
 	hasAur := len(dp.Aur) > 0
 
-	if hasAur && 0 == os.Geteuid() {
-		return fmt.Errorf(bold(red(arrow)) + " Refusing to install AUR Packages as root, Aborting.")
-	}
+	// if hasAur && 0 == os.Geteuid() {
+	// 	return fmt.Errorf(bold(red(arrow)) + " Refusing to install AUR Packages as root, Aborting.")
+	// }
 
 	do = getDepOrder(dp)
 	if err != nil {


### PR DESCRIPTION
Hey @Jguer / @Morganamilo,

I have been attempting to get yay to run as root and then switch to the nobody user to build packages but have hit a small speed bump and was wondering if I could borrow your eyes?

I believe I am almost there as it seems to be able to build the initial package you specify as nobody but it the package has unsatisfied AUR dependencies these seem to still be being built as root and I am unsure why at the moment.

Could you take a look? (I am still looking but not seeing it at the moment).

Thanks,

Alan Jenkins