### PR TITLE
Don't assume the go root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ BINNAME := yay
 PACKAGE := ${PKGNAME}_${VERSION}_${ARCH}
 
 export GOPATH=$(shell pwd)/.go
-export GOROOT=/usr/lib/go
 
 default: build
 


### PR DESCRIPTION
The go root might be in different places if the user is using
a different go binary that is not managed by the system (eg
/usr/local/bin/go). In this case the go binary should be smart enough to
default to it's own go root. Or if there are still problems, it is on
the user to configure it themselves.