### PR TITLE
Rework editing and diff showing

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -313,10 +313,18 @@ func handleConfig(option, value string) bool {
 		config.PGPFetch = true
 	case "nopgpfetch":
 		config.PGPFetch = false
-	case "showdiffs":
-		config.ShowDiffs = true
-	case "noshowdiffs":
-		config.ShowDiffs = false
+	case "cleanmenu":
+		config.CleanMenu = true
+	case "nocleanmenu":
+		config.CleanMenu = false
+	case "diffmenu":
+		config.DiffMenu = true
+	case "nodiffmenu":
+		config.DiffMenu = false
+	case "editmenu":
+		config.EditMenu = true
+	case "noeditmenu":
+		config.EditMenu = false
 	case "a", "aur":
 		mode = ModeAUR
 	case "repo":

--- a/config.go
+++ b/config.go
@@ -65,6 +65,9 @@ type Configuration struct {
 	Provides      bool   `json:"provides"`
 	PGPFetch      bool   `json:"pgpfetch"`
 	ShowDiffs     bool   `json:"showdifs"`
+	CleanMenu     bool   `json:"cleanmenu"`
+	DiffMenu      bool   `json:"diffmenu"`
+	EditMenu      bool   `json:"editmenu"`
 }
 
 var version = "5.688"
@@ -168,7 +171,9 @@ func defaultSettings(config *Configuration) {
 	config.AnswerUpgrade = ""
 	config.GitClone = true
 	config.Provides = true
-	config.ShowDiffs = true
+	config.CleanMenu = false
+	config.DiffMenu = true
+	config.EditMenu = false
 }
 
 // Editor returns the preferred system editor.


### PR DESCRIPTION
Clean build needs to happen before downloading pkgbuilds so that they
can be deletd before downloading.

Editing and diff viewing needs to happen after downloading the
pkgbuilds.

Prevously we asked to clean and edit at the same time. Then clean,
download pkgbuilds and open the editor.

This poeses a problem for diff viewing and editing. It's likley that the
user will see the diff and use that to decide if they want to edit the
pkgbuild. Using the current method, the user will be asked to view diffs
and edit before actually seeing any diffs.

Instead split cleaning diff showing and editing to three seperate menus
in the following order:
 1. show clean menu
 2. clean
 3. download pkgbuilds
 4. show diff menu
 5. show diffs
 6. show edit menu
 7. edit pkgbuilds

Also each menu is seperatly enableable. By default only the diff menu is
shows. If the user wishes to clean build, edit pkgbuilds or disable
diffs then the user can use the --[no]{clean,diff,edit}menu flags. This
replaces the --[no]showdiffs flags.

@Jguer tell me how you like this approach.