### PR TITLE
Remove unused code, fix typo for -g flag

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -405,20 +405,6 @@ func handleYogurt() (err error) {
 func handleSync() (err error) {
 	targets := cmdArgs.targets
 
-	if cmdArgs.existsArg("y", "refresh") {
-		arguments := cmdArgs.copy()
-		cmdArgs.delArg("y", "refresh")
-		arguments.delArg("u", "sysupgrade")
-		arguments.delArg("s", "search")
-		arguments.delArg("i", "info")
-		arguments.delArg("l", "list")
-		arguments.clearTargets()
-		err = show(passToPacman(arguments))
-		if err != nil {
-			return
-		}
-	}
-
 	if cmdArgs.existsArg("s", "search") {
 		if cmdArgs.existsArg("q", "quiet") {
 			config.SearchMode = Minimal
@@ -431,7 +417,7 @@ func handleSync() (err error) {
 		err = syncClean(cmdArgs)
 	} else if cmdArgs.existsArg("l", "list") {
 		err = show(passToPacman(cmdArgs))
-	} else if cmdArgs.existsArg("c", "clean") {
+	} else if cmdArgs.existsArg("g", "groups") {
 		err = show(passToPacman(cmdArgs))
 	} else if cmdArgs.existsArg("i", "info") {
 		err = syncInfo(targets)
@@ -439,6 +425,8 @@ func handleSync() (err error) {
 		err = install(cmdArgs)
 	} else if len(cmdArgs.targets) > 0 {
 		err = install(cmdArgs)
+	} else if cmdArgs.existsArg("y", "refresh") {
+		err = show(passToPacman(cmdArgs))
 	}
 
 	return

--- a/exec.go
+++ b/exec.go
@@ -60,11 +60,12 @@ func waitLock() {
 		return
 	}
 
-	fmt.Println(bold(yellow(smallArrow)), "db.lck is present. Waiting... ")
+	fmt.Print(bold(yellow(smallArrow)), " db.lck is present. Waiting...")
 
 	for {
 		time.Sleep(3 * time.Second)
 		if _, err := os.Stat(filepath.Join(alpmConf.DBPath, "db.lck")); err != nil {
+			fmt.Println()
 			return
 		}
 	}
@@ -88,7 +89,7 @@ func passToPacman(args *arguments) *exec.Cmd {
 
 	argArr = append(argArr, args.targets...)
 
-	if args.needWait() {
+	if args.needRoot() {
 		waitLock()
 	}
 	return exec.Command(argArr[0], argArr[1:]...)

--- a/parser.go
+++ b/parser.go
@@ -127,9 +127,10 @@ func (parser *arguments) needRoot() bool {
 	}
 
 	switch parser.op {
-	case "V", "version":
-		return false
 	case "D", "database":
+		if parser.existsArg("k", "check") {
+			return false
+		}
 		return true
 	case "F", "files":
 		if parser.existsArg("y", "refresh") {
@@ -150,58 +151,7 @@ func (parser *arguments) needRoot() bool {
 		if parser.existsArg("l", "list") {
 			return false
 		}
-		if parser.existsArg("i", "info") {
-			return false
-		}
-		return true
-	case "T", "deptest":
-		return false
-	case "U", "upgrade":
-		return true
-
-	// yay specific
-	case "Y", "yay":
-		return false
-	case "P", "print":
-		return false
-	case "G", "getpkgbuild":
-		return false
-	default:
-		return false
-	}
-}
-
-//needWait checks if waitLock() should be called before calling pacman
-func (parser *arguments) needWait() bool {
-	if parser.existsArg("h", "help") {
-		return false
-	}
-
-	if parser.existsArg("p", "print") {
-		return false
-	}
-
-	switch parser.op {
-	case "D", "database":
-		return true
-	case "F", "files":
-		if parser.existsArg("y", "refresh") {
-			return true
-		}
-		return false
-	case "R", "remove":
-		return true
-	case "S", "sync":
-		if parser.existsArg("y", "refresh") {
-			return true
-		}
-		if parser.existsArg("u", "sysupgrade") {
-			return true
-		}
-		if parser.existsArg("s", "search") {
-			return false
-		}
-		if parser.existsArg("l", "list") {
+		if parser.existsArg("g", "groups") {
 			return false
 		}
 		if parser.existsArg("i", "info") {


### PR DESCRIPTION
As it turns out, the times you need root also tend to be the time you
need to manipulate the database. So the needWait() function can be
removed and repllaced by needRoot()

Also this brings us back down to more lines lost than gained since last release ;)