### PR TITLE
Enable clean menu by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -171,7 +171,7 @@ func defaultSettings(config *Configuration) {
 	config.AnswerUpgrade = ""
 	config.GitClone = true
 	config.Provides = true
-	config.CleanMenu = false
+	config.CleanMenu = true
 	config.DiffMenu = true
 	config.EditMenu = false
 }


### PR DESCRIPTION
I swear set this to true before merging 8430c41 but apparently I didnt.