### PR TITLE
Support source URLs that contain ?

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -97,6 +97,8 @@ func parseSource(source string) (url string, branch string, protocols []string) 
 		branch = "HEAD"
 	}
 
+	url = strings.Split(url, "?")[0]
+
 	return
 }
 


### PR DESCRIPTION
Since pacman 5.1 makepkg supports  ? to signal some stuffg in
a similar way to #. Cut this out so URLs with ? no longer fail.