### PR TITLE
 Rework completion

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -361,13 +361,10 @@ func handlePrint() (err error) {
 		err = printUpdateList(cmdArgs)
 	case cmdArgs.existsArg("w", "news"):
 		err = printNewsFeed()
+	case cmdArgs.existsDouble("c", "complete"):
+		complete(true)
 	case cmdArgs.existsArg("c", "complete"):
-		switch {
-		case cmdArgs.existsArg("f", "fish"):
-			complete("fish")
-		default:
-			complete("sh")
-		}
+		complete(false)
 	case cmdArgs.existsArg("s", "stats"):
 		err = localStatistics()
 	default:

--- a/cmd.go
+++ b/cmd.go
@@ -221,6 +221,11 @@ func handleConfig(option, value string) bool {
 		config.SortMode = TopDown
 	case "bottomup":
 		config.SortMode = BottomUp
+	case "completioninterval":
+		n, err := strconv.Atoi(value)
+		if err == nil {
+			config.CompletionInterval = n
+		}
 	case "sortby":
 		config.SortBy = value
 	case "noconfirm":

--- a/completions.go
+++ b/completions.go
@@ -52,7 +52,7 @@ func updateCompletion(force bool) error {
 	path := filepath.Join(cacheHome, "completion.cache")
 	info, err := os.Stat(path)
 
-	if os.IsNotExist(err) || time.Since(info.ModTime()).Hours() >= 7*24 || force {
+	if os.IsNotExist(err) || (config.CompletionInterval != -1 && time.Since(info.ModTime()).Hours() >= float64(config.CompletionInterval*24)) || force {
 		os.MkdirAll(filepath.Dir(path), 0755)
 		out, errf := os.Create(path)
 		if errf != nil {

--- a/config.go
+++ b/config.go
@@ -35,44 +35,45 @@ const (
 
 // Configuration stores yay's config.
 type Configuration struct {
-	BuildDir        string `json:"buildDir"`
-	Editor          string `json:"editor"`
-	EditorFlags     string `json:"editorflags"`
-	MakepkgBin      string `json:"makepkgbin"`
-	MakepkgConf     string `json:"makepkgconf"`
-	PacmanBin       string `json:"pacmanbin"`
-	PacmanConf      string `json:"pacmanconf"`
-	TarBin          string `json:"tarbin"`
-	ReDownload      string `json:"redownload"`
-	ReBuild         string `json:"rebuild"`
-	AnswerClean     string `json:"answerclean"`
-	AnswerDiff      string `json:"answerdiff"`
-	AnswerEdit      string `json:"answeredit"`
-	AnswerUpgrade   string `json:"answerupgrade"`
-	GitBin          string `json:"gitbin"`
-	GpgBin          string `json:"gpgbin"`
-	GpgFlags        string `json:"gpgflags"`
-	MFlags          string `json:"mflags"`
-	SortBy          string `json:"sortby"`
-	GitFlags        string `json:"gitflags"`
-	RemoveMake      string `json:"removemake"`
-	RequestSplitN   int    `json:"requestsplitn"`
-	SearchMode      int    `json:"-"`
-	SortMode        int    `json:"sortmode"`
-	SudoLoop        bool   `json:"sudoloop"`
-	TimeUpdate      bool   `json:"timeupdate"`
-	NoConfirm       bool   `json:"-"`
-	Devel           bool   `json:"devel"`
-	CleanAfter      bool   `json:"cleanAfter"`
-	GitClone        bool   `json:"gitclone"`
-	Provides        bool   `json:"provides"`
-	PGPFetch        bool   `json:"pgpfetch"`
-	UpgradeMenu     bool   `json:"upgrademenu"`
-	CleanMenu       bool   `json:"cleanmenu"`
-	DiffMenu        bool   `json:"diffmenu"`
-	EditMenu        bool   `json:"editmenu"`
-	CombinedUpgrade bool   `json:"combinedupgrade"`
-	UseAsk          bool   `json:"useask"`
+	BuildDir           string `json:"buildDir"`
+	Editor             string `json:"editor"`
+	EditorFlags        string `json:"editorflags"`
+	MakepkgBin         string `json:"makepkgbin"`
+	MakepkgConf        string `json:"makepkgconf"`
+	PacmanBin          string `json:"pacmanbin"`
+	PacmanConf         string `json:"pacmanconf"`
+	TarBin             string `json:"tarbin"`
+	ReDownload         string `json:"redownload"`
+	ReBuild            string `json:"rebuild"`
+	AnswerClean        string `json:"answerclean"`
+	AnswerDiff         string `json:"answerdiff"`
+	AnswerEdit         string `json:"answeredit"`
+	AnswerUpgrade      string `json:"answerupgrade"`
+	GitBin             string `json:"gitbin"`
+	GpgBin             string `json:"gpgbin"`
+	GpgFlags           string `json:"gpgflags"`
+	MFlags             string `json:"mflags"`
+	SortBy             string `json:"sortby"`
+	GitFlags           string `json:"gitflags"`
+	RemoveMake         string `json:"removemake"`
+	RequestSplitN      int    `json:"requestsplitn"`
+	SearchMode         int    `json:"-"`
+	SortMode           int    `json:"sortmode"`
+	CompletionInterval int    `json:"completionrefreshtime"`
+	SudoLoop           bool   `json:"sudoloop"`
+	TimeUpdate         bool   `json:"timeupdate"`
+	NoConfirm          bool   `json:"-"`
+	Devel              bool   `json:"devel"`
+	CleanAfter         bool   `json:"cleanAfter"`
+	GitClone           bool   `json:"gitclone"`
+	Provides           bool   `json:"provides"`
+	PGPFetch           bool   `json:"pgpfetch"`
+	UpgradeMenu        bool   `json:"upgrademenu"`
+	CleanMenu          bool   `json:"cleanmenu"`
+	DiffMenu           bool   `json:"diffmenu"`
+	EditMenu           bool   `json:"editmenu"`
+	CombinedUpgrade    bool   `json:"combinedupgrade"`
+	UseAsk             bool   `json:"useask"`
 }
 
 var version = "7.885"
@@ -163,6 +164,7 @@ func defaultSettings(config *Configuration) {
 	config.MFlags = ""
 	config.GitFlags = ""
 	config.SortMode = BottomUp
+	config.CompletionInterval = 7
 	config.SortBy = "votes"
 	config.SudoLoop = false
 	config.TarBin = "bsdtar"

--- a/install.go
+++ b/install.go
@@ -312,6 +312,8 @@ func install(parser *arguments) error {
 		}
 	}
 
+	go updateCompletion(false)
+
 	err = downloadPkgBuildsSources(do.Aur, do.Bases, incompatible)
 	if err != nil {
 		return err

--- a/parser.go
+++ b/parser.go
@@ -472,6 +472,8 @@ func hasParam(arg string) bool {
 		return true
 	case "answerupgrade":
 		return true
+	case "completioninterval":
+		return true
 	case "sortby":
 		return true
 	default:


### PR DESCRIPTION
Bash seperates on whitespace, so the fish completion file
actually works for bash and zsh. So remove the concept of shells
entirley and just use the singular aur_sh.cache file.

If for some reason output without the repository data is needed, the
user could always just pipe it into awk like so
`yay -Pc | awk '{print $1}'`. Or perhaps a --quiet option could be added
where yay will strip the output itself.

The completion cache now updates when installing AUR packages. This is
done as a goroutine with no wait groups. This ensures the program will
never hang if there is a problem.

The completion is stil updated during -Pc but as long as an AUR package
has been installed recently it should not need to update.

The cache will now also wait 7 days instead of 2 before refreshing.
A refresh can be forced using -Pcc.

Make the completion refresh time configurable
The default setting is 7 days. The user can specify a different time in
days. -1 can be set to never refresh while 0 can be used to always
refresh.

Alternative to #539