### PR TITLE
Allow --print again

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -381,7 +381,7 @@ func isArg(arg string) bool {
 	case "dbonly":
 	case "noprogressbar":
 	case "noscriptlet":
-	case "p":
+	case "p", "print":
 	case "print-format":
 	case "asdeps":
 	case "asexplicit":


### PR DESCRIPTION
Comit 2d6fe95903ac118811d8f24a5fb3361de09e0114 renamed the Yay specific
flag -P/--print to -P/--show. The rename caused --print to stop being
accepted as it was no longer in the list of accepted args.