### PR TITLE
[Solves #734] Allow configurable default for questions

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -64,7 +64,7 @@ Permanent configuration options:
     --answerdiff    <a>   Set a predetermined answer for the diff menu
     --answeredit    <a>   Set a predetermined answer for the edit pkgbuild menu
     --answerupgrade <a>   Set a predetermined answer for the upgrade menu
-    --askwithdefault      Don't skip the menu when any of the above is set
+    --askwithdefault      Don't skip the menu when --answerclean, --answerdiff or --answeredit are set
     --noanswerclean       Unset the answer for the clean build menu
     --noanswerdiff        Unset the answer for the edit diff menu
     --noansweredit        Unset the answer for the edit pkgbuild menu

--- a/cmd.go
+++ b/cmd.go
@@ -59,10 +59,12 @@ Permanent configuration options:
     --requestsplitn <n>   Max amount of packages to query per AUR request
     --completioninterval  <n> Time in days to to refresh completion cache
     --sortby    <field>   Sort AUR results by a specific field during search
+
     --answerclean   <a>   Set a predetermined answer for the clean build menu
     --answerdiff    <a>   Set a predetermined answer for the diff menu
     --answeredit    <a>   Set a predetermined answer for the edit pkgbuild menu
     --answerupgrade <a>   Set a predetermined answer for the upgrade menu
+    --askwithdefault      Don't skip the menu when any of the above is set
     --noanswerclean       Unset the answer for the clean build menu
     --noanswerdiff        Unset the answer for the edit diff menu
     --noansweredit        Unset the answer for the edit pkgbuild menu

--- a/completions/bash
+++ b/completions/bash
@@ -65,7 +65,7 @@ _yay() {
            #yay stuff
            makepkg pacman tar git gpg gpgflags config requestsplitn sudoloop nosudoloop
            redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild
-           sortby answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
+           sortby answerclean answerdiff answeredit answerupgrade askwithdefault noanswerclean noanswerdiff
            noansweredit noanswerupgrade cleanmenu diffmenu editmenu upgrademenu cleanafter nocleanafter
            nocleanmenu nodiffmenu noupgrademenu provides noprovides pgpfetch nopgpfetch
            useask nouseask combinedupgrade nocombinedupgrade aur repo makepkgconf

--- a/completions/fish
+++ b/completions/fish
@@ -97,7 +97,7 @@ complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specif
 complete -c $progname -n "not $noopt" -l answerclean -d 'Set a predetermined answer for the clean build menu' -f
 complete -c $progname -n "not $noopt" -l answeredit -d 'Set a predetermined answer for the edit pkgbuild menu' -f
 complete -c $progname -n "not $noopt" -l answerupgrade -d 'Set a predetermined answer for the upgrade menu' -f
-complete -c $progname -n "not $noopt" -l askwithdefault -d 'Do not skip the menu when any of --answerclean, --answeredit or --answerupgrade are set' -f
+complete -c $progname -n "not $noopt" -l askwithdefault -d 'Do not skip the menu when --answerclean, --answerdiff or --answeredit are set' -f
 complete -c $progname -n "not $noopt" -l noanswerclean -d 'Unset the answer for the clean build menu' -f
 complete -c $progname -n "not $noopt" -l noansweredit -d 'Unset the answer for the edit pkgbuild menu' -f
 complete -c $progname -n "not $noopt" -l noanswerupgrade -d 'Unset the answer for the upgrade menu' -f

--- a/completions/fish
+++ b/completions/fish
@@ -97,6 +97,7 @@ complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specif
 complete -c $progname -n "not $noopt" -l answerclean -d 'Set a predetermined answer for the clean build menu' -f
 complete -c $progname -n "not $noopt" -l answeredit -d 'Set a predetermined answer for the edit pkgbuild menu' -f
 complete -c $progname -n "not $noopt" -l answerupgrade -d 'Set a predetermined answer for the upgrade menu' -f
+complete -c $progname -n "not $noopt" -l askwithdefault -d 'Do not skip the menu when any of --answerclean, --answeredit or --answerupgrade are set' -f
 complete -c $progname -n "not $noopt" -l noanswerclean -d 'Unset the answer for the clean build menu' -f
 complete -c $progname -n "not $noopt" -l noansweredit -d 'Unset the answer for the edit pkgbuild menu' -f
 complete -c $progname -n "not $noopt" -l noanswerupgrade -d 'Unset the answer for the upgrade menu' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -61,6 +61,7 @@ _pacman_opts_common=(
 	'--answerclean[Set a predetermined answer for the clean build menu]:answer'
 	'--answeredit[Set a predetermined answer for the edit pkgbuild menu]:answer'
 	'--answerupgrade[Set a predetermined answer for the upgrade menu]:answer'
+	'--askwithdefault[Do not skip the menu when any of --answerclean, --answeredit or --answerupgrade are set]:answer'
 	'--noanswerclean[Unset the answer for the clean build menu]'
 	'--noansweredit[Unset the answer for the edit pkgbuild menu]'
 	'--noanswerupgrade[Unset the answer for the upgrade menu]'

--- a/completions/zsh
+++ b/completions/zsh
@@ -61,7 +61,7 @@ _pacman_opts_common=(
 	'--answerclean[Set a predetermined answer for the clean build menu]:answer'
 	'--answeredit[Set a predetermined answer for the edit pkgbuild menu]:answer'
 	'--answerupgrade[Set a predetermined answer for the upgrade menu]:answer'
-	'--askwithdefault[Do not skip the menu when any of --answerclean, --answeredit or --answerupgrade are set]:answer'
+	'--askwithdefault[Do not skip the menu when --answerclean, --answerdiff or --answeredit are set]:answer'
 	'--noanswerclean[Unset the answer for the clean build menu]'
 	'--noansweredit[Unset the answer for the edit pkgbuild menu]'
 	'--noanswerupgrade[Unset the answer for the upgrade menu]'

--- a/config.go
+++ b/config.go
@@ -297,7 +297,7 @@ func continueTask(s string, cont bool) bool {
 }
 
 func getInput(defaultValue string) (string, error) {
-	if (defaultValue != "" || config.NoConfirm) && config.AskWithDefault == false {
+	if (defaultValue != "" || config.NoConfirm) && !config.AskWithDefault {
 		fmt.Println(defaultValue)
 		return defaultValue, nil
 	}
@@ -313,7 +313,13 @@ func getInput(defaultValue string) (string, error) {
 		return "", fmt.Errorf("Input too long")
 	}
 
-	return string(buf), nil
+	input := string(buf)
+
+	if input == "" && config.AskWithDefault && defaultValue != "" {
+		input = defaultValue
+	}
+
+	return input, nil
 }
 
 func (config Configuration) String() string {

--- a/config.go
+++ b/config.go
@@ -51,6 +51,7 @@ type Configuration struct {
 	AnswerDiff         string `json:"answerdiff"`
 	AnswerEdit         string `json:"answeredit"`
 	AnswerUpgrade      string `json:"answerupgrade"`
+	AskWithDefault     bool   `json:"askwithdefault"`
 	GitBin             string `json:"gitbin"`
 	GpgBin             string `json:"gpgbin"`
 	GpgFlags           string `json:"gpgflags"`
@@ -173,6 +174,7 @@ func (config *Configuration) defaultSettings() {
 	config.AnswerDiff = ""
 	config.AnswerEdit = ""
 	config.AnswerUpgrade = ""
+	config.AskWithDefault = false
 	config.RemoveMake = "ask"
 	config.GitClone = true
 	config.Provides = true
@@ -295,7 +297,7 @@ func continueTask(s string, cont bool) bool {
 }
 
 func getInput(defaultValue string) (string, error) {
-	if defaultValue != "" || config.NoConfirm {
+	if (defaultValue != "" || config.NoConfirm) && config.AskWithDefault == false {
 		fmt.Println(defaultValue)
 		return defaultValue, nil
 	}

--- a/install.go
+++ b/install.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -533,6 +534,33 @@ func pkgbuildNumberMenu(bases []Base, installed stringSet) bool {
 	return askClean
 }
 
+func buildAnswerMenu(defaultAnswer string) string {
+	answers := map[string][2]string{
+		"[N]one":         {"N", "None"},
+		"[A]ll":          {"A", "All"},
+		"[Ab]ort":        {"Ab", "Abort"},
+		"[I]nstalled":    {"I", "Installed"},
+		"[No]tInstalled": {"No", "Not Installed"},
+	}
+
+	var menu bytes.Buffer
+
+	for text, keys := range answers {
+		for _, key := range keys {
+			if defaultAnswer == key {
+				text = cyan(text)
+				break
+			}
+		}
+		menu.WriteString(text)
+		menu.WriteString(" ")
+	}
+
+	menu.WriteString("or (1 2 3, 1-3, ^4)")
+
+	return menu.String()
+}
+
 func cleanNumberMenu(bases []Base, installed stringSet, hasClean bool) ([]Base, error) {
 	toClean := make([]Base, 0)
 
@@ -540,10 +568,13 @@ func cleanNumberMenu(bases []Base, installed stringSet, hasClean bool) ([]Base, 
 		return toClean, nil
 	}
 
+	defaultAnswer := config.AnswerClean
+
 	fmt.Println(bold(green(arrow + " Packages to cleanBuild?")))
-	fmt.Println(bold(green(arrow) + cyan(" [N]one ") + "[A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"))
+	fmt.Println(bold(green(arrow) + buildAnswerMenu(defaultAnswer)))
 	fmt.Print(bold(green(arrow + " ")))
-	cleanInput, err := getInput(config.AnswerClean)
+
+	cleanInput, err := getInput(defaultAnswer)
 	if err != nil {
 		return nil, err
 	}

--- a/install.go
+++ b/install.go
@@ -568,13 +568,11 @@ func cleanNumberMenu(bases []Base, installed stringSet, hasClean bool) ([]Base, 
 		return toClean, nil
 	}
 
-	defaultAnswer := config.AnswerClean
-
 	fmt.Println(bold(green(arrow + " Packages to cleanBuild?")))
-	fmt.Println(bold(green(arrow) + buildAnswerMenu(defaultAnswer)))
+	fmt.Println(bold(green(arrow) + buildAnswerMenu(config.AnswerClean)))
 	fmt.Print(bold(green(arrow + " ")))
 
-	cleanInput, err := getInput(defaultAnswer)
+	cleanInput, err := getInput(config.AnswerClean)
 	if err != nil {
 		return nil, err
 	}
@@ -645,23 +643,24 @@ func editDiffNumberMenu(bases []Base, installed stringSet, diff bool) ([]Base, e
 	toEdit := make([]Base, 0)
 	var editInput string
 	var err error
-
-	fmt.Println(bold(green(arrow) + cyan(" [N]one ") + "[A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"))
+	var defaultAnswer string
+	var question string
 
 	if diff {
-		fmt.Println(bold(green(arrow + " Diffs to show?")))
-		fmt.Print(bold(green(arrow + " ")))
-		editInput, err = getInput(config.AnswerDiff)
-		if err != nil {
-			return nil, err
-		}
+		defaultAnswer = config.AnswerDiff
+		question = "Diffs to show?"
 	} else {
-		fmt.Println(bold(green(arrow + " PKGBUILDs to edit?")))
-		fmt.Print(bold(green(arrow + " ")))
-		editInput, err = getInput(config.AnswerEdit)
-		if err != nil {
-			return nil, err
-		}
+		defaultAnswer = config.AnswerEdit
+		question = "PKGBUILDs to edit?"
+	}
+
+	fmt.Println(bold(green(arrow) + buildAnswerMenu(defaultAnswer)))
+	fmt.Println(bold(green(arrow + " " + question)))
+	fmt.Print(bold(green(arrow + " ")))
+
+	editInput, err = getInput(defaultAnswer)
+	if err != nil {
+		return nil, err
 	}
 
 	eInclude, eExclude, eOtherInclude, eOtherExclude := parseNumberMenu(editInput)

--- a/install.go
+++ b/install.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -685,29 +684,36 @@ func editDiffNumberMenu(bases []Base, installed stringSet, diff bool) ([]Base, e
 }
 
 func generateMenuText(defaultAnswer string) string {
-	answers := map[string][2]string{
-		"[N]one":         {"n", "none"},
-		"[A]ll":          {"a", "all"},
-		"[Ab]ort":        {"ab", "abort"},
-		"[I]nstalled":    {"i", "installed"},
-		"[No]tInstalled": {"no", "not installed"},
-	}
 	defaultAnswer = strings.ToLower(defaultAnswer)
 
-	var answerKeys []string
-	for k := range answers {
-		answerKeys = append(answerKeys, k)
+	items := []string{
+		"[N]one",
+		"[A]ll",
+		"[Ab]ort",
+		"[I]nstalled",
+		"[No]tInstalled",
 	}
-	sort.Strings(answerKeys)
-
+	var highlight int
 	var menu bytes.Buffer
 
-	for _, key := range answerKeys {
-		if defaultAnswer == answers[key][0] || defaultAnswer == answers[key][1] {
-			key = cyan(key)
+	switch defaultAnswer {
+	case "a", "all":
+		highlight = 1
+	case "ab", "abort":
+		highlight = 2
+	case "i", "installed":
+		highlight = 3
+	case "no", "not installed":
+		highlight = 4
+	default:
+		highlight = 0
+	}
+
+	for key, item := range items {
+		if key == highlight {
+			item = cyan(item)
 		}
-		menu.WriteString(" ")
-		menu.WriteString(key)
+		menu.WriteString(" " + item)
 	}
 
 	menu.WriteString(" or (1 2 3, 1-3, ^4)")

--- a/parser.go
+++ b/parser.go
@@ -441,6 +441,7 @@ func isArg(arg string) bool {
 	case "answerdiff":
 	case "noanswerdiff":
 	case "answeredit":
+	case "askwithdefault":
 	case "noansweredit":
 	case "answerupgrade":
 	case "noanswerupgrade":
@@ -558,6 +559,8 @@ func handleConfig(option, value string) bool {
 		config.AnswerUpgrade = value
 	case "noanswerupgrade":
 		config.AnswerUpgrade = ""
+	case "askwithdefault":
+		config.AskWithDefault = true
 	case "gitclone":
 		config.GitClone = true
 	case "nogitclone":


### PR DESCRIPTION
First I want to stress that constructive feedback is _very_ welcome, especially since I started writing Go code only recently and am still learning the intricacies of the language.

I use yay as my daily AUR helper, so contributing here is a great opportunity to get more hands-on experience with Go and give something back to the project at the same time.

This PR for the feature request #734 adds a new flag `--askwithdefault`, and a matching config option `AskWithDefault`, that alters the way `--answerdiff` `--answeredit` and `--answerclean` work.

When the flag is set or the config option is true, yay no longer skips the answer prompts entirely. Instead, the user can override the --answer* value by entering something else, or simply press enter to confirm the default.