### PR TITLE
Fix provider menu showing when it shouldn't

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -19,6 +19,10 @@ func questionCallback(question alpm.QuestionAny) {
 		return
 	}
 
+	if hideMenus {
+		return
+	}
+
 	size := 0
 
 	qp.Providers(alpmHandle).ForEach(func(pkg alpm.Package) error {

--- a/config.go
+++ b/config.go
@@ -119,6 +119,8 @@ var alpmHandle *alpm.Handle
 // Mode is used to restrict yay to AUR or repo only modes
 var mode = ModeAny
 
+var hideMenus = false
+
 // SaveConfig writes yay config to file.
 func (config *Configuration) saveConfig() error {
 	marshalledinfo, _ := json.MarshalIndent(config, "", "\t")

--- a/depPool.go
+++ b/depPool.go
@@ -302,7 +302,10 @@ func (dp *depPool) resolveAURPackages(pkgs stringSet, explicit bool) error {
 		}
 
 		_, isInstalled := dp.LocalDb.PkgCache().FindSatisfier(dep) //has satisfier installed: skip
-		repoPkg, inRepos := dp.SyncDb.FindSatisfier(dep)           //has satisfier in repo: fetch it
+		hm := hideMenus
+		hideMenus = isInstalled == nil
+		repoPkg, inRepos := dp.SyncDb.FindSatisfier(dep) //has satisfier in repo: fetch it
+		hideMenus = hm
 		if isInstalled == nil && (config.ReBuild != "tree" || inRepos == nil) {
 			continue
 		}


### PR DESCRIPTION
If the package is already installed, we need to check if it is in the
repos to see if it aplies to rebuild tree. Normally alpm will not prompt
us to select a provider if we already have one installed. An exception
comes up when we have a provider installed that is from the AUR. In this
case FindSatisfier() still asks us to select a provider.

Now make sure to never to never show the menu if the package exists in
the local repo.

Fixes #730