### PR TITLE
Remove default usage of --ask

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -341,6 +341,10 @@ func handleConfig(option, value string) bool {
 		config.EditMenu = true
 	case "noeditmenu":
 		config.EditMenu = false
+	case "useask":
+		config.UseAsk = true
+	case "nouseask":
+		config.UseAsk = false
 	case "a", "aur":
 		mode = ModeAUR
 	case "repo":

--- a/config.go
+++ b/config.go
@@ -69,6 +69,7 @@ type Configuration struct {
 	CleanMenu     bool   `json:"cleanmenu"`
 	DiffMenu      bool   `json:"diffmenu"`
 	EditMenu      bool   `json:"editmenu"`
+	UseAsk      bool   `json:"useask"`
 }
 
 var version = "7.885"
@@ -177,6 +178,7 @@ func defaultSettings(config *Configuration) {
 	config.CleanMenu = true
 	config.DiffMenu = true
 	config.EditMenu = false
+	config.UseAsk = false
 }
 
 // Editor returns the preferred system editor.

--- a/depCheck.go
+++ b/depCheck.go
@@ -124,7 +124,7 @@ func (dp *depPool) checkReverseConflicts(conflicts mapStringSet) {
 	})
 }
 
-func (dp *depPool) CheckConflicts() error {
+func (dp *depPool) CheckConflicts() (mapStringSet, error) {
 	var wg sync.WaitGroup
 	innerConflicts := make(mapStringSet)
 	conflicts := make(mapStringSet)
@@ -159,12 +159,17 @@ func (dp *depPool) CheckConflicts() error {
 			fmt.Println(str)
 		}
 
-		return fmt.Errorf("Unresolvable package conflicts, aborting")
+		return nil, fmt.Errorf("Unresolvable package conflicts, aborting")
 	}
 
 	if len(conflicts) != 0 {
 		fmt.Println()
 		fmt.Println(bold(red(arrow)), bold("Package conflicts found:"))
+
+		if !config.UseAsk {
+			fmt.Println(bold(red(arrow)), bold("You will have to confirm these when installing"))
+		}
+
 		for name, pkgs := range conflicts {
 			str := red(bold(smallArrow)) + " Installing " + cyan(name) + " will remove:"
 			for pkg := range pkgs {
@@ -178,7 +183,7 @@ func (dp *depPool) CheckConflicts() error {
 		fmt.Println()
 	}
 
-	return nil
+	return conflicts, nil
 }
 
 type missing struct {


### PR DESCRIPTION
--ask is no longer used when installing AUR packages, instead pass no
confirm when we know there are no conflicts and wait for manual
confirmation when there are.

This means that when there are no conflicts there should be no change in
behaviour and the user will not need to intervene at all.

The old behaviour can still be used with --useask.

fixes #490 