### PR TITLE
Support color = auto

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -121,3 +121,10 @@ func passToGit(dir string, _args ...string) *exec.Cmd {
 	cmd := exec.Command(config.GitBin, args...)
 	return cmd
 }
+
+func isTty() bool {
+	cmd := exec.Command("test", "-t", "1")
+	cmd.Stdout = os.Stdout
+	err := cmd.Run()
+	return err == nil
+}

--- a/main.go
+++ b/main.go
@@ -146,12 +146,14 @@ func initAlpm() error {
 		return err
 	}
 
-	if value, _, _ := cmdArgs.getArg("color"); value == "always" || value == "auto" {
+	if value, _, _ := cmdArgs.getArg("color"); value == "always" {
 		useColor = true
+	} else if value == "auto" {
+		useColor = isTty()
 	} else if value == "never" {
 		useColor = false
 	} else {
-		useColor = pacmanConf.Color
+		useColor = pacmanConf.Color && isTty()
 	}
 
 	return nil


### PR DESCRIPTION
This is done using the test command as the stdlib lacks any way to
do this without using syscalls directly

Fixes #224 

This issue has been open a long time and no actual good solution has come up. This solution is not idea, but it's not horrible as we already rely on other external commands.