### PR TITLE
Always pass PacmanConf to pacman

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -119,18 +119,6 @@ If no operation is provided -Y will be assumed`)
 }
 
 func handleCmd() (err error) {
-	for option, value := range cmdArgs.options {
-		if handleConfig(option, value) {
-			cmdArgs.delArg(option)
-		}
-	}
-
-	for option, value := range cmdArgs.globals {
-		if handleConfig(option, value) {
-			cmdArgs.delArg(option)
-		}
-	}
-
 	if shouldSaveConfig {
 		config.saveConfig()
 	}
@@ -232,6 +220,8 @@ func handleConfig(option, value string) bool {
 		config.SortBy = value
 	case "noconfirm":
 		config.NoConfirm = true
+	case "config":
+		config.PacmanConf = value
 	case "redownload":
 		config.ReDownload = "yes"
 	case "redownloadall":

--- a/exec.go
+++ b/exec.go
@@ -85,8 +85,8 @@ func passToPacman(args *arguments) *exec.Cmd {
 		argArr = append(argArr, "--noconfirm")
 	}
 
+	argArr = append(argArr, "--config", config.PacmanConf)
 	argArr = append(argArr, "--")
-
 	argArr = append(argArr, args.targets...)
 
 	if args.needRoot() {

--- a/main.go
+++ b/main.go
@@ -109,11 +109,6 @@ func initAlpm() (err error) {
 	var exists bool
 	//var double bool
 
-	value, _, exists = cmdArgs.getArg("config")
-	if exists {
-		config.PacmanConf = value
-	}
-
 	alpmConf, err = readAlpmConfig(config.PacmanConf)
 	if err != nil {
 		err = fmt.Errorf("Unable to read Pacman conf: %s", err)
@@ -222,6 +217,8 @@ func main() {
 		status = 1
 		goto cleanup
 	}
+
+	cmdArgs.extractYayOptions()
 
 	err = initVCS()
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -593,10 +593,10 @@ func (parser *arguments) parseCommandLine() (err error) {
 		parser.op = "Y"
 	}
 
-	if cmdArgs.existsArg("-") {
+	if parser.existsArg("-") {
 		var file *os.File
-		err = cmdArgs.parseStdin()
-		cmdArgs.delArg("-")
+		err = parser.parseStdin()
+		parser.delArg("-")
 
 		if err != nil {
 			return
@@ -612,6 +612,20 @@ func (parser *arguments) parseCommandLine() (err error) {
 	}
 
 	return
+}
+
+func (parser *arguments) extractYayOptions() {
+	for option, value := range parser.options {
+		if handleConfig(option, value) {
+			parser.delArg(option)
+		}
+	}
+
+	for option, value := range parser.globals {
+		if handleConfig(option, value) {
+			parser.delArg(option)
+		}
+	}
 }
 
 //parses input for number menus splitted by spaces or commas


### PR DESCRIPTION
Normaly we only pass --config to pacman if the user specifies it on the
command line. Otherwise we let pacman use it's default config location.

If the user has changed pacmanconf in Yay's config file then this could
cause a miss match between the config we use to init alpm and the config
pacman is using.