### PR TITLE
add path expansion for '~' in 'config.BuildDir'

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	pacmanconf "github.com/Morganamilo/go-pacmanconf"
@@ -184,6 +185,9 @@ func (config *Configuration) defaultSettings() {
 
 func (config *Configuration) expandEnv() {
 	config.AURURL = os.ExpandEnv(config.AURURL)
+	if strings.HasPrefix(config.BuildDir, "~"+string(os.PathSeparator)) {
+		config.BuildDir = filepath.Join("$HOME", config.BuildDir[2:])
+	}
 	config.BuildDir = os.ExpandEnv(config.BuildDir)
 	config.Editor = os.ExpandEnv(config.Editor)
 	config.EditorFlags = os.ExpandEnv(config.EditorFlags)


### PR DESCRIPTION
currently, setting `buildDir` in `~/.config/yay/config.json` to something like `"buildDir": "~/.cache/yay"` fails, as go doesn't expand the tilde to `$home`. This makes sense from a program standpoint, as the tilde only expands in shell and not in the environment, but to a user it is unclear why this setting would create a folder in the current directory named `~`.

Also, I am unashamed to admit when I was first starting out on linux I lost an install by running `rm -rf ~` because there was a local folder called `./~`, so I can personally attest that it is potentially dangerous for yay  to be making folders with this naming convention :confounded: 