### PR TITLE
FR #936: Adds config parameter for searching in package names only and not in descriptions

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -104,6 +104,8 @@ Permanent configuration options:
     --nouseask            Confirm conflicts manually during the install
     --combinedupgrade     Refresh then perform the repo and AUR upgrade together
     --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
+    --searchby	<field>	  Filter search results by specific field (currently only 'name' is supported)
+    --nosearchby		  Clear search field filter, search in all package fields
 
     --sudoloop            Loop sudo calls in the background to avoid timeout
     --nosudoloop          Do not loop sudo calls in the background

--- a/completions/bash
+++ b/completions/bash
@@ -57,7 +57,8 @@ _yay() {
           search unrequired upgrades' 'c e g i k l m n o p s t u')
   remove=('cascade dbonly nodeps assume-installed nosave print recursive unneeded' 'c n p s u')
   sync=('asdeps asexplicit clean dbonly downloadonly force groups ignore ignoregroup
-         info list needed nodeps assume-installed print refresh recursive search sysupgrade'
+         info list needed nodeps assume-installed print refresh recursive search sysupgrade
+         searchby nosearchby'
         'c g i l p s u w y')
   upgrade=('asdeps asexplicit force needed nodeps assume-installed print recursive' 'p')
   common=('arch cachedir color config confirm dbpath debug gpgdir help hookdir logfile

--- a/completions/fish
+++ b/completions/fish
@@ -208,6 +208,8 @@ complete -c $progname -n "$sync; and __fish_contains_opt -s u sysupgrade" -s u -
 complete -c $progname -n $sync -s w -l downloadonly -d 'Only download the target packages'
 complete -c $progname -n $sync -s y -l refresh -d 'Download fresh copy of the package list'
 complete -c $progname -n "$sync" -xa "$listall $listgroups"
+complete -c $progname -n $sync -s w -l searchby -d 'Filter search results by specific field (currently only 'name' is supported)'
+complete -c $progname -n $sync -s w -l nosearchby -d 'Clear search field filter, search in all package fields'
 
 # Database options
 set -l has_db_opt '__fish_contains_opt asdeps asexplicit'

--- a/completions/zsh
+++ b/completions/zsh
@@ -225,6 +225,8 @@ _pacman_opts_sync_modifiers=(
 	'--asexplicit[Install packages as explicitly installed]'
 	'--force[Overwrite conflicting files]'
 	'--print-format[Specify how the targets should be printed]'
+	'--searchby[Filter search results by specific field (currently only 'name' is supported)]'
+	'--nosearchby[Clear search field filter, search in all package fields]'
 )
 
 # handles --help subcommand

--- a/config.go
+++ b/config.go
@@ -9,8 +9,8 @@ import (
 	"os/exec"
 	"strings"
 
-	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 	alpm "github.com/Jguer/go-alpm"
+	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 )
 
 // Verbosity settings for search
@@ -58,6 +58,7 @@ type Configuration struct {
 	SortBy             string `json:"sortby"`
 	GitFlags           string `json:"gitflags"`
 	RemoveMake         string `json:"removemake"`
+	SearchBy           string `json:"searchby"`
 	RequestSplitN      int    `json:"requestsplitn"`
 	SearchMode         int    `json:"-"`
 	SortMode           int    `json:"sortmode"`
@@ -170,6 +171,7 @@ func defaultSettings() *Configuration {
 		AnswerEdit:         "",
 		AnswerUpgrade:      "",
 		RemoveMake:         "ask",
+		SearchBy:           "",
 		GitClone:           true,
 		Provides:           true,
 		UpgradeMenu:        true,

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -483,6 +483,14 @@ passed to gpg. Multiple arguments may be passed by supplying a space
 separated list that is quoted by the shell.
 
 .TP
+.B \-\-searchby <Name|...>
+Filter search results by specific field (currently only 'name' is supported)
+
+.TP
+.B \-\-nosearchby
+Clear search field filter, search in all package fields
+
+.TP
 .B \-\-sudoloop
 Loop sudo calls in the background to prevent sudo from timing out during long
 builds.

--- a/parser.go
+++ b/parser.go
@@ -489,6 +489,8 @@ func isArg(arg string) bool {
 	case "news":
 	case "gendb":
 	case "currentconfig":
+	case "searchby":
+	case "nosearchby":
 	default:
 		return false
 	}
@@ -640,6 +642,10 @@ func handleConfig(option, value string) bool {
 		config.RemoveMake = "no"
 	case "askremovemake":
 		config.RemoveMake = "ask"
+	case "searchby":
+		config.SearchBy = value
+	case "nosearchby":
+		config.SearchBy = ""
 	default:
 		return false
 	}
@@ -729,6 +735,7 @@ func hasParam(arg string) bool {
 	case "answerupgrade":
 	case "completioninterval":
 	case "sortby":
+	case "searchby":
 	default:
 		return false
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+)
+
+// -----------------------------
+// validPkgName
+// -----------------------------
+
+func TestValidPkgName_WhenTestedPackageNameContainsAllSearched_ReturnsTrue(t *testing.T) {
+
+	searchedPkgNames := []string{"one", "two", "three"}
+	pkgName := "zeroOneTwoThreeFour"
+
+	if !validPkgName(searchedPkgNames, pkgName) {
+		t.Fatalf("Tested package name (%s) scontains all searched package names (%s)", searchedPkgNames, pkgName)
+	}
+}
+
+func TestValidPkgName_WhenTestedPackageNameDoesNotContainAllSearched_ReturnsFalse(t *testing.T) {
+
+	searchedPkgNames := []string{"one", "two", "three"}
+	pkgName := "zeroOneThreeFour"
+
+	if validPkgName(searchedPkgNames, pkgName) {
+		t.Fatalf("Tested package name (%s) does not contain searched package name 'two'", searchedPkgNames)
+	}
+}
+
+func TestValidPkgName_WhenTestedPackageNameIsEmpty_ReturnsFalse(t *testing.T) {
+
+	searchedPkgNames := []string{"one", "two", "three"}
+	pkgName := ""
+
+	if validPkgName(searchedPkgNames, pkgName) {
+		t.Fatalf("Tested package name is empty")
+	}
+}
+
+func TestValidPkgName_WhenSearchedPackageNamesIsEmpty_ReturnsTrue(t *testing.T) {
+
+	var searchedPkgNames []string
+	pkgName := "test"
+
+	if !validPkgName(searchedPkgNames, pkgName) {
+		t.Fatalf("Searched package names is empty, all results are valid.")
+	}
+}


### PR DESCRIPTION
Implements FR #936.
`--pkgnameonly` and `--nopkgnameonly` config params have been added
As config param, each option can be permanently stored if combined with `--save`

Example usage: `yay -Ss --pkgnameonly pkg1 pkg2 ...` 