### PR TITLE
Remove the timeout warning for vcs checks

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -160,7 +160,6 @@ func getCommit(url string, branch string, protocols []string) string {
 		//Introduce a time out so this can not hang
 		timer := time.AfterFunc(5*time.Second, func() {
 			cmd.Process.Kill()
-			fmt.Println(bold(yellow(arrow)), "Timeout:", cyan(url))
 		})
 
 		err = cmd.Wait()


### PR DESCRIPTION
This message is proving to be more misleading than helpful. For
git+https sources, many hosts seem to always timeout when trying
ls-remote over git:// but then succeed on https://. This leads to
a time out message being displayed even though the URL was queried
successfully on the second try.