### PR TITLE
Also remove -u when not doing combined upgrade

### DIFF
--- a/install.go
+++ b/install.go
@@ -160,6 +160,10 @@ func install(parser *arguments) error {
 	}
 
 	if len(dp.Aur) == 0 {
+		if !config.CombinedUpgrade {
+			return nil
+		}
+
 		parser.op = "S"
 		parser.delArg("y", "refresh")
 		parser.options["ignore"] = arguments.options["ignore"]
@@ -292,6 +296,10 @@ func install(parser *arguments) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if !config.CombinedUpgrade {
+		arguments.delArg("u", "sysupgrade")
 	}
 
 	if len(arguments.targets) > 0 || arguments.existsArg("u") {


### PR DESCRIPTION
When not doing combined upgrade we do pacman -Syu early. So there is no
need to use -u when installing repo dependencies of AUR packages.