### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/print.go
+++ b/print.go
@@ -189,7 +189,7 @@ func (u upSlice) print() {
 	}
 }
 
-// printDownloadsFromRepo prints repository packages to be downloaded
+// Print prints repository packages to be downloaded
 func (do *depOrder) Print() {
 	repo := ""
 	repoMake := ""


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?