### PR TITLE
Hide provider menu with --noprovides

### DIFF
--- a/depPool.go
+++ b/depPool.go
@@ -428,6 +428,10 @@ func (dp *depPool) findSatisfierAurCache(dep string) *rpc.Pkg {
 		}
 	}
 
+	if !config.Provides && providers.Len() >= 1 {
+		return providers.Pkgs[0]
+	}
+
 	if providers.Len() == 1 {
 		return providers.Pkgs[0]
 	}


### PR DESCRIPTION
This feature was already implemented in
e71fb8617a5b014d2f875554e270b5b47d9182d1 but was accidently reverted.