### PR TITLE
run pacman -Qk(k) as root

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -136,6 +136,9 @@ func (parser *arguments) needRoot() bool {
 		}
 		return false
 	case "Q", "query":
+		if parser.existsArg("k", "check") {
+			return true
+		}
 		return false
 	case "R", "remove":
 		return true


### PR DESCRIPTION
running the "k" commands as root ensures the right permissions on reading the files of the packages and avoid warnings about missing files

fixes #525