### PR TITLE
Fix missing '-' in flags

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -374,16 +374,15 @@ func isArg(arg string) bool {
 	case "logfile":
 	case "noconfirm":
 	case "confirm":
-	case "disabledownloadtimeout":
+	case "disable-download-timeout":
 	case "sysroot":
 	case "d", "nodeps":
 	case "assume-installed":
-	case "assumeinstalled":
 	case "dbonly":
 	case "noprogressbar":
 	case "noscriptlet":
 	case "p":
-	case "printformat":
+	case "print-format":
 	case "asdeps":
 	case "asexplicit":
 	case "ignore":


### PR DESCRIPTION
isArg() was generated from pacman's manpage using a script. All dashes
were stripped out. Some flags used '-' as a seperator and were stripped
out by mistake.