### PR TITLE
Handle libalpm callbacks when checking DB satisfiers for a package

### DIFF
--- a/install.go
+++ b/install.go
@@ -356,7 +356,10 @@ func inRepos(syncDb alpm.DbList, pkg string) bool {
 		return true
 	}
 
+	previousHideMenus := hideMenus
+	hideMenus = false
 	_, err := syncDb.FindSatisfier(target.DepString())
+	hideMenus = previousHideMenus
 	if err == nil {
 		return true
 	}
@@ -384,7 +387,6 @@ func earlyPacmanCall(parser *arguments) error {
 	if mode == ModeRepo {
 		arguments.targets = targets
 	} else {
-		alpmHandle.SetQuestionCallback(func(alpm.QuestionAny) {})
 		//separate aur and repo targets
 		for _, target := range targets {
 			if inRepos(syncDb, target) {


### PR DESCRIPTION
This fixes #753 by re-enabling the default libalpm callback handling behaviour right before checking the satisfiers of a given package.

Before this patch, all libalpm callbacks were being suppressed, which meant a user would never see the `ALPM_QUESTION_INSTALL_IGNOREPKG` prompt to confirm the explicit installation request of a package in the `IgnorePkg` list.