### PR TITLE
Add config option to enable or disable AUR completions

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -105,6 +105,9 @@ Permanent configuration options:
     --timeupdate          Check packages' AUR page for changes during sysupgrade
     --notimeupdate        Do not check packages' AUR page for changes
 
+    --completeaur         Include AUR packages in completions
+    --nocompleteaur       Do not include AUR packages in completions
+
 Print specific options:
     -c --complete         Used for completions
     -d --defaultconfig    Print default yay configuration
@@ -353,6 +356,10 @@ func handleConfig(option, value string) bool {
 		config.CombinedUpgrade = true
 	case "nocombinedupgrade":
 		config.CombinedUpgrade = false
+	case "completeaur":
+		config.CompleteAUR = true
+	case "nocompleteaur":
+		config.CompleteAUR = false
 	case "a", "aur":
 		mode = ModeAUR
 	case "repo":

--- a/completions.go
+++ b/completions.go
@@ -120,9 +120,11 @@ func complete(shell string) error {
 	}
 
 	// AUR
-	err = completePart(shell, path_aur, true)
-	if err != nil {
-		return err
+	if config.CompleteAUR {
+		err = completePart(shell, path_aur, true)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/completions.go
+++ b/completions.go
@@ -63,17 +63,11 @@ func createRepoList(out *os.File, shell string) (err error) {
 	return nil
 }
 
-// Complete provides completion info for shells
-func complete(shell string) error {
-	var path string
-
-	if shell == "fish" {
-		path = filepath.Join(cacheHome, "aur_fish"+".cache")
-	} else {
-		path = filepath.Join(cacheHome, "aur_sh"+".cache")
-	}
+// Generates aur or repo completion cache file
+func completePart(shell string, path string, aur bool) error {
 	info, err := os.Stat(path)
 
+	// Cache is old or missing. Generate and print
 	if os.IsNotExist(err) || time.Since(info.ModTime()).Hours() > 48 {
 		os.MkdirAll(filepath.Dir(path), 0755)
 		out, errf := os.Create(path)
@@ -81,15 +75,19 @@ func complete(shell string) error {
 			return errf
 		}
 
-		if createAURList(out, shell) != nil {
+		var erra error
+		if aur {
+			erra = createAURList(out, shell)
+		} else {
+			erra = createRepoList(out, shell)
+		}
+		out.Close()
+		if erra != nil {
 			defer os.Remove(path)
 		}
-		erra := createRepoList(out, shell)
-
-		out.Close()
 		return erra
 	}
-
+	// Cache is good. Open and print
 	in, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
@@ -98,4 +96,34 @@ func complete(shell string) error {
 
 	_, err = io.Copy(os.Stdout, in)
 	return err
+}
+
+// Complete provides completion info for shells
+func complete(shell string) error {
+	var path_aur string
+	var path_repo string
+
+	var err error
+
+	if shell == "fish" {
+		path_aur = filepath.Join(cacheHome, "aur_fish"+".cache")
+		path_repo = filepath.Join(cacheHome, "repo_fish"+".cache")
+	} else {
+		path_aur = filepath.Join(cacheHome, "aur_sh"+".cache")
+		path_repo = filepath.Join(cacheHome, "repo_sh"+".cache")
+	}
+
+	// Repo
+	err = completePart(shell, path_repo, false)
+	if err != nil {
+		return err
+	}
+
+	// AUR
+	err = completePart(shell, path_aur, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -71,6 +71,7 @@ type Configuration struct {
 	EditMenu        bool   `json:"editmenu"`
 	CombinedUpgrade bool   `json:"combinedupgrade"`
 	UseAsk          bool   `json:"useask"`
+	CompleteAUR     bool   `json:"completeaur"`
 }
 
 var version = "7.885"
@@ -181,6 +182,7 @@ func defaultSettings(config *Configuration) {
 	config.EditMenu = false
 	config.UseAsk = false
 	config.CombinedUpgrade = false
+	config.CompleteAUR = true
 }
 
 // Editor returns the preferred system editor.


### PR DESCRIPTION
Personally, I find the initial delay when it's building the cache annoying and the extra clutter makes it harder to find the repo package I'm looking for. So let's add an option to disable it!

Two parts to this pull request:
1) Split the cache file into separate aur and repo caches
2) Add a config option to disable aur completions