### PR TITLE
remove unwanted space

### DIFF
--- a/download.go
+++ b/download.go
@@ -216,7 +216,7 @@ func getPkgbuildsfromABS(pkgs []string, path string) (bool, error) {
 
 		if pkgDB != "" {
 			if db, err := alpmHandle.SyncDBByName(pkgDB); err == nil {
-				pkg  = db.Pkg(name)
+				pkg = db.Pkg(name)
 			}
 		} else {
 			dbList.ForEach(func(db alpm.DB) error {


### PR DESCRIPTION
This commit fixes ```make test``` fail
```bash
~ make test                                                                                                                            
gofmt -l *.go
download.go
Files need to be linted
make: *** [Makefile:46: test] Ошибка 1
```