### PR TITLE
Give an example of how to update only AUR packages

### DIFF
--- a/doc/yay.8
+++ b/doc/yay.8
@@ -474,6 +474,10 @@ yay \-Syu
 Update package list and upgrade all currently installed repo and \fBAUR\fR.
 
 .TP
+yay \-Sua
+Update all currently installed \fBAUR\fR packages.
+
+.TP
 yay \-S \fIfoo\fR
 Installs package \fIfoo\fR from the repos or the \fBAUR\fR.
 


### PR DESCRIPTION
I've seen `yay -Syua` given as an example all over the place. I'm not
sure if this is left over as a habbit from yaourt. In yay, -a restricts
the upgrade to AUR packages ONLY while I believe in yaourt it means to
also include the AUR.

The problem with `yay -Syua` is that you are doing a database refresh
and then only upgrading the AUR packages. Essencially:

pacman -Sy && update-aur

This is a recipy for partial upgrades.

Either upgrade everything `yay -Syu` or just the AUR `yay -Sua`.