### PR TITLE
 Allow many aur packages to be installed at once.

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -45,7 +45,7 @@ func cleanRemove(pkgNames []string) (err error) {
 		return nil
 	}
 
-	arguments := makeArguments()
+	arguments := cmdArgs.copyGlobal()
 	arguments.addArg("R")
 	arguments.addTarget(pkgNames...)
 

--- a/cmd.go
+++ b/cmd.go
@@ -350,7 +350,7 @@ func displayNumberMenu(pkgS []string) (err error) {
 	}
 
 	include, exclude, _, otherExclude := parseNumberMenu(string(numberBuf))
-	arguments := makeArguments()
+	arguments := cmdArgs.copyGlobal()
 
 	isInclude := len(exclude) == 0 && len(otherExclude) == 0
 

--- a/config.go
+++ b/config.go
@@ -9,8 +9,8 @@ import (
 	"os/exec"
 	"strings"
 
-	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 	alpm "github.com/Jguer/go-alpm"
+	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 )
 
 // Verbosity settings for search
@@ -47,6 +47,7 @@ type Configuration struct {
 	TarBin             string `json:"tarbin"`
 	ReDownload         string `json:"redownload"`
 	ReBuild            string `json:"rebuild"`
+	BatchInstall       bool   `json:"batchinstall"`
 	AnswerClean        string `json:"answerclean"`
 	AnswerDiff         string `json:"answerdiff"`
 	AnswerEdit         string `json:"answeredit"`
@@ -165,6 +166,7 @@ func defaultSettings() *Configuration {
 		RequestSplitN:      150,
 		ReDownload:         "no",
 		ReBuild:            "no",
+		BatchInstall:       false,
 		AnswerClean:        "",
 		AnswerDiff:         "",
 		AnswerEdit:         "",

--- a/install.go
+++ b/install.go
@@ -282,9 +282,9 @@ func install(parser *arguments) (err error) {
 			return fmt.Errorf("Error installing repo packages")
 		}
 
-		depArguments := makeArguments()
+		depArguments := parser.copyGlobal()
 		depArguments.addArg("D", "asdeps")
-		expArguments := makeArguments()
+		expArguments := parser.copyGlobal()
 		expArguments.addArg("D", "asexplicit")
 
 		for _, pkg := range do.Repo {
@@ -1003,9 +1003,9 @@ func buildInstallPkgbuilds(dp *depPool, do *depOrder, srcinfos map[string]*gosrc
 			}
 		}
 
-		depArguments := makeArguments()
+		depArguments := parser.copyGlobal()
 		depArguments.addArg("D", "asdeps")
-		expArguments := makeArguments()
+		expArguments := parser.copyGlobal()
 		expArguments.addArg("D", "asexplicit")
 
 		//remotenames: names of all non repo packages on the system

--- a/install.go
+++ b/install.go
@@ -1047,17 +1047,12 @@ func buildInstallPkgbuilds(dp *depPool, do *depOrder, srcinfos map[string]*gosrc
 			}
 
 			arguments.addTarget(pkgdest)
-			if !dp.Explicit.get(split.Name) && !localNamesCache.get(split.Name) && !remoteNamesCache.get(split.Name) {
+			if parser.existsArg("asdeps", "asdep") {
 				deps = append(deps, split.Name)
-			}
-
-			if dp.Explicit.get(split.Name) {
-				if parser.existsArg("asdeps", "asdep") {
-					deps = append(deps, split.Name)
-				} else if parser.existsArg("asexplicit", "asexp") {
-					exp = append(exp, split.Name)
-
-				}
+			} else if parser.existsArg("asexplicit", "asexp") {
+				exp = append(exp, split.Name)
+			} else if !dp.Explicit.get(split.Name) && !localNamesCache.get(split.Name) && !remoteNamesCache.get(split.Name) {
+				deps = append(deps, split.Name)
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 	alpm "github.com/Jguer/go-alpm"
+	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 )
 
 func setPaths() error {

--- a/parser.go
+++ b/parser.go
@@ -88,6 +88,15 @@ func makeArguments() *arguments {
 	}
 }
 
+func (parser *arguments) copyGlobal() (cp *arguments) {
+	cp = makeArguments()
+	for k, v := range parser.globals {
+		cp.globals[k] = v
+	}
+
+	return
+}
+
 func (parser *arguments) copy() (cp *arguments) {
 	cp = makeArguments()
 

--- a/parser.go
+++ b/parser.go
@@ -449,6 +449,8 @@ func isArg(arg string) bool {
 	case "rebuildall":
 	case "rebuildtree":
 	case "norebuild":
+	case "batchinstall":
+	case "nobatchinstall":
 	case "answerclean":
 	case "noanswerclean":
 	case "answerdiff":
@@ -555,6 +557,10 @@ func handleConfig(option, value string) bool {
 		config.ReBuild = "tree"
 	case "norebuild":
 		config.ReBuild = "no"
+	case "batchinstall":
+		config.BatchInstall = true
+	case "nobatchinstall":
+		config.BatchInstall = false
 	case "answerclean":
 		config.AnswerClean = value
 	case "noanswerclean":


### PR DESCRIPTION
Allow many aur packages to be installed at once.
After building an AUR package don't install it right away. Instead queue
it for install.

Then when a package comes along that does not have all of its
dependencies satisfied, install the queued packages before builting.

This allows a standard AUR update to be done with one transaction, while
building AUR packages will long dependency chains will work as normal.

---

This depended on #767 so now that it's merged I can open this. I'm a little unsure of it as It fear it make .so issues more likely.

But then again updates are unordered anyway so it's possible that `b` depends on `a` and our -Syu updates b first then a updates and gets a .so bump. This as not been a problem so maybe this won't be either.

I know @maximbaz really wanted this before he moved to aurutils ;)