### PR TITLE
Specify canonical import path

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main
+package main // import "github.com/Jguer/yay"
 
 import (
 	"encoding/json"


### PR DESCRIPTION
This will be made unnecessary by #706, but can be merged without
requiring taking the full plunge into Go modules.

Fixes #704