### PR TITLE
Support -Sl

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"net/http"
 	"os"
 
 	alpm "github.com/jguer/go-alpm"
@@ -259,7 +260,7 @@ func handleSync() error {
 		return syncClean(cmdArgs)
 	}
 	if cmdArgs.existsArg("l", "list") {
-		return show(passToPacman(cmdArgs))
+		return syncList(cmdArgs)
 	}
 	if cmdArgs.existsArg("g", "groups") {
 		return show(passToPacman(cmdArgs))
@@ -384,4 +385,52 @@ func displayNumberMenu(pkgS []string) (err error) {
 	err = install(arguments)
 
 	return err
+}
+
+func syncList(parser *arguments) error {
+	aur := false
+
+	for i := len(parser.targets) - 1; i >= 0; i-- {
+		if parser.targets[i] == "aur" && (mode == modeAny || mode == modeAUR) {
+			parser.targets = append(parser.targets[:i], parser.targets[i+1:]...)
+			aur = true
+		}
+	}
+
+	if (mode == modeAny || mode == modeAUR) && (len(parser.targets) == 0 || aur) {
+		localDb, err := alpmHandle.LocalDb()
+		if err != nil {
+			return err
+		}
+
+		resp, err := http.Get(config.AURURL + "/packages.gz")
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+
+		scanner.Scan()
+		for scanner.Scan() {
+			name := scanner.Text()
+			if cmdArgs.existsArg("q", "quiet") {
+				fmt.Println(name)
+			} else {
+				fmt.Printf("%s %s %s", magenta("aur"), bold(name), bold(green("unknown-version")))
+
+				if _, err := localDb.PkgByName(name); err == nil {
+					fmt.Print(bold(blue(" [Installed]")))
+				}
+
+				fmt.Println()
+			}
+		}
+	}
+
+	if (mode == modeAny || mode == modeRepo) && (len(parser.targets) != 0 || !aur) {
+		return show(passToPacman(parser))
+	}
+
+	return nil
 }

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -41,7 +41,7 @@ If no operation is selected \-Y will be assumed.
 
 .SH EXTENDED PACMAN OPERATIONS
 .TP
-.B \-S, \-Si, \-Ss, \-Su, \-Sc, \-Qu
+.B \-S, \-Si, \-Sl, \-Ss, \-Su, \-Sc, \-Qu
 These operations are extended to support both AUR and repo packages.
 
 .TP

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/Jguer/yay/v9
 
 require (
-  github.com/Morganamilo/go-pacmanconf v0.0.0-20180910220353-9c5265e1b14f
-  github.com/Morganamilo/go-srcinfo v0.0.0-20180702014333-368edc79b2c5
-  github.com/jguer/go-alpm v0.0.0-20180914002751-643c287316a5
-  github.com/mikkeloscar/aur v0.0.0-20181111113612-b71516da3ae9
+	github.com/Morganamilo/go-pacmanconf v0.0.0-20180910220353-9c5265e1b14f
+	github.com/Morganamilo/go-srcinfo v0.0.0-20180702014333-368edc79b2c5
+	github.com/jguer/go-alpm v0.0.0-20180914002751-643c287316a5
+	github.com/mikkeloscar/aur v0.0.0-20181111113612-b71516da3ae9
 )


### PR DESCRIPTION
Adds (mostly) complete -Sl support. While pacman will also print the
version number for the package, packages.gz does not give version
numbers. Using -Si to fetch all that data would also be unthinkable.

Instead of just missing out the version number yay will print
"unknown-version". This is so that tools that expect a version number do
not break.