### PR TITLE
Refacotr continueTask()

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -82,7 +82,7 @@ func syncClean(parser *arguments) error {
 	fmt.Println()
 	fmt.Printf("Build directory: %s\n", config.BuildDir)
 
-	if continueTask(question, "nN") {
+	if continueTask(question, true) {
 		err = cleanAUR(keepInstalled, keepCurrent, removeAll)
 	}
 
@@ -90,7 +90,7 @@ func syncClean(parser *arguments) error {
 		return err
 	}
 
-	if continueTask("Do you want to remove ALL untracked AUR files?", "nN") {
+	if continueTask("Do you want to remove ALL untracked AUR files?", true) {
 		err = cleanUntracked()
 	}
 

--- a/config.go
+++ b/config.go
@@ -241,31 +241,33 @@ func editor() (string, []string) {
 
 // ContinueTask prompts if user wants to continue task.
 //If NoConfirm is set the action will continue without user input.
-func continueTask(s string, def string) (cont bool) {
+func continueTask(s string, cont bool) bool {
 	if config.NoConfirm {
-		return true
-	}
-	var postFix string
-
-	if def == "nN" {
-		postFix = " [Y/n] "
-	} else {
-		postFix = " [y/N] "
+		return cont
 	}
 
 	var response string
+	var postFix string
+	yes := "yes"
+	no := "no"
+	y := string([]rune(yes)[0])
+	n := string([]rune(no)[0])
+
+	if cont {
+		postFix = fmt.Sprintf(" [%s/%s] ", strings.ToUpper(y), n)
+	} else {
+		postFix = fmt.Sprintf(" [%s/%s] ", y, strings.ToUpper(n))
+	}
+
 	fmt.Print(bold(green(arrow)+" "+s), bold(postFix))
 
-	n, err := fmt.Scanln(&response)
-	if err != nil || n == 0 {
-		return true
+	len, err := fmt.Scanln(&response)
+	if err != nil || len == 0 {
+		return cont
 	}
 
-	if response == string(def[0]) || response == string(def[1]) {
-		return false
-	}
-
-	return true
+	response = strings.ToLower(response)
+	return response == yes || response == y
 }
 
 func getInput(defaultValue string) (string, error) {

--- a/install.go
+++ b/install.go
@@ -170,7 +170,7 @@ func install(parser *arguments) error {
 			removeMake = true
 		} else if config.RemoveMake == "no" {
 			removeMake = false
-		} else if !continueTask("Remove make dependencies after install?", "yY") {
+		} else if continueTask("Remove make dependencies after install?", false) {
 			removeMake = true
 		}
 	}
@@ -213,7 +213,7 @@ func install(parser *arguments) error {
 		oldValue := config.NoConfirm
 		config.NoConfirm = false
 		fmt.Println()
-		if !continueTask(bold(green("Proceed with install?")), "nN") {
+		if !continueTask(bold(green("Proceed with install?")), true) {
 			return fmt.Errorf("Aborting due to user")
 		}
 		config.NoConfirm = oldValue
@@ -249,7 +249,7 @@ func install(parser *arguments) error {
 		oldValue := config.NoConfirm
 		config.NoConfirm = false
 		fmt.Println()
-		if !continueTask(bold(green("Proceed with install?")), "nN") {
+		if !continueTask(bold(green("Proceed with install?")), true) {
 			return fmt.Errorf("Aborting due to user")
 		}
 		config.NoConfirm = oldValue
@@ -441,7 +441,7 @@ nextpkg:
 
 		fmt.Println()
 
-		if !continueTask("Try to build them anyway?", "nN") {
+		if !continueTask("Try to build them anyway?", true) {
 			return nil, fmt.Errorf("Aborting due to user")
 		}
 	}

--- a/keys.go
+++ b/keys.go
@@ -80,7 +80,7 @@ func checkPgpKeys(pkgs []*rpc.Pkg, bases map[string][]*rpc.Pkg, srcinfos map[str
 	fmt.Println()
 	fmt.Println(str)
 
-	if continueTask(bold(green("Import?")), "nN") {
+	if continueTask(bold(green("Import?")), true) {
 		return importKeys(problematic.toSlice())
 	}
 


### PR DESCRIPTION
The main reason behind this is for future localisation. yes and no can
be set to the localized equivalent and it should just work.

This Refactor also changes the function in ways which make it much less
confusing.

The param is no longer reversed and changed to a boolean. Before you had
to pass in Yy to get a default of no and vice versa.

The function now retuens false for no and true for yes. Before it would
return true if the default option was choosen.