### PR TITLE
 skip build when package is up to date and --needed

### DIFF
--- a/install.go
+++ b/install.go
@@ -478,7 +478,7 @@ func parsePackageList(dir string) (map[string]string, string, error) {
 		// This assumes 3 dashes after the pkgname, Will cause an error
 		// if the PKGEXT contains a dash. Please no one do that.
 		pkgname := strings.Join(split[:len(split)-3], "-")
-		version = strings.Join(split[len(split)-3:len(split)-2], "-")
+		version = strings.Join(split[len(split)-3:len(split)-1], "-")
 		pkgdests[pkgname] = line
 	}
 

--- a/install.go
+++ b/install.go
@@ -931,9 +931,23 @@ func buildInstallPkgbuilds(dp *depPool, do *depOrder, srcinfos map[string]*gosrc
 			built = false
 		}
 
+		if cmdArgs.existsArg("needed") {
+			installed := true
+			for _, split := range base {
+				if alpmpkg, err := dp.LocalDb.PkgByName(split.Name); err != nil || alpmpkg.Version() != version {
+					installed = false
+				}
+			}
+
+			if installed {
+				fmt.Println(cyan(pkg+"-"+version) + bold(" is up to date -- skipping"))
+				continue
+			}
+		}
+
 		if built {
 			fmt.Println(bold(yellow(arrow)),
-				cyan(pkg+"-"+version)+bold(" Already made -- skipping build"))
+				cyan(pkg+"-"+version)+bold(" already made -- skipping build"))
 		} else {
 			args := []string{"-cf", "--noconfirm", "--noextract", "--noprepare", "--holdver"}
 


### PR DESCRIPTION
Before --needed was left purerly to pacman. The problem with this is
that if a package is not in the cache, it will end up being build just
for pacman to skip over the install.

Now Yay will handle this and skip the build and install if --needed is
used. The inital clone and pkgver bumb is still donw.

Noted here: https://github.com/Jguer/yay/issues/46#issuecomment-382174633