### PR TITLE
Make output more similar to `pacman`s

### DIFF
--- a/install.go
+++ b/install.go
@@ -106,8 +106,6 @@ func install(parser *arguments) error {
 			arguments.options["ignore"] = ignoreStr
 		}
 
-		fmt.Println()
-
 		for pkg := range aurUp {
 			parser.addTarget(pkg)
 		}
@@ -127,7 +125,7 @@ func install(parser *arguments) error {
 
 	if len(dp.Aur) == 0 {
 		if !config.CombinedUpgrade {
-			fmt.Println("There is nothing to do")
+			fmt.Println(" there is nothing to do")
 			return nil
 		}
 
@@ -160,7 +158,7 @@ func install(parser *arguments) error {
 	}
 
 	if len(do.Aur) == 0 && len(arguments.targets) == 0 && (!parser.existsArg("u", "sysupgrade") || mode == ModeAUR) {
-		fmt.Println("There is nothing to do")
+		fmt.Println(" there is nothing to do")
 		return nil
 	}
 


### PR DESCRIPTION
Before:

* Empty line after `Searching AUR`
* `There is` starts with capital letter without space before

```
> yay --combinedupgrade -Syu
:: Synchronizing package databases...
 core is up to date
 extra is up to date
 community is up to date
 multilib is up to date
:: Searching databases for updates...
:: Searching AUR for updates...

:: Starting full system upgrade...
 there is nothing to do

> yay --nocombinedupgrade -Syu
:: Synchronizing package databases...
 core is up to date
 extra is up to date
 community is up to date
 multilib is up to date
:: Starting full system upgrade...
 there is nothing to do
:: Searching databases for updates...
:: Searching AUR for updates...

There is nothing to do
```

After:

```
> yay --combinedupgrade -Syu
:: Synchronizing package databases...
 core is up to date
 extra is up to date
 community is up to date
 multilib is up to date
:: Searching databases for updates...
:: Searching AUR for updates...
:: Starting full system upgrade...
 there is nothing to do

> yay --nocombinedupgrade -Syu
:: Synchronizing package databases...
 core is up to date
 extra is up to date
 community is up to date
 multilib is up to date
:: Starting full system upgrade...
 there is nothing to do
:: Searching databases for updates...
:: Searching AUR for updates...
 there is nothing to do
```