### PR TITLE
Fix devel updates

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -134,9 +135,13 @@ func updateVCSData(pkgName string, sources []gosrc.ArchString) {
 
 func getCommit(url string, branch string, protocols []string) string {
 	for _, protocol := range protocols {
-		cmd := passToGit("ls-remote", protocol+"://"+url, branch)
+		var outbuf bytes.Buffer
+
+		cmd := passToGit("", "ls-remote", protocol+"://"+url, branch)
+		cmd.Stdout = &outbuf
 		cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-		stdout, _, err := capture(cmd)
+
+		err := cmd.Start()
 		if err != nil {
 			continue
 		}
@@ -155,6 +160,7 @@ func getCommit(url string, branch string, protocols []string) string {
 			continue
 		}
 
+		stdout := outbuf.String()
 		split := strings.Fields(stdout)
 
 		if len(split) < 2 {


### PR DESCRIPTION
Commit 474cc56f8d77acc70ab7df264d15beea0a05cc91 refactored the
getCommit() function to use the standard passToGit() and capture()
functions.

Unlike every other external call, here we use .Wait() and kill the
command after 5 seconds. This was missed and ended up breaking the
function.

So instead don't use capture but the manual .Wait() call. passToGit() is
still used.