### PR TITLE
Fix panic on invalid version strings

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -53,6 +53,10 @@ func splitDep(dep string) (string, string, string) {
 		return match
 	})
 
+	if len(split) == 0 {
+		return "", "", ""
+	}
+
 	if len(split) == 1 {
 		return split[0], "", ""
 	}


### PR DESCRIPTION
Fixed issue #621. Fixed out of bounds error that causes yay to panic when splitting invalid version strings.