### PR TITLE
Support the NO_COLOR environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func initAlpm() (err error) {
 	value, _, _ = cmdArgs.getArg("color")
 	if value == "always" || value == "auto" {
 		useColor = true
-	} else if value == "never" {
+	} else if value == "never" || os.Getenv("NO_COLOR") != "" {
 		useColor = false
 	} else {
 		useColor = alpmConf.Options&alpm.ConfColor > 0


### PR DESCRIPTION
Support the `NO_COLOR` environment variable for disabling colorized
output.

From http://no-color.org/ :

> By adopting this standard, users that prefer to have plain,
> non-colored text output can set one environment variable in their shell
> to have it automatically affect all supported software.