### PR TITLE
Don't print nothing to do every time

### DIFF
--- a/install.go
+++ b/install.go
@@ -125,7 +125,9 @@ func install(parser *arguments) error {
 
 	if len(dp.Aur) == 0 {
 		if !config.CombinedUpgrade {
-			fmt.Println(" there is nothing to do")
+			if parser.existsArg("u", "sysupgrade") {
+				fmt.Println(" there is nothing to do")
+			}
 			return nil
 		}
 


### PR DESCRIPTION
When using nocombinedupgrade "there is nothing to do" is printed when
insinstalling repo packages. This is because as far as AUR
installer is concerned, there is nothing to do. Instead only print that
when doing a sysupgrade.