### PR TITLE
Use modules with gcc-go9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,7 @@ BINNAME := yay
 PACKAGE := ${PKGNAME}_${VERSION}_${ARCH}
 
 ifneq (,$(findstring gccgo,$(GOCC)))
-	export GOPATH=$(shell pwd)/.go
 	LDFLAGS := -gccgoflags '-s -w'
-	MOD :=
 endif
 
 default: build


### PR DESCRIPTION
Waiting on https://bugs.archlinux.org/task/62934, but working even without it on gcc-go 9.1.0-1