### PR TITLE
Support source URLs that contain ? again

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -98,6 +98,7 @@ func parseSource(source string) (url string, branch string, protocols []string) 
 	}
 
 	url = strings.Split(url, "?")[0]
+	branch = strings.Split(branch, "?")[0]
 
 	return
 }


### PR DESCRIPTION
Turns out the query part of a source url can be dirrectly after the URL
or after the # fragment. So the branch needs to be stripped too.