### PR TITLE
Separate Pacman upgrade and AUR Upgrade by default

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -345,6 +345,10 @@ func handleConfig(option, value string) bool {
 		config.UseAsk = true
 	case "nouseask":
 		config.UseAsk = false
+	case "combinedupgrade":
+		config.CombinedUpgrade = true
+	case "nocombinedupgrade":
+		config.CombinedUpgrade = false
 	case "a", "aur":
 		mode = ModeAUR
 	case "repo":

--- a/config.go
+++ b/config.go
@@ -35,41 +35,42 @@ const (
 
 // Configuration stores yay's config.
 type Configuration struct {
-	BuildDir      string `json:"buildDir"`
-	Editor        string `json:"editor"`
-	EditorFlags   string `json:"editorflags"`
-	MakepkgBin    string `json:"makepkgbin"`
-	PacmanBin     string `json:"pacmanbin"`
-	PacmanConf    string `json:"pacmanconf"`
-	TarBin        string `json:"tarbin"`
-	ReDownload    string `json:"redownload"`
-	ReBuild       string `json:"rebuild"`
-	AnswerClean   string `json:"answerclean"`
-	AnswerDiff    string `json:"answerdiff"`
-	AnswerEdit    string `json:"answeredit"`
-	AnswerUpgrade string `json:"answerupgrade"`
-	GitBin        string `json:"gitbin"`
-	GpgBin        string `json:"gpgbin"`
-	GpgFlags      string `json:"gpgflags"`
-	MFlags        string `json:"mflags"`
-	SortBy        string `json:"sortby"`
-	GitFlags      string `json:"gitflags"`
-	RequestSplitN int    `json:"requestsplitn"`
-	SearchMode    int    `json:"-"`
-	SortMode      int    `json:"sortmode"`
-	SudoLoop      bool   `json:"sudoloop"`
-	TimeUpdate    bool   `json:"timeupdate"`
-	NoConfirm     bool   `json:"-"`
-	Devel         bool   `json:"devel"`
-	CleanAfter    bool   `json:"cleanAfter"`
-	GitClone      bool   `json:"gitclone"`
-	Provides      bool   `json:"provides"`
-	PGPFetch      bool   `json:"pgpfetch"`
-	UpgradeMenu   bool   `json:"upgrademenu"`
-	CleanMenu     bool   `json:"cleanmenu"`
-	DiffMenu      bool   `json:"diffmenu"`
-	EditMenu      bool   `json:"editmenu"`
-	UseAsk      bool   `json:"useask"`
+	BuildDir        string `json:"buildDir"`
+	Editor          string `json:"editor"`
+	EditorFlags     string `json:"editorflags"`
+	MakepkgBin      string `json:"makepkgbin"`
+	PacmanBin       string `json:"pacmanbin"`
+	PacmanConf      string `json:"pacmanconf"`
+	TarBin          string `json:"tarbin"`
+	ReDownload      string `json:"redownload"`
+	ReBuild         string `json:"rebuild"`
+	AnswerClean     string `json:"answerclean"`
+	AnswerDiff      string `json:"answerdiff"`
+	AnswerEdit      string `json:"answeredit"`
+	AnswerUpgrade   string `json:"answerupgrade"`
+	GitBin          string `json:"gitbin"`
+	GpgBin          string `json:"gpgbin"`
+	GpgFlags        string `json:"gpgflags"`
+	MFlags          string `json:"mflags"`
+	SortBy          string `json:"sortby"`
+	GitFlags        string `json:"gitflags"`
+	RequestSplitN   int    `json:"requestsplitn"`
+	SearchMode      int    `json:"-"`
+	SortMode        int    `json:"sortmode"`
+	SudoLoop        bool   `json:"sudoloop"`
+	TimeUpdate      bool   `json:"timeupdate"`
+	NoConfirm       bool   `json:"-"`
+	Devel           bool   `json:"devel"`
+	CleanAfter      bool   `json:"cleanAfter"`
+	GitClone        bool   `json:"gitclone"`
+	Provides        bool   `json:"provides"`
+	PGPFetch        bool   `json:"pgpfetch"`
+	UpgradeMenu     bool   `json:"upgrademenu"`
+	CleanMenu       bool   `json:"cleanmenu"`
+	DiffMenu        bool   `json:"diffmenu"`
+	EditMenu        bool   `json:"editmenu"`
+	CombinedUpgrade bool   `json:"combinedupgrade"`
+	UseAsk          bool   `json:"useask"`
 }
 
 var version = "7.885"
@@ -179,6 +180,7 @@ func defaultSettings(config *Configuration) {
 	config.DiffMenu = true
 	config.EditMenu = false
 	config.UseAsk = false
+	config.CombinedUpgrade = false
 }
 
 // Editor returns the preferred system editor.

--- a/main.go
+++ b/main.go
@@ -159,9 +159,8 @@ func initAlpm() (err error) {
 		alpmConf.GPGDir = value
 	}
 
-	alpmHandle, err = alpmConf.CreateHandle()
+	err = initAlpmHandle()
 	if err != nil {
-		err = fmt.Errorf("Unable to CreateHandle: %s", err)
 		return
 	}
 
@@ -174,8 +173,24 @@ func initAlpm() (err error) {
 		useColor = alpmConf.Options&alpm.ConfColor > 0
 	}
 
-	alpmHandle.SetQuestionCallback(questionCallback)
+	return
+}
 
+func initAlpmHandle() (err error) {
+	if alpmHandle != nil {
+		err = alpmHandle.Release()
+		if err != nil {
+			return err
+		}
+	}
+
+	alpmHandle, err = alpmConf.CreateHandle()
+	if err != nil {
+		err = fmt.Errorf("Unable to CreateHandle: %s", err)
+		return
+	}
+
+	alpmHandle.SetQuestionCallback(questionCallback)
 	return
 }
 


### PR DESCRIPTION
Currently When performing a system upgrade, Yay will first refresh the
database then perform the repo and AUR upgrade. This allows Yay to add
some features such as better batch interaction, showing potential
dependency problems before the upgrade starts and combined menus
showing AUR and repo upgrades together.

There has been discussion that this approach is a bad idea. The main issue
people have is that the separation of the database refresh and the upgrade
could lead to a partial upgrade if Yay fails between the two stages.

Personally I do not like this argument, there are valid reasons to Yay
to fail between these points. For example there may be dependency or
conflict issues during the AUR upgrade. Yay can detect these before any
installing actually starts and exit, just like how pacman will when
there are dependency problems.

If Yay does fail between these points, for the previously mentioned
reasons or even a crash then a simple refresh will not cause a
partial upgrade by itself. It is then the user's responsibility
to either resolve these issues or instead perform an upgrade using
pacman directly.

My opinions aside, The discussions on the Arch wiki has reached
a decision, this method is not recommended. So to follow the decided
best practises this behaviour has been disabled by default.

This behaviour can be toggled using the --[no]combinedupgrade flag

It should be noted that Yay's upgrade menu will not show repo packages
unless --combinedupgrade is used.