### PR TITLE
 Use goroutines for fetching packages via -G

### DIFF
--- a/doc/yay.8
+++ b/doc/yay.8
@@ -31,7 +31,8 @@ Perform yay specific print operations.
 
 .TP
 .B \-G, \-\-getpkgbuild
-Downloads PKGBUILD from ABS or AUR.
+Downloads PKGBUILD from ABS or AUR. ABS pkgbuilds are always downloaded using
+tarballs and taken from trunk. The ABS can only be used for Arch Linux repositories
 
 .RE
 If no arguments are provided 'yay \-Syu' will be performed.
@@ -276,7 +277,7 @@ Show a detailed list of updates in a similar format to VerbosePkgLists.
 Upgrades can also be skipped using numbers, number ranges or repo names.
 Adidionally ^ can be used to invert the selection.
 
-\fBWarning\fR: It is not recommended to skip updates from the repositores as
+\fBWarning\fR: It is not recommended to skip updates from the repositories as
 this can lead to partial upgrades. This feature is intended to easily skip AUR
 updates on the fly that may be broken or have a long compile time. Ultimately
 it is up to the user what upgrades they skip.

--- a/exec.go
+++ b/exec.go
@@ -25,8 +25,8 @@ func capture(cmd *exec.Cmd) (string, string, error) {
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf
 	err := cmd.Run()
-	stdout := outbuf.String()
-	stderr := errbuf.String()
+	stdout := strings.TrimSpace(outbuf.String())
+	stderr := strings.TrimSpace(errbuf.String())
 
 	return stdout, stderr, err
 }

--- a/install.go
+++ b/install.go
@@ -185,7 +185,7 @@ func install(parser *arguments) error {
 	}
 
 	toSkip := pkgbuildsToSkip(do.Aur, targets)
-	cloned, err := downloadPkgbuilds(do.Aur, toSkip)
+	cloned, err := downloadPkgbuilds(do.Aur, toSkip, config.BuildDir)
 	if err != nil {
 		return err
 	}
@@ -809,7 +809,7 @@ func mergePkgbuilds(bases []Base) error {
 	return nil
 }
 
-func downloadPkgbuilds(bases []Base, toSkip stringSet) (stringSet, error) {
+func downloadPkgbuilds(bases []Base, toSkip stringSet, buildDir string) (stringSet, error) {
 	cloned := make(stringSet)
 	downloaded := 0
 	var wg sync.WaitGroup
@@ -830,7 +830,7 @@ func downloadPkgbuilds(bases []Base, toSkip stringSet) (stringSet, error) {
 		}
 
 		if shouldUseGit(filepath.Join(config.BuildDir, pkg)) {
-			clone, err := gitDownload(baseURL+"/"+pkg+".git", config.BuildDir, pkg)
+			clone, err := gitDownload(baseURL+"/"+pkg+".git", buildDir, pkg)
 			if err != nil {
 				errs.Add(err)
 				return
@@ -841,7 +841,7 @@ func downloadPkgbuilds(bases []Base, toSkip stringSet) (stringSet, error) {
 				mux.Unlock()
 			}
 		} else {
-			err := downloadAndUnpack(baseURL+base.URLPath(), config.BuildDir)
+			err := downloadAndUnpack(baseURL+base.URLPath(), buildDir)
 			if err != nil {
 				errs.Add(err)
 				return

--- a/utils.go
+++ b/utils.go
@@ -139,10 +139,10 @@ func (err *MultiError) Error() string {
 	str := ""
 
 	for _, e := range err.Errors {
-		str += e.Error()
+		str += e.Error() + "\n"
 	}
 
-	return str
+	return str[:len(str)-1]
 }
 
 func (err *MultiError) Add(e error) {

--- a/vcs.go
+++ b/vcs.go
@@ -38,7 +38,7 @@ func createDevelDB() error {
 
 	bases := getBases(info)
 	toSkip := pkgbuildsToSkip(bases, sliceToStringSet(remoteNames))
-	downloadPkgbuilds(bases, toSkip)
+	downloadPkgbuilds(bases, toSkip, config.BuildDir)
 	srcinfos, _ := parseSrcinfoFiles(bases, false)
 
 	for _, pkgbuild := range srcinfos {


### PR DESCRIPTION
Continuation of #613. -G is now also run in parallel and uses the existing AUR pkgbuild functions. 