### PR TITLE
Fix depends sometimes being ordered incorrectly

### DIFF
--- a/config.go
+++ b/config.go
@@ -193,7 +193,6 @@ func (config *Configuration) defaultSettings() {
 	config.CombinedUpgrade = false
 }
 
-
 func (config *Configuration) expandEnv() {
 	config.AURURL = os.ExpandEnv(config.AURURL)
 	config.BuildDir = os.ExpandEnv(config.BuildDir)


### PR DESCRIPTION
During the merge of depOrder.Bases and depOrder.Aur, there was a point were the depends were read in and out of a map, creating a somewhat random order. Now just use a slice.

Fixes #681 #659