### PR TITLE
README grammar, spelling, rewording, organizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,25 +66,23 @@ Following are the dependencies managed under dep:
 * https://github.com/Morganamilo/go-srcinfo
 * https://github.com/mikkeloscar/aur
 
-#### 2. Set GOPATH (As Needed)
-
-Yay's Makefile automatically sets the `GOPATH` to `$PWD/.go`. This path will
-ensure dependencies in `vendor/` are built. Running manual go commands such as
-`go build` will require that you either set the `GOPATH` manually or `go get`
-the vendored dependencies into your own `GOPATH`.
-
-#### 3. Build
+#### 2. Build
 
 Run `make` to build yay. This command will generate a binary called `yay` in
 the same directory as the Makefile.
 
-#### 4. Check Style
+Note: Yay's Makefile automatically sets the `GOPATH` to `$PWD/.go`. This path will
+ensure dependencies in `vendor/` are built. Running manual go commands such as
+`go build` will require that you either set the `GOPATH` manually or `go get`
+the vendored dependencies into your own `GOPATH`.
+
+#### 3. Check Style
 
 All code should be formatted through `go fmt`. This tool will automatically
 format code for you. We recommend, however, that you write code in the proper
 style and use `go fmt` only to catch mistakes.
 
-#### 5. Test
+#### 4. Test
 
 Run `make test` to test yay. This command will verify that the code is
 formatted correctly, run the code through `go vet`, and run unit tests.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [
 
 * Wrap the pacman interface
 * Yaourt-style interactive search/install
-* Minimize dependencies
+* Minimal dependencies
 * Minimize user input
 * Know when git packages are due for upgrades
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Yet Another Yogurt - An AUR Helper Written in Go
 There's a point in everyone's life when you feel the need to write an AUR helper because there are only about 20 of them.
 So say hi to 20+1.
 
-_Yay_ is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [apacman](https://github.com/oshazard/apacman) and [pacaur](https://github.com/rmarquis/pacaur). It is developed with these objectives in mind:
+Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [apacman](https://github.com/oshazard/apacman) and [pacaur](https://github.com/rmarquis/pacaur). It is developed with these objectives in mind:
 
-* Wrap the _pacman_ interface
-* Search for packages like _yaourt_ does
+* Wrap the pacman interface
+* Search for packages like yaourt does
 * Minimize dependencies
 * Minimize user input
 * Know when git packages are due for upgrades
@@ -28,14 +28,14 @@ _Yay_ is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt),
 * Narrow search terms (`yay linux header` will first search `linux` and then narrow on `header`)
 * Remove make dependencies at the end of the build process
 * Run without sourcing PKGBUILD
-* Limit runtime dependencies to subset of _pacman_ dependencies
+* Limit runtime dependencies to subset of pacman dependencies
 
 ## Installation
 
-If you are migrating from another AUR helper, you can simply install _yay_ with that helper.
+If you are migrating from another AUR helper, you can simply install yay with that helper.
 
-If you are starting from scratch, you can install _yay_ by cloning the PKGBUILD and
-then building with _makepkg_:
+If you are starting from scratch, you can install yay by cloning the PKGBUILD and
+then building with makepkg:
 ```sh
 git clone https://aur.archlinux.org/yay.git
 cd yay
@@ -53,10 +53,10 @@ Otherwise send us a pull request and we will be happy to review it.
 
 #### 1. Install Dependencies
 
-Install `go` and `base-devel` with _pacman_.
+Install `go` and `base-devel` with pacman.
 
-Note that _yay_ requires a few other projects (as vendored dependencies). These
-projects are stored in `vendor/`, are built into _yay_ at build time, and do not
+Note that yay requires a few other projects (as vendored dependencies). These
+projects are stored in `vendor/`, are built into yay at build time, and do not
 need to be installed separately. Do not edit files in `vendor/`. Here are yay's
 current vendored dependencies:
 
@@ -66,14 +66,14 @@ current vendored dependencies:
 
 #### 2. Set GOPATH (As Needed)
 
-_Yay_'s Makefile automatically sets the `GOPATH` to `$PWD/.go`. This path will
-ensure dependencies in `vendor/` are built. Running manual _go_ commands such as
+Yay's Makefile automatically sets the `GOPATH` to `$PWD/.go`. This path will
+ensure dependencies in `vendor/` are built. Running manual go commands such as
 `go build` will require that you either set the `GOPATH` manually or `go get`
 the vendored dependencies into your own `GOPATH`.
 
 #### 3. Build
 
-Run `make` to build _yay_. This command will generate a binary called `yay` in
+Run `make` to build yay. This command will generate a binary called `yay` in
 the same directory as the Makefile.
 
 #### 4. Check Style
@@ -84,16 +84,16 @@ style and use `go fmt` only to catch mistakes.
 
 #### 5. Test
 
-Run `make test` to test _yay_. This command will verify that the code is
+Run `make test` to test yay. This command will verify that the code is
 formatted correctly, run the code through `go vet`, and run unit tests.
 
 ## Frequently Asked Questions
 
-#### _Yay_ does not display colored output. How do I fix it?
+#### Yay does not display colored output. How do I fix it?
   Make sure you have the `Color` option in your `/etc/pacman.conf`
   (see issue [#123](https://github.com/Jguer/yay/issues/123)).
 
-#### _Yay_ is not prompting to skip packages during system upgrade.
+#### Yay is not prompting to skip packages during system upgrade.
   The default behavior was changed after
   [v8.918](https://github.com/Jguer/yay/releases/tag/v8.918)
   (see [3bdb534](https://github.com/Jguer/yay/commit/3bdb5343218d99d40f8a449b887348611f6bdbfc)
@@ -103,26 +103,26 @@ formatted correctly, run the code through `go vet`, and run unit tests.
   system in a
   [partially-upgraded state](https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported).
 
-#### Sometimes diffs are printed to the terminal, and other times they are paged via _less_. How do I fix this?
-  _Yay_ uses `git diff` to display diffs, which by default tells _less_ not to
+#### Sometimes diffs are printed to the terminal, and other times they are paged via less. How do I fix this?
+  Yay uses `git diff` to display diffs, which by default tells less not to
   page if the output can fit into one terminal length. This behavior can be
   overridden by exporting your own flags (`export LESS=SRX`).
 
-#### _Yay_ is not asking me to edit PKGBUILDS, and I don't like the diff menu! What can I do?
+#### Yay is not asking me to edit PKGBUILDS, and I don't like the diff menu! What can I do?
   `yay --editmenu --nodiffmenu --save`
 
-#### How can I tell _yay_ to act only on AUR packages, or only on repo packages?
+#### How can I tell yay to act only on AUR packages, or only on repo packages?
   `yay -{OPERATION} --aur`  
   `yay -{OPERATION} --repo`
 
-#### An `Out Of Date AUR Packages` message is displayed. Why doesn't _yay_ update them?
+#### An `Out Of Date AUR Packages` message is displayed. Why doesn't yay update them?
   This message does not mean that updated AUR packages are available. It means
   means the packages have been flagged out of date on the AUR, but
   their maintainers have not yet updated the `PKGBUILD`s
   (see [outdated AUR packages](https://wiki.archlinux.org/index.php/Arch_User_Repository#Foo_in_the_AUR_is_outdated.3B_what_should_I_do.3F)).
 
-#### _Yay_ doesn't install dependencies added to a PKGBUILD during installation.
-  _Yay_ resolves all dependencies ahead of time. You are free to edit the
+#### Yay doesn't install dependencies added to a PKGBUILD during installation.
+  Yay resolves all dependencies ahead of time. You are free to edit the
   PKGBUILD in any way, but any problems you cause are your own and should not be
   reported unless they can be reproduced with the original PKGBUILD.
 

--- a/README.md
+++ b/README.md
@@ -146,4 +146,3 @@ formatted correctly, run the code through `go vet`, and run unit tests.
 <img src="https://cdn.rawgit.com/Jguer/jguer.github.io/5412b8d6/yay/yay-ps.png" width="450">
 <img src="https://cdn.rawgit.com/Jguer/jguer.github.io/5412b8d6/yay/yayupgrade.png" width="450">
 <img src="https://cdn.rawgit.com/Jguer/jguer.github.io/5412b8d6/yay/yaysearch.png" width="450">
-

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ on, we suggest opening an issue detailing your ideas first.
 
 Otherwise send us a pull request and we will be happy to review it.
 
-#### 1. Dependencies
+#### Dependencies
 
 Yay depends on:
 
@@ -70,7 +70,7 @@ Following are the dependencies managed under dep:
 * https://github.com/Morganamilo/go-srcinfo
 * https://github.com/mikkeloscar/aur
 
-#### 2. Build
+#### Building
 
 Run `make` to build yay. This command will generate a binary called `yay` in
 the same directory as the Makefile.
@@ -80,13 +80,13 @@ ensure dependencies in `vendor/` are built. Running manual go commands such as
 `go build` will require that you either set the `GOPATH` manually or `go get`
 the vendored dependencies into your own `GOPATH`.
 
-#### 3. Check Style
+#### Code Style
 
 All code should be formatted through `go fmt`. This tool will automatically
 format code for you. We recommend, however, that you write code in the proper
 style and use `go fmt` only to catch mistakes.
 
-#### 4. Test
+#### Testing
 
 Run `make test` to test yay. This command will verify that the code is
 formatted correctly, run the code through `go vet`, and run unit tests.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [
 * Narrow search terms (`yay linux header` will first search `linux` and then narrow on `header`)
 * Remove make dependencies at the end of the build process
 * Run without sourcing PKGBUILD
-* Limit runtime dependencies to subset of pacman dependencies
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,41 @@
 # yay
 
-Yet another Yogurt - An AUR Helper written in Go
+Yet Another Yogurt - An AUR Helper Written in Go
 
 #### Packages
 
 [![yay](https://img.shields.io/aur/version/yay.svg?label=yay)](https://aur.archlinux.org/packages/yay/) [![yay-bin](https://img.shields.io/aur/version/yay-bin.svg?label=yay-bin)](https://aur.archlinux.org/packages/yay-bin/) [![yay-git](https://img.shields.io/aur/version/yay-git.svg?label=yay-git)](https://aur.archlinux.org/packages/yay-git/) [![GitHub license](https://img.shields.io/github/license/jguer/yay.svg)](https://github.com/Jguer/yay/blob/master/LICENSE)  
+
+## Objectives
+
 There's a point in everyone's life when you feel the need to write an AUR helper because there are only about 20 of them.
 So say hi to 20+1.
 
-Yay was created with a few objectives in mind and based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [apacman](https://github.com/oshazard/apacman) and [pacaur](https://github.com/rmarquis/pacaur):
+_Yay_ is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [apacman](https://github.com/oshazard/apacman) and [pacaur](https://github.com/rmarquis/pacaur). It is developed with these objectives in mind:
 
-* Have almost no dependencies
-* Provide an interface for pacman
-* Have yaourt-like search
+* Wrap the _pacman_ interface
+* Search for packages like _yaourt_ does
+* Minimize dependencies
 * Minimize user input
-* Know when git packages are due for an upgrade
+* Know when git packages are due for upgrades
 
 ## Features
 
-* AUR Tab completion
-* Download PKGBUILD from ABS or AUR
-* Ask all questions first and then start building
-* Search narrowing (`yay linux header` will first search linux and then narrow on header)
-* No sourcing of PKGBUILD is done
-* The binary has no dependencies that pacman doesn't already have
-* Advanced dependency solving
+* Perform advanced dependency solving
+* Download PKGBUILDs from ABS or AUR
+* Tab-complete the AUR
+* Query user up-front for all input (prior to starting builds)
+* Narrow search terms (`yay linux header` will first search `linux` and then narrow on `header`)
 * Remove make dependencies at the end of the build process
+* Run without sourcing PKGBUILD
+* Limit runtime dependencies to subset of _pacman_ dependencies
 
 ## Installation
 
-If you are migrating from another AUR helper you can simply install Yay from
-the AUR like any other package.
+If you are migrating from another AUR helper, you can simply install _yay_ with that helper.
 
-The initial installation of Yay can be done by cloning the PKGBUILD and
-building with makepkg.
+If you are starting from scratch, you can install _yay_ by cloning the PKGBUILD and
+then building with _makepkg_:
 ```sh
 git clone https://aur.archlinux.org/yay.git
 cd yay
@@ -49,86 +51,99 @@ on, we suggest opening an issue detailing your ideas first.
 
 Otherwise send us a pull request and we will be happy to review it.
 
-### Code Style
+#### 1. Install Dependencies
 
-All code should be formatted through `go fmt`. This tool will automatically
-format code for you. Although it is recommended you write code in this style
-and just use this tool to catch mistakes.
+Install `go` and `base-devel` with _pacman_.
 
-### Building
-
-Yay is easy to build with its only build dependency being `go` and the
-assumption of `base-devel` being installed.
-
-Run `make` to build Yay. This will generate a binary called `yay` in the same
-directory as the Makefile.
-
-Run `make test` to test Yay. This will check the code is formatted correctly,
-run the code through `go vet` and run unit tests.
-
-Yay's Makefile automatically sets the `GOPATH` to `$PWD/.go`. This makes it easy to
-build using the dependencies in `vendor/`. Running manual go commands such as
-`go build` will require that you to either set the `GOPATH` manually or `go get`
-The dependencies into your own `GOPATH`.
-
-### Vendored Dependencies
-
-Yay depends on a couple of other projects. These are stored in `vendor/` and
-are built into Yay at build time. They do not need to be installed separately.
-
-Currently yay Depends on:
+Note that _yay_ requires a few other projects (as vendored dependencies). These
+projects are stored in `vendor/`, are built into _yay_ at build time, and do not
+need to be installed separately:
 
 * https://github.com/Jguer/go-alpm
 * https://github.com/Morganamilo/go-srcinfo
 * https://github.com/mikkeloscar/aur
 
+#### 2. Set GOPATH (As Needed)
+
+_Yay_'s Makefile automatically sets the `GOPATH` to `$PWD/.go`. This path will
+ensure dependencies in `vendor/` are built. Running manual _go_ commands such as
+`go build` will require that you either set the `GOPATH` manually or `go get`
+the vendored dependencies into your own `GOPATH`.
+
+#### 3. Build
+
+Run `make` to build _yay_. This command will generate a binary called `yay` in
+the same directory as the Makefile.
+
+#### 4. Check Style
+
+All code should be formatted through `go fmt`. This tool will automatically
+format code for you. We recommend, however, that you write code in the proper
+style and use `go fmt` only to catch mistakes.
+
+#### 5. Test
+
+Run `make test` to test _yay_. This command will verify that the code is
+formatted correctly, run the code through `go vet`, and run unit tests.
+
 ## Frequently Asked Questions
 
-#### Yay does not display colored output. How do I fix it?
-  Make sure you have the `Color` option in your `/etc/pacman.conf` [#123](https://github.com/Jguer/yay/issues/123)
+#### _Yay_ does not display colored output. How do I fix it?
+  Make sure you have the `Color` option in your `/etc/pacman.conf`
+  (see issue [#123](https://github.com/Jguer/yay/issues/123)).
 
-#### Yay is not prompting to skip packages during sysupgrade (issue [#554](https://github.com/Jguer/yay/issues/554))
-  The default behavior was changed after [v8.918](https://github.com/Jguer/yay/releases/tag/v8.918)
-  (see: [3bdb534](https://github.com/Jguer/yay/commit/3bdb5343218d99d40f8a449b887348611f6bdbfc)).
-  To restore such behavior use `--combinedupgrade`. This can also be
-  permanently enabled by appending `--save`.
-  Note: this causes [native pacman](https://wiki.archlinux.org/index.php/AUR_helpers) to become partial.
+#### _Yay_ is not prompting to skip packages during system upgrade.
+  The default behavior was changed after
+  [v8.918](https://github.com/Jguer/yay/releases/tag/v8.918)
+  (see [3bdb534](https://github.com/Jguer/yay/commit/3bdb5343218d99d40f8a449b887348611f6bdbfc)
+  and issue [#554](https://github.com/Jguer/yay/issues/554)).
+  To restore the package-skip behavior use `--combinedupgrade` (make
+  it permanent by appending `--save`). Note: skipping packages will leave your
+  system in a
+  [partially-upgraded state](https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported).
 
-#### Sometimes diffs are printed to the terminal and other times they are paged via less. How do I fix this?
-  Yay uses `git diff` to display diffs, by default git tells less to not page
-  if the output can fit one terminal length. This can be overridden by
-  exporting your own flags `export LESS=SRX`.
+#### Sometimes diffs are printed to the terminal, and other times they are paged via _less_. How do I fix this?
+  _Yay_ uses `git diff` to display diffs, which by default tells _less_ not to
+  page if the output can fit into one terminal length. This behavior can be
+  overridden by exporting your own flags (`export LESS=SRX`).
 
-#### Yay is not asking me to edit PKGBUILDS and I don't like diff menu! What do?
+#### _Yay_ is not asking me to edit PKGBUILDS, and I don't like the diff menu! What can I do?
   `yay --editmenu --nodiffmenu --save`
 
-#### Only act on AUR packages or only on repo packages?
-  `yay -{OPERATION} --aur`
+#### How can I tell _yay_ to act only on AUR packages, or only on repo packages?
+  `yay -{OPERATION} --aur`  
   `yay -{OPERATION} --repo`
 
-#### `Out Of Date AUR Packages` message is displayed, why doesn't `yay` update them?
-  This means the package has been flagged out of date on the AUR, but its
-  maintainer has not yet updated the `PKGBUILD`.
+#### An `Out Of Date AUR Packages` message is displayed. Why doesn't _yay_ update them?
+  This message does not mean that updated AUR packages are available. It means
+  means the packages have been flagged out of date on the AUR, but
+  their maintainers have not yet updated the `PKGBUILD`s
+  (see [outdated AUR packages](https://wiki.archlinux.org/index.php/Arch_User_Repository#Foo_in_the_AUR_is_outdated.3B_what_should_I_do.3F)).
 
-#### Yay doesn't install dependencies added to PKGBUILD during installation.
-  Yay resolves all dependencies ahead of time. You are free to edit the
+#### _Yay_ doesn't install dependencies added to a PKGBUILD during installation.
+  _Yay_ resolves all dependencies ahead of time. You are free to edit the
   PKGBUILD in any way, but any problems you cause are your own and should not be
   reported unless they can be reproduced with the original PKGBUILD.
 
 ## Examples of Custom Operations
 
-* `yay <Search Term>` presents package selection menu
-* `yay -Ps` prints system statistics
-* `yay -Pu` prints update list
-* `yay -Yc` cleans unneeded dependencies
-* `yay -G` downloads PKGBUILD from ABS or AUR
-* `yay -Y --gendb` generates development package DB used for devel updates.
-* `yay -Syu --devel --timeupdate` Normal update but also check for development
-  package updates and uses PKGBUILD modification time and not version to
-  determine update
+* present package-installation selection menu  
+  `yay <Search Term>`
+* print system statistics  
+  `yay -Ps`
+* clean unneeded dependencies  
+  `yay -Yc`
+* download PKGBUILD from ABS or AUR  
+  `yay -G <AUR Package>`
+* generate development package database used for devel updates  
+  `yay -Y --gendb`
+* perform system upgrade, but also check for development package updates and use
+  PKGBUILD modification time (not version number) to determine updates  
+  `yay -Syu --devel --timeupdate`
 
 ## Images
 
 <img src="https://cdn.rawgit.com/Jguer/jguer.github.io/5412b8d6/yay/yay-ps.png" width="450">
 <img src="https://cdn.rawgit.com/Jguer/jguer.github.io/5412b8d6/yay/yayupgrade.png" width="450">
 <img src="https://cdn.rawgit.com/Jguer/jguer.github.io/5412b8d6/yay/yaysearch.png" width="450">
+

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Install `go` and `base-devel` with _pacman_.
 
 Note that _yay_ requires a few other projects (as vendored dependencies). These
 projects are stored in `vendor/`, are built into _yay_ at build time, and do not
-need to be installed separately:
+need to be installed separately. Do not edit files in `vendor/`. Here are yay's
+current vendored dependencies:
 
 * https://github.com/Jguer/go-alpm
 * https://github.com/Morganamilo/go-srcinfo

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ Otherwise send us a pull request and we will be happy to review it.
 
 Install `go` and `base-devel` with pacman.
 
-Note that yay requires a few other projects (as vendored dependencies). These
+Note: Yay depends on a few other projects (as vendored dependencies). These
 projects are stored in `vendor/`, are built into yay at build time, and do not
-need to be installed separately. Do not edit files in `vendor/`. Here are yay's
-current vendored dependencies:
+need to be installed separately. These files are managed by
+[dep](https://github.com/golang/dep) and should not be modified manually.
+
+Following are the dependencies managed under dep:
 
 * https://github.com/Jguer/go-alpm
 * https://github.com/Morganamilo/go-srcinfo

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ cd yay
 makepkg -si
 ```
 
+## Support
+
+All support related to Yay should be requested via GitHub issues. Since Yay is not
+officially supported by Arch Linux, support should not be sought out on the
+forums, AUR comments or other official channels.
+
+A broken AUR package should be reported as a comment on the package's AUR page.
+A package may only be considered broken if it fails to build with makepkg.
+Reports should be made using makepkg and include the full output as well as any
+other relevant information. Never make reports using Yay or any other external
+tools.
+
 ## Contributing
 
 Contributors are always welcome!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yay
+# Yay
 
 Yet Another Yogurt - An AUR Helper Written in Go
 
@@ -32,9 +32,9 @@ Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [
 
 ## Installation
 
-If you are migrating from another AUR helper, you can simply install yay with that helper.
+If you are migrating from another AUR helper, you can simply install Yay with that helper.
 
-Alternatively, the initial installation of yay can be done by cloning the PKGBUILD and
+Alternatively, the initial installation of Yay can be done by cloning the PKGBUILD and
 building with makepkg:
 ```sh
 git clone https://aur.archlinux.org/yay.git
@@ -72,7 +72,7 @@ Following are the dependencies managed under dep:
 
 #### Building
 
-Run `make` to build yay. This command will generate a binary called `yay` in
+Run `make` to build Yay. This command will generate a binary called `yay` in
 the same directory as the Makefile.
 
 Note: Yay's Makefile automatically sets the `GOPATH` to `$PWD/.go`. This path will
@@ -88,7 +88,7 @@ style and use `go fmt` only to catch mistakes.
 
 #### Testing
 
-Run `make test` to test yay. This command will verify that the code is
+Run `make test` to test Yay. This command will verify that the code is
 formatted correctly, run the code through `go vet`, and run unit tests.
 
 ## Frequently Asked Questions
@@ -115,11 +115,11 @@ formatted correctly, run the code through `go vet`, and run unit tests.
 #### Yay is not asking me to edit PKGBUILDS, and I don't like the diff menu! What can I do?
   `yay --editmenu --nodiffmenu --save`
 
-#### How can I tell yay to act only on AUR packages, or only on repo packages?
+#### How can I tell Yay to act only on AUR packages, or only on repo packages?
   `yay -{OPERATION} --aur`
   `yay -{OPERATION} --repo`
 
-#### An `Out Of Date AUR Packages` message is displayed. Why doesn't yay update them?
+#### An `Out Of Date AUR Packages` message is displayed. Why doesn't Yay update them?
   This message does not mean that updated AUR packages are available. It means
   means the packages have been flagged out of date on the AUR, but
   their maintainers have not yet updated the `PKGBUILD`s

--- a/README.md
+++ b/README.md
@@ -51,11 +51,15 @@ on, we suggest opening an issue detailing your ideas first.
 
 Otherwise send us a pull request and we will be happy to review it.
 
-#### 1. Install Dependencies
+#### 1. Dependencies
 
-Install `go` and `base-devel` with pacman.
+Yay depends on:
 
-Note: Yay depends on a few other projects (as vendored dependencies). These
+* go (make only)
+* git
+* base-devel
+
+Note: Yay also depends on a few other projects (as vendored dependencies). These
 projects are stored in `vendor/`, are built into yay at build time, and do not
 need to be installed separately. These files are managed by
 [dep](https://github.com/golang/dep) and should not be modified manually.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ on, we suggest opening an issue detailing your ideas first.
 
 Otherwise send us a pull request and we will be happy to review it.
 
-#### Dependencies
+### Dependencies
 
 Yay depends on:
 
@@ -70,7 +70,7 @@ Following are the dependencies managed under dep:
 * https://github.com/Morganamilo/go-srcinfo
 * https://github.com/mikkeloscar/aur
 
-#### Building
+### Building
 
 Run `make` to build Yay. This command will generate a binary called `yay` in
 the same directory as the Makefile.
@@ -80,13 +80,13 @@ ensure dependencies in `vendor/` are built. Running manual go commands such as
 `go build` will require that you either set the `GOPATH` manually or `go get`
 the vendored dependencies into your own `GOPATH`.
 
-#### Code Style
+### Code Style
 
 All code should be formatted through `go fmt`. This tool will automatically
 format code for you. We recommend, however, that you write code in the proper
 style and use `go fmt` only to catch mistakes.
 
-#### Testing
+### Testing
 
 Run `make test` to test Yay. This command will verify that the code is
 formatted correctly, run the code through `go vet`, and run unit tests.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ So say hi to 20+1.
 
 Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [apacman](https://github.com/oshazard/apacman) and [pacaur](https://github.com/rmarquis/pacaur). It is developed with these objectives in mind:
 
-* Wrap the pacman interface
+* Provide an interface for pacman
 * Yaourt-style interactive search/install
 * Minimal dependencies
 * Minimize user input

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [
 
 If you are migrating from another AUR helper, you can simply install yay with that helper.
 
-If you are starting from scratch, you can install yay by cloning the PKGBUILD and
-then building with makepkg:
+Alternatively, the initial installation of yay can be done by cloning the PKGBUILD and
+building with makepkg:
 ```sh
 git clone https://aur.archlinux.org/yay.git
 cd yay

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [
 * Tab-complete the AUR
 * Query user up-front for all input (prior to starting builds)
 * Narrow search terms (`yay linux header` will first search `linux` and then narrow on `header`)
+* Find matching package providers during search and allow selection
 * Remove make dependencies at the end of the build process
 * Run without sourcing PKGBUILD
 

--- a/README.md
+++ b/README.md
@@ -128,19 +128,24 @@ formatted correctly, run the code through `go vet`, and run unit tests.
 
 ## Examples of Custom Operations
 
-* present package-installation selection menu  
-  `yay <Search Term>`
-* print system statistics  
-  `yay -Ps`
-* clean unneeded dependencies  
-  `yay -Yc`
-* download PKGBUILD from ABS or AUR  
-  `yay -G <AUR Package>`
-* generate development package database used for devel updates  
-  `yay -Y --gendb`
-* perform system upgrade, but also check for development package updates and use
-  PKGBUILD modification time (not version number) to determine updates  
-  `yay -Syu --devel --timeupdate`
+`yay <Search Term>`  
+&nbsp; &nbsp; &nbsp; &nbsp; Present package-installation selection menu.
+
+`yay -Ps`  
+&nbsp; &nbsp; &nbsp; &nbsp; Print system statistics.
+
+`yay -Yc`  
+&nbsp; &nbsp; &nbsp; &nbsp; Clean unneeded dependencies.
+
+`yay -G <AUR Package>`  
+&nbsp; &nbsp; &nbsp; &nbsp; Download PKGBUILD from ABS or AUR.
+
+`yay -Y --gendb`  
+&nbsp; &nbsp; &nbsp; &nbsp; Generate development package database used for devel update.
+
+`yay -Syu --devel --timeupdate`  
+&nbsp; &nbsp; &nbsp; &nbsp; Perform system upgrade, but also check for development package updates and use  
+&nbsp; &nbsp; &nbsp; &nbsp; PKGBUILD modification time (not version number) to determine update.
 
 ## Images
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ So say hi to 20+1.
 Yay is based on the design of [yaourt](https://github.com/archlinuxfr/yaourt), [apacman](https://github.com/oshazard/apacman) and [pacaur](https://github.com/rmarquis/pacaur). It is developed with these objectives in mind:
 
 * Wrap the pacman interface
-* Search for packages like yaourt does
+* Yaourt-style interactive search/install
 * Minimize dependencies
 * Minimize user input
 * Know when git packages are due for upgrades

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ formatted correctly, run the code through `go vet`, and run unit tests.
   `yay --editmenu --nodiffmenu --save`
 
 #### How can I tell yay to act only on AUR packages, or only on repo packages?
-  `yay -{OPERATION} --aur`  
+  `yay -{OPERATION} --aur`
   `yay -{OPERATION} --repo`
 
 #### An `Out Of Date AUR Packages` message is displayed. Why doesn't yay update them?


### PR DESCRIPTION
- Add "Objectives" section to group objectives.
- Transform Objective/Feature section bullets into action phrases.
- Fix yay/yaourt/etc capitalization. Italicize and follow ArchWiki style.
- Clearly identify the two Install section options with similar wording.
- Reorganize and reword Contributing section.
- Fix wording in last Code Style section sentence.
- Fix misc FAQ wording.
- Use same style for all FAQ issue links.
- Change link in "skipping packages" FAQ item to ArchWiki partial upgrade.
- Fix FAQ aur-only/repo-only cmd example line-spacing.
- Remove yay -Pu example since it is a deprecated (and wrapped) option.