### PR TITLE
Use no-progress when cloning packages

### DIFF
--- a/download.go
+++ b/download.go
@@ -60,7 +60,7 @@ func gitHasDiff(path string, name string) (bool, error) {
 func gitDownload(url string, path string, name string) (bool, error) {
 	_, err := os.Stat(filepath.Join(path, name, ".git"))
 	if os.IsNotExist(err) {
-		err = show(passToGit(path, "clone", url, name))
+		err = show(passToGit(path, "clone", "--no-progress", url, name))
 		if err != nil {
 			return false, fmt.Errorf("error cloning %s", name)
 		}


### PR DESCRIPTION
The output is annoying and takes up many lines. All AUR packages clone
extremley fast anyway, making the progress unneeded.