### PR TITLE
Fixup some download bugs

### DIFF
--- a/depPool.go
+++ b/depPool.go
@@ -301,14 +301,12 @@ func (dp *depPool) resolveAURPackages(pkgs stringSet, explicit bool) error {
 			continue
 		}
 
-		//has satisfier installed: skip
-		_, isInstalled := dp.LocalDb.PkgCache().FindSatisfier(dep)
-		if isInstalled == nil {
+		_, isInstalled := dp.LocalDb.PkgCache().FindSatisfier(dep) //has satisfier installed: skip
+		repoPkg, inRepos := dp.SyncDb.FindSatisfier(dep)           //has satisfier in repo: fetch it
+		if isInstalled == nil && (config.ReBuild != "tree" || inRepos == nil) {
 			continue
 		}
 
-		//has satisfier in repo: fetch it
-		repoPkg, inRepos := dp.SyncDb.FindSatisfier(dep)
 		if inRepos == nil {
 			dp.ResolveRepoDependency(repoPkg)
 			continue
@@ -321,7 +319,6 @@ func (dp *depPool) resolveAURPackages(pkgs stringSet, explicit bool) error {
 	}
 
 	err = dp.resolveAURPackages(newAURPackages, false)
-
 	return err
 }
 

--- a/download.go
+++ b/download.go
@@ -286,9 +286,14 @@ func getPkgbuildsfromABS(pkgs []string, path string) (bool, error) {
 		mux.Unlock()
 	}
 
+	count := 0
 	for name, url := range names {
 		wg.Add(1)
 		go download(name, url)
+		count++
+		if count%25 == 0 {
+			wg.Wait()
+		}
 	}
 
 	wg.Wait()

--- a/install.go
+++ b/install.go
@@ -935,7 +935,7 @@ func buildInstallPkgbuilds(dp *depPool, do *depOrder, srcinfos map[string]*gosrc
 		for _, b := range base {
 			isExplicit = isExplicit || dp.Explicit.get(b.Name)
 		}
-		if config.ReBuild == "no" || (config.ReBuild == "yes" && isExplicit) {
+		if config.ReBuild == "no" || (config.ReBuild == "yes" && !isExplicit) {
 			for _, split := range base {
 				pkgdest, ok := pkgdests[split.Name]
 				if !ok {

--- a/install.go
+++ b/install.go
@@ -796,14 +796,16 @@ func pkgbuildsToSkip(bases []Base, targets stringSet) stringSet {
 			isTarget = isTarget || targets.get(pkg.Name)
 		}
 
-		if config.ReDownload == "no" || (config.ReDownload == "yes" && isTarget) {
-			dir := filepath.Join(config.BuildDir, base.Pkgbase(), ".SRCINFO")
-			pkgbuild, err := gosrc.ParseFile(dir)
+		if (config.ReDownload == "yes" && isTarget) || config.ReDownload == "all" {
+			continue
+		}
 
-			if err == nil {
-				if alpm.VerCmp(pkgbuild.Version(), base.Version()) >= 0 {
-					toSkip.set(base.Pkgbase())
-				}
+		dir := filepath.Join(config.BuildDir, base.Pkgbase(), ".SRCINFO")
+		pkgbuild, err := gosrc.ParseFile(dir)
+
+		if err == nil {
+			if alpm.VerCmp(pkgbuild.Version(), base.Version()) >= 0 {
+				toSkip.set(base.Pkgbase())
 			}
 		}
 	}

--- a/install.go
+++ b/install.go
@@ -872,9 +872,14 @@ func downloadPkgbuilds(bases []Base, toSkip stringSet, buildDir string) (stringS
 		mux.Unlock()
 	}
 
+	count := 0
 	for k, base := range bases {
 		wg.Add(1)
 		go download(k, base)
+		count++
+		if count%25 == 0 {
+			wg.Wait()
+		}
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Fix redownload logic
--redownload was reversed and redownloaded the deps instead of the
targets.


Limit download concurrency to 25 threads
Trying to download the ros packages, my system didn't like trying to download 250 packages at once. 

Currently it does it in "batches", so it fetches the first 25 packages, once they all finish it goes on to the next 25. Ideally it would launch a new thread as soon as one finishes. I don't really want to spend time on that and this works well enough. If there's an elegant solution I'd be happy to implement it.