### PR TITLE
Abort ealy when there's conflicts with --noconfirm

### DIFF
--- a/depCheck.go
+++ b/depCheck.go
@@ -180,6 +180,10 @@ func (dp *depPool) CheckConflicts() (mapStringSet, error) {
 		}
 
 		fmt.Println()
+
+		if config.NoConfirm && !config.UseAsk {
+			return nil, fmt.Errorf("Package conflicts can not be resolved with noconfirm, aborting")
+		}
 	}
 
 	return conflicts, nil


### PR DESCRIPTION
When using --nouseask, manual intervention is needed to resolve conflicts.
When also useing --noconfirm the install will always fail. So abort
early, before trying to install any AUR packages.