### PR TITLE
Allow running yay via sudo

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -195,6 +196,13 @@ func cleanup() int {
 func main() {
 	if 0 == os.Geteuid() {
 		fmt.Println("Please avoid running yay as root/sudo.")
+	}
+
+	if 0 == os.Geteuid() && os.Getenv("SUDO_UID") != "" && os.Getenv("SUDO_GID") != "" {
+		args := []string{"-g", "#" + os.Getenv("SUDO_GID"), "-u", "#" + os.Getenv("SUDO_UID")}
+		args = append(args, os.Args...)
+		exitOnError(show(exec.Command("sudo", args...)))
+		os.Exit(cleanup())
 	}
 
 	exitOnError(setPaths())


### PR DESCRIPTION
This commit allows running yay via sudo. It does not however let you run
yay as root. Instead the SUDO_UID and SUDO_GID are used to sudo back
into the previous user that originally called yay.

This could allow for `PACMAN=yay makepkg` as a way to build packages
with makepkg while having dependency resolution for the AUR.

The return code problem would also need to be solved for this to work.

This could help with use cases such as #663 #652 and partially implements #69.

Not too sure if this is a good idea. Just an idea I had and it's literally 8 lines of code. Opinions welcome.