### PR TITLE
[Fixes #5] --build option

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,6 +65,7 @@ type Configuration struct {
 	SudoLoop           bool   `json:"sudoloop"`
 	TimeUpdate         bool   `json:"timeupdate"`
 	NoConfirm          bool   `json:"-"`
+	Build              bool   `json:"-"`
 	Devel              bool   `json:"devel"`
 	CleanAfter         bool   `json:"cleanAfter"`
 	GitClone           bool   `json:"gitclone"`

--- a/install.go
+++ b/install.go
@@ -35,9 +35,9 @@ func install(parser *arguments) error {
 				}
 			}
 		} else if parser.existsArg("y", "refresh") || parser.existsArg("u", "sysupgrade") || len(parser.targets) > 0 {
-			if parser.existsArg("build") {
+			// If --build, don’t install nore update anything at this stage
+			if config.Build {
 				arguments := parser.copy()
-				arguments.delArg("build")
 				arguments.delArg("u", "sysupgrade")
 				arguments.clearTargets()
 				err = earlyPacmanCall(arguments)
@@ -130,7 +130,7 @@ func install(parser *arguments) error {
 		return err
 	}
 
-	if len(ds.Aur) == 0 && !parser.existsArg("build") {
+	if len(ds.Aur) == 0 && !config.Build {
 		if !config.CombinedUpgrade {
 			if parser.existsArg("u", "sysupgrade") {
 				fmt.Println(" there is nothing to do")
@@ -153,7 +153,7 @@ func install(parser *arguments) error {
 		return err
 	}
 
-	if parser.existsArg("build") {
+	if config.Build {
 		downloadABS(ds.Repo, config.BuildDir)
 	}
 
@@ -280,7 +280,7 @@ func install(parser *arguments) error {
 		arguments.delArg("u", "sysupgrade")
 	}
 
-	if !parser.existsArg("build") && len(arguments.targets) > 0 || arguments.existsArg("u") {
+	if !config.Build && len(arguments.targets) > 0 || arguments.existsArg("u") {
 		err := show(passToPacman(arguments))
 		if err != nil {
 			return fmt.Errorf("Error installing repo packages")

--- a/install.go
+++ b/install.go
@@ -35,7 +35,16 @@ func install(parser *arguments) error {
 				}
 			}
 		} else if parser.existsArg("y", "refresh") || parser.existsArg("u", "sysupgrade") || len(parser.targets) > 0 {
-			if !parser.existsArg("build") {
+			if parser.existsArg("build") {
+				arguments := parser.copy()
+				arguments.delArg("build")
+				arguments.delArg("u", "sysupgrade")
+				arguments.clearTargets()
+				err = earlyPacmanCall(arguments)
+				if err != nil {
+					return err
+				}
+			} else {
 				err = earlyPacmanCall(parser)
 				if err != nil {
 					return err

--- a/install.go
+++ b/install.go
@@ -970,7 +970,7 @@ func buildInstallABS(dp *depPool, do *depOrder, parser *arguments, incompatible 
 		dir := filepath.Join(config.BuildDir, "packages", pkg, "trunk")
 		built := true
 
-		args := []string{"--nobuild", "-fC", "-s"}
+		args := []string{"--nobuild", "-fC"}
 
 		if incompatible.get(pkg) {
 			args = append(args, "--ignorearch")

--- a/parser.go
+++ b/parser.go
@@ -366,6 +366,7 @@ func isArg(arg string) bool {
 	case "r", "root":
 	case "v", "verbose":
 	case "arch":
+	case "build":
 	case "cachedir":
 	case "color":
 	case "config":

--- a/parser.go
+++ b/parser.go
@@ -527,6 +527,8 @@ func handleConfig(option, value string) bool {
 		config.SortBy = value
 	case "noconfirm":
 		config.NoConfirm = true
+	case "build":
+		config.Build = true
 	case "config":
 		config.PacmanConf = value
 	case "redownload":


### PR DESCRIPTION
Attempt to add a build from ABS options for official packages.
Non-failing yay -S[y][u] --build [\<pkg\>], as long as \<pkg\> is an official or AUR package or there are only official & AUR packages to update.

May not be merged as is, as thorough tests are most certainly needed to make sure all cases are covered!
An important point to address is the management of additional non-official repositories: as is they are silently ignored with --build option, and I don’t know how to deal with them in a tidy manner.

Any comments and hints are welcome towards improving this PR before potential merging.