### PR TITLE
Ensure AUR upgrades actually use the AUR

### DIFF
--- a/install.go
+++ b/install.go
@@ -93,7 +93,8 @@ func install(parser *arguments) error {
 		}
 
 		for up := range aurUp {
-			requestTargets = append(requestTargets, up)
+			requestTargets = append(requestTargets, "aur/" + up)
+			parser.addTarget("aur/" + up)
 		}
 
 		value, _, exists := cmdArgs.getArg("ignore")
@@ -104,10 +105,6 @@ func install(parser *arguments) error {
 				ignoreStr += "," + value
 			}
 			arguments.options["ignore"] = ignoreStr
-		}
-
-		for pkg := range aurUp {
-			parser.addTarget(pkg)
 		}
 	}
 


### PR DESCRIPTION
Yay's dependency resolving takes provides into account. When upgrading
AUR package 'foo', if a repo package provides 'foo' then yay would get
confused and pull in the package providing 'foo' instead of the AUR
package.

This commit ensures AUR upgrades always exclusively check the AUR.

Fixes #546