### PR TITLE
Add SudoBin

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -105,6 +105,8 @@ Permanent configuration options:
     --combinedupgrade     Refresh then perform the repo and AUR upgrade together
     --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
 
+    --sudo                <file>  sudo command to use
+    --sudoflags           <flags> Pass arguments to sudo
     --sudoloop            Loop sudo calls in the background to avoid timeout
     --nosudoloop          Do not loop sudo calls in the background
 

--- a/config.go
+++ b/config.go
@@ -58,6 +58,8 @@ type Configuration struct {
 	SortBy             string `json:"sortby"`
 	GitFlags           string `json:"gitflags"`
 	RemoveMake         string `json:"removemake"`
+	SudoBin            string `json:"sudobin"`
+	SudoFlags          string `json:"sudoflags"`
 	RequestSplitN      int    `json:"requestsplitn"`
 	SearchMode         int    `json:"-"`
 	SortMode           int    `json:"sortmode"`
@@ -161,6 +163,8 @@ func defaultSettings() *Configuration {
 		TarBin:             "bsdtar",
 		GitBin:             "git",
 		GpgBin:             "gpg",
+		SudoBin:            "sudo",
+		SudoFlags:          "",
 		TimeUpdate:         false,
 		RequestSplitN:      150,
 		ReDownload:         "no",
@@ -203,6 +207,8 @@ func (config *Configuration) expandEnv() {
 	config.TarBin = os.ExpandEnv(config.TarBin)
 	config.GitBin = os.ExpandEnv(config.GitBin)
 	config.GpgBin = os.ExpandEnv(config.GpgBin)
+	config.SudoBin = os.ExpandEnv(config.SudoBin)
+	config.SudoFlags = os.ExpandEnv(config.SudoFlags)
 	config.ReDownload = os.ExpandEnv(config.ReDownload)
 	config.ReBuild = os.ExpandEnv(config.ReBuild)
 	config.AnswerClean = os.ExpandEnv(config.AnswerClean)

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -483,6 +483,19 @@ passed to gpg. Multiple arguments may be passed by supplying a space
 separated list that is quoted by the shell.
 
 .TP
+.B \-\-sudo <command>
+The command to use for \fBsudo\fR calls. This can be a command in
+\fBPATH\fR or an absolute path to the file.
+The sudoloop is not guarantee to work with a custom \fBsudo\fR command.
+
+.TP
+.B \-\-sudoflags <flags>
+Passes arguments to sudo. These flags get passed to every instance where
+sudo is called by Yay. Arguments are split on whitespace before being
+passed to sudo. Multiple arguments may be passed by supplying a space
+separated list that is quoted by the shell.
+
+.TP
 .B \-\-sudoloop
 Loop sudo calls in the background to prevent sudo from timing out during long
 builds.

--- a/exec.go
+++ b/exec.go
@@ -45,7 +45,7 @@ func sudoLoop() {
 
 func updateSudo() {
 	for {
-		err := show(exec.Command("sudo", "-v"))
+		err := show(exec.Command(config.SudoBin, "-v"))
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 		} else {
@@ -77,7 +77,7 @@ func passToPacman(args *arguments) *exec.Cmd {
 	argArr := make([]string, 0)
 
 	if args.needRoot() {
-		argArr = append(argArr, "sudo")
+		argArr = append(argArr, config.SudoBin, config.SudoFlags)
 	}
 
 	argArr = append(argArr, config.PacmanBin)

--- a/parser.go
+++ b/parser.go
@@ -460,6 +460,8 @@ func isArg(arg string) bool {
 	case "tar":
 	case "git":
 	case "gpg":
+	case "sudo":
+	case "sudoflags":
 	case "requestsplitn":
 	case "sudoloop":
 	case "nosudoloop":
@@ -589,6 +591,10 @@ func handleConfig(option, value string) bool {
 		config.GitBin = value
 	case "gpg":
 		config.GpgBin = value
+	case "sudo":
+		config.SudoBin = value
+	case "sudoflags":
+		config.SudoFlags = value
 	case "requestsplitn":
 		n, err := strconv.Atoi(value)
 		if err == nil && n > 0 {
@@ -722,6 +728,8 @@ func hasParam(arg string) bool {
 	case "tar":
 	case "git":
 	case "gpg":
+	case "sudo":
+	case "sudoflags":
 	case "requestsplitn":
 	case "answerclean":
 	case "answerdiff":


### PR DESCRIPTION
Hello,

this adds the possibility to use a custom binary for sudo instead of the default one (that might also make yay usable for people using doas or other commands instead of sudo for example, the sudoloop won't work though in that case), much like what's done for GpgBin and GitBin.
I've added a default value so that it makes no difference for most users.

