### PR TITLE
Wait for db.lck to become available before starting a db operation

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -54,9 +54,9 @@ func updateSudo() {
 }
 
 // waitLock will lock yay checking the status of db.lck until it does not exist
-func waitLock() (err error) {
+func waitLock() {
 	if _, err := os.Stat(alpmConf.DBPath + "db.lck"); err != nil {
-		return nil
+		return
 	}
 
 	fmt.Println(bold(yellow(smallArrow)), "db.lck is present. Waiting... ")
@@ -64,7 +64,7 @@ func waitLock() (err error) {
 	for {
 		time.Sleep(3 * time.Second)
 		if _, err := os.Stat(alpmConf.DBPath + "db.lck"); err != nil {
-			return nil
+			return
 		}
 	}
 }

--- a/exec.go
+++ b/exec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -55,7 +56,7 @@ func updateSudo() {
 
 // waitLock will lock yay checking the status of db.lck until it does not exist
 func waitLock() {
-	if _, err := os.Stat(alpmConf.DBPath + "db.lck"); err != nil {
+	if _, err := os.Stat(filepath.Join(alpmConf.DBPath, "db.lck")); err != nil {
 		return
 	}
 
@@ -63,7 +64,7 @@ func waitLock() {
 
 	for {
 		time.Sleep(3 * time.Second)
-		if _, err := os.Stat(alpmConf.DBPath + "db.lck"); err != nil {
+		if _, err := os.Stat(filepath.Join(alpmConf.DBPath, "db.lck")); err != nil {
 			return
 		}
 	}

--- a/exec.go
+++ b/exec.go
@@ -53,6 +53,17 @@ func updateSudo() {
 	}
 }
 
+// waitLock will lock yay checking the status of db.lck until it does not exist
+func waitLock() (err error) {
+	for {
+		if _, err := os.Stat("/var/lib/pacman/db.lck"); os.IsNotExist(err) {
+			return nil
+		}
+		fmt.Println(bold(yellow(smallArrow)), "db.lck is present. Waiting 3 seconds and trying again")
+		time.Sleep(3 * time.Second)
+	}
+}
+
 func passToPacman(args *arguments) *exec.Cmd {
 	argArr := make([]string, 0)
 
@@ -71,6 +82,9 @@ func passToPacman(args *arguments) *exec.Cmd {
 
 	argArr = append(argArr, args.targets...)
 
+	if args.needWait() {
+		waitLock()
+	}
 	return exec.Command(argArr[0], argArr[1:]...)
 }
 

--- a/exec.go
+++ b/exec.go
@@ -55,12 +55,17 @@ func updateSudo() {
 
 // waitLock will lock yay checking the status of db.lck until it does not exist
 func waitLock() (err error) {
+	if _, err := os.Stat(alpmConf.DBPath + "db.lck"); err != nil {
+		return nil
+	}
+
+	fmt.Println(bold(yellow(smallArrow)), "db.lck is present. Waiting... ")
+
 	for {
-		if _, err := os.Stat("/var/lib/pacman/db.lck"); os.IsNotExist(err) {
+		time.Sleep(3 * time.Second)
+		if _, err := os.Stat(alpmConf.DBPath + "db.lck"); err != nil {
 			return nil
 		}
-		fmt.Println(bold(yellow(smallArrow)), "db.lck is present. Waiting 3 seconds and trying again")
-		time.Sleep(3 * time.Second)
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -144,12 +144,6 @@ func (parser *arguments) needRoot() bool {
 	case "R", "remove":
 		return true
 	case "S", "sync":
-		if parser.existsArg("y", "refresh") {
-			return true
-		}
-		if parser.existsArg("u", "sysupgrade") {
-			return true
-		}
 		if parser.existsArg("s", "search") {
 			return false
 		}

--- a/parser.go
+++ b/parser.go
@@ -177,6 +177,50 @@ func (parser *arguments) needRoot() bool {
 	}
 }
 
+//needWait checks if waitLock() should be called before calling pacman
+func (parser *arguments) needWait() bool {
+	if parser.existsArg("h", "help") {
+		return false
+	}
+
+	if parser.existsArg("p", "print") {
+		return false
+	}
+
+	switch parser.op {
+	case "D", "database":
+		return true
+	case "F", "files":
+		if parser.existsArg("y", "refresh") {
+			return true
+		}
+		return false
+	case "R", "remove":
+		return true
+	case "S", "sync":
+		if parser.existsArg("y", "refresh") {
+			return true
+		}
+		if parser.existsArg("u", "sysupgrade") {
+			return true
+		}
+		if parser.existsArg("s", "search") {
+			return false
+		}
+		if parser.existsArg("l", "list") {
+			return false
+		}
+		if parser.existsArg("i", "info") {
+			return false
+		}
+		return true
+	case "U", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
 func (parser *arguments) addOP(op string) (err error) {
 	if parser.op != "" {
 		err = fmt.Errorf("only one operation may be used at a time")


### PR DESCRIPTION
On split updates some funkiness can happen where an `yay` instance is unlocked before the other one gets to the 2nd pacman call but it should be working resulting in:
```
yay-1 -Syu
yay-2 -Syu
yay-1 pacman
yay-2 pacman
yay-1 pacman
yay-2 pacman
```

It should be stable enough for forced deployment without a flag though