### PR TITLE
 Show diffs before merging

### DIFF
--- a/download.go
+++ b/download.go
@@ -44,13 +44,22 @@ func downloadFile(path string, url string) (err error) {
 	return err
 }
 
-func gitGetHash(path string, name string) (string, error) {
+func gitHasDiff(path string, name string) (bool, error) {
 	stdout, stderr, err := passToGitCapture(filepath.Join(path, name), "rev-parse", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("%s%s", stderr, err)
+		return false, fmt.Errorf("%s%s", stderr, err)
 	}
 
-	return strings.TrimSpace(stdout), nil
+	head := strings.TrimSpace(stdout)
+
+	stdout, stderr, err = passToGitCapture(filepath.Join(path, name), "rev-parse", "HEAD@{upstream}")
+	if err != nil {
+		return false, fmt.Errorf("%s%s", stderr, err)
+	}
+
+	upstream := strings.TrimSpace(stdout)
+
+	return head != upstream, nil
 }
 
 func gitDownload(url string, path string, name string) error {

--- a/download.go
+++ b/download.go
@@ -71,7 +71,11 @@ func gitDownload(url string, path string, name string) error {
 		return fmt.Errorf("error fetching %s", name)
 	}
 
-	err = passToGit(filepath.Join(path, name), "reset", "--hard", "HEAD")
+	return nil
+}
+
+func gitMerge(url string, path string, name string) error {
+	err := passToGit(filepath.Join(path, name), "reset", "--hard", "HEAD")
 	if err != nil {
 		return fmt.Errorf("error resetting %s", name)
 	}

--- a/download.go
+++ b/download.go
@@ -62,25 +62,25 @@ func gitHasDiff(path string, name string) (bool, error) {
 	return head != upstream, nil
 }
 
-func gitDownload(url string, path string, name string) error {
+func gitDownload(url string, path string, name string) (bool, error) {
 	_, err := os.Stat(filepath.Join(path, name, ".git"))
 	if os.IsNotExist(err) {
 		err = passToGit(path, "clone", url, name)
 		if err != nil {
-			return fmt.Errorf("error cloning %s", name)
+			return false, fmt.Errorf("error cloning %s", name)
 		}
 
-		return nil
+		return true, nil
 	} else if err != nil {
-		return fmt.Errorf("error reading %s", filepath.Join(path, name, ".git"))
+		return false, fmt.Errorf("error reading %s", filepath.Join(path, name, ".git"))
 	}
 
 	err = passToGit(filepath.Join(path, name), "fetch")
 	if err != nil {
-		return fmt.Errorf("error fetching %s", name)
+		return false, fmt.Errorf("error fetching %s", name)
 	}
 
-	return nil
+	return false, nil
 }
 
 func gitMerge(url string, path string, name string) error {
@@ -248,7 +248,7 @@ func getPkgbuildsfromAUR(pkgs []string, dir string) (bool, error) {
 		}
 
 		if shouldUseGit(filepath.Join(dir, pkg.PackageBase)) {
-			err = gitDownload(baseURL+"/"+pkg.PackageBase+".git", dir, pkg.PackageBase)
+			_, err = gitDownload(baseURL+"/"+pkg.PackageBase+".git", dir, pkg.PackageBase)
 		} else {
 			err = downloadAndUnpack(baseURL+aq[0].URLPath, dir)
 		}

--- a/install.go
+++ b/install.go
@@ -636,10 +636,16 @@ func downloadPkgBuilds(pkgs []*rpc.Pkg, targets stringSet, bases map[string][]*r
 
 		var err error
 		if shouldUseGit(filepath.Join(config.BuildDir, pkg.PackageBase)) {
-			err = gitDownload(baseURL+"/"+pkg.PackageBase+".git", config.BuildDir, pkg.PackageBase)
+			err = gitDownload(baseURL + "/" + pkg.PackageBase + ".git", config.BuildDir, pkg.PackageBase)
 			if err != nil {
 				return hashes, err
 			}
+
+			err = gitMerge(baseURL + "/" + pkg.PackageBase + ".git", config.BuildDir, pkg.PackageBase)
+			if err != nil {
+				return hashes, err
+			}
+
 		} else {
 			err = downloadAndUnpack(baseURL+pkg.URLPath, config.BuildDir)
 		}

--- a/install.go
+++ b/install.go
@@ -160,7 +160,7 @@ func install(parser *arguments) error {
 		if err != nil {
 			return err
 		}
-	
+
 		if len(toEdit) > 0 {
 			if config.ShowDiffs {
 				err = showPkgBuildDiffs(toEdit, do.Bases)
@@ -183,7 +183,6 @@ func install(parser *arguments) error {
 		if err != nil {
 			return err
 		}
-
 
 		//initial srcinfo parse before pkgver() bump
 		err = parseSRCINFOFiles(do.Aur, srcinfosStale, do.Bases)
@@ -621,7 +620,7 @@ func pkgBuildsToSkip(pkgs []*rpc.Pkg, targets stringSet) stringSet {
 func mergePkgBuilds(pkgs []*rpc.Pkg) error {
 	for _, pkg := range pkgs {
 		if shouldUseGit(filepath.Join(config.BuildDir, pkg.PackageBase)) {
-			err := gitMerge(baseURL + "/" + pkg.PackageBase + ".git", config.BuildDir, pkg.PackageBase)
+			err := gitMerge(baseURL+"/"+pkg.PackageBase+".git", config.BuildDir, pkg.PackageBase)
 			if err != nil {
 				return err
 			}
@@ -630,7 +629,6 @@ func mergePkgBuilds(pkgs []*rpc.Pkg) error {
 
 	return nil
 }
-
 
 func downloadPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg, toSkip stringSet) error {
 	for k, pkg := range pkgs {
@@ -645,7 +643,7 @@ func downloadPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg, toSkip stri
 		fmt.Printf(str, k+1, len(pkgs), cyan(formatPkgbase(pkg, bases)))
 
 		if shouldUseGit(filepath.Join(config.BuildDir, pkg.PackageBase)) {
-			err := gitDownload(baseURL + "/" + pkg.PackageBase + ".git", config.BuildDir, pkg.PackageBase)
+			err := gitDownload(baseURL+"/"+pkg.PackageBase+".git", config.BuildDir, pkg.PackageBase)
 			if err != nil {
 				return err
 			}

--- a/install.go
+++ b/install.go
@@ -155,7 +155,8 @@ func install(parser *arguments) error {
 
 		cleanBuilds(toClean)
 
-		oldHashes, err := downloadPkgBuilds(do.Aur, targets, do.Bases)
+		toSkip := pkgBuildsToSkip(do.Aur, targets)
+		oldHashes, err := downloadPkgBuilds(do.Aur, do.Bases, toSkip)
 		if err != nil {
 			return err
 		}
@@ -593,9 +594,8 @@ func tryParsesrcinfosFile(pkgs []*rpc.Pkg, srcinfos map[string]*gopkg.PKGBUILD, 
 	}
 }
 
-func downloadPkgBuilds(pkgs []*rpc.Pkg, targets stringSet, bases map[string][]*rpc.Pkg) (map[string]string, error) {
+func pkgBuildsToSkip(pkgs []*rpc.Pkg, targets stringSet) stringSet {
 	toSkip := make(stringSet)
-	hashes := make(map[string]string)
 
 	for _, pkg := range pkgs {
 		if config.ReDownload == "no" || (config.ReDownload == "yes" && !targets.get(pkg.Name)) {
@@ -613,6 +613,12 @@ func downloadPkgBuilds(pkgs []*rpc.Pkg, targets stringSet, bases map[string][]*r
 			}
 		}
 	}
+
+	return toSkip
+}
+
+func downloadPkgBuilds(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg, toSkip stringSet) (map[string]string, error) {
+	hashes := make(map[string]string)
 
 	for k, pkg := range pkgs {
 		if shouldUseGit(filepath.Join(config.BuildDir, pkg.PackageBase)) {

--- a/vcs.go
+++ b/vcs.go
@@ -43,7 +43,8 @@ func createDevelDB() error {
 
 	bases := getBases(infoMap)
 
-	downloadPkgBuilds(info, sliceToStringSet(remoteNames), bases)
+	toSkip := pkgBuildsToSkip(info, sliceToStringSet(remoteNames))
+	downloadPkgBuilds(info, bases, toSkip)
 	tryParsesrcinfosFile(info, srcinfosStale, bases)
 
 	for _, pkg := range info {


### PR DESCRIPTION
This is what e3776c..66041a has been leading up to. Git fetch will be
called on all pkgbuilds, then the user is offered a chance to view the
diffs. If they choose to continue, merging happens. This allows users to
abort the install after viewing diffs and still be able to see thoes
diffs again if they try to install later on.

This also makes the git stuff a little more modular which should help in
organising diff showing + pkgbuild editing.