### PR TITLE
Display what file caused clean errors.

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -188,8 +188,9 @@ func cleanUntracked() error {
 
 		dir := filepath.Join(config.BuildDir, file.Name())
 		if shouldUseGit(dir) {
-			if err := show(passToGit(dir, "clean", "-fx")); err != nil {
-				return err
+			_, stderr, err := capture(passToGit(dir, "clean", "-fx"))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error cleaning %s: %s", dir, stderr)
 			}
 		}
 	}


### PR DESCRIPTION
Previously if a clean failed, you'd get an error, but wouldn't know what
directory caused the error, requiring a bunch of manual checking of each
directory until you found it.
This adds an error message displaying which folder failed to clean.

It also continues cleaning the other directories even if one failed.