### PR TITLE
Remove redundant variable from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ endif
 VERSION := ${MAJORVERSION}.${MINORVERSION}
 
 LDFLAGS := -ldflags '-s -w -X main.version=${VERSION}'
-GOFILES := $(shell ls *.go | grep -v /vendor/)
 ARCH := $(shell uname -m)
 PKGNAME := yay
 BINNAME := yay


### PR DESCRIPTION
The only use of this variable was removed here: 721086c06a9
