### PR TITLE
Expand environment variables in config

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -132,6 +132,8 @@ func handleCmd() (err error) {
 		config.saveConfig()
 	}
 
+	config.expandEnv()
+
 	if cmdArgs.existsArg("h", "help") {
 		err = handleHelp()
 		return
@@ -196,7 +198,8 @@ func handlePrint() (err error) {
 	switch {
 	case cmdArgs.existsArg("d", "defaultconfig"):
 		var tmpConfig Configuration
-		defaultSettings(&tmpConfig)
+		tmpConfig.defaultSettings()
+		tmpConfig.expandEnv()
 		fmt.Printf("%v", tmpConfig)
 	case cmdArgs.existsArg("g", "currentconfig"):
 		fmt.Printf("%v", config)

--- a/config.go
+++ b/config.go
@@ -146,9 +146,14 @@ func (config *Configuration) saveConfig() error {
 	return err
 }
 
-func defaultSettings(config *Configuration) {
+func (config *Configuration) defaultSettings() {
+	buildDir := "$HOME/.config/yay"
+	if os.Getenv("XDG_CONFIG_HOME") != "" {
+		buildDir = "$XDG_CONFIG_HOME/yay"
+	}
+
 	config.AURURL = "https://aur.archlinux.org"
-	config.BuildDir = cacheHome
+	config.BuildDir = buildDir
 	config.CleanAfter = false
 	config.Editor = ""
 	config.EditorFlags = ""
@@ -186,6 +191,32 @@ func defaultSettings(config *Configuration) {
 	config.EditMenu = false
 	config.UseAsk = false
 	config.CombinedUpgrade = false
+}
+
+
+func (config *Configuration) expandEnv() {
+	config.AURURL = os.ExpandEnv(config.AURURL)
+	config.BuildDir = os.ExpandEnv(config.BuildDir)
+	config.Editor = os.ExpandEnv(config.Editor)
+	config.EditorFlags = os.ExpandEnv(config.EditorFlags)
+	config.MakepkgBin = os.ExpandEnv(config.MakepkgBin)
+	config.MakepkgConf = os.ExpandEnv(config.MakepkgConf)
+	config.PacmanBin = os.ExpandEnv(config.PacmanBin)
+	config.PacmanConf = os.ExpandEnv(config.PacmanConf)
+	config.GpgFlags = os.ExpandEnv(config.GpgFlags)
+	config.MFlags = os.ExpandEnv(config.MFlags)
+	config.GitFlags = os.ExpandEnv(config.GitFlags)
+	config.SortBy = os.ExpandEnv(config.SortBy)
+	config.TarBin = os.ExpandEnv(config.TarBin)
+	config.GitBin = os.ExpandEnv(config.GitBin)
+	config.GpgBin = os.ExpandEnv(config.GpgBin)
+	config.ReDownload = os.ExpandEnv(config.ReDownload)
+	config.ReBuild = os.ExpandEnv(config.ReBuild)
+	config.AnswerClean = os.ExpandEnv(config.AnswerClean)
+	config.AnswerDiff = os.ExpandEnv(config.AnswerDiff)
+	config.AnswerEdit = os.ExpandEnv(config.AnswerEdit)
+	config.AnswerUpgrade = os.ExpandEnv(config.AnswerUpgrade)
+	config.RemoveMake = os.ExpandEnv(config.RemoveMake)
 }
 
 // Editor returns the preferred system editor.

--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func main() {
 	}
 
 	exitOnError(setPaths())
-	defaultSettings(&config)
+	config.defaultSettings()
 	exitOnError(initHomeDirs())
 	exitOnError(initConfig())
 	exitOnError(cmdArgs.parseCommandLine())


### PR DESCRIPTION
All string variables are expanded because why not? Would be weird to have it just for builddir.

`-Pg` and `-Pd` will show the expanded versions of the config, a little annoying but no big deal. `--save` will correctly keep the variables though which is the important thing.

Fixes #639 #627 