### PR TITLE
remove unnecessary assignment

### DIFF
--- a/download.go
+++ b/download.go
@@ -216,7 +216,7 @@ func getPkgbuildsfromABS(pkgs []string, path string) (bool, error) {
 
 		if pkgDB != "" {
 			if db, err := alpmHandle.SyncDBByName(pkgDB); err == nil {
-				pkg  = db.Pkg(name)
+				pkg = db.Pkg(name)
 			}
 		} else {
 			dbList.ForEach(func(db alpm.DB) error {

--- a/query.go
+++ b/query.go
@@ -486,8 +486,7 @@ func aurInfo(names []string, warnings *aurWarnings) ([]*rpc.Pkg, error) {
 		}
 		mux.Lock()
 		for _, _i := range tempInfo {
-			i := _i
-			info = append(info, &i)
+			info = append(info, &_i)
 		}
 		mux.Unlock()
 	}


### PR DESCRIPTION
Each iteration of "range" instruction already makes copy of element, so 
```go
i := _i
```
instructions is unnecessary in this case.