### PR TITLE
Correct package range in error message

### DIFF
--- a/print.go
+++ b/print.go
@@ -663,7 +663,7 @@ func providerMenu(dep string, providers providers) *rpc.Pkg {
 		}
 
 		if num < 1 || num >= size {
-			fmt.Fprintf(os.Stderr, "%s invalid value: %d is not between %d and %d\n", red("error:"), num, 1, size)
+			fmt.Fprintf(os.Stderr, "%s invalid value: %d is not between %d and %d\n", red("error:"), num, 1, size - 1)
 			continue
 		}
 


### PR DESCRIPTION
```
# ./yay -S nvidia-docker
:: There are 2 providers available for nvidia-container-runtime-hook:
:: Repository AUR
    1) nvidia-container-runtime-hook 2) nvidia-container-runtime-hook-bin

Enter a number (default=1): 3
error: invalid value: 3 is not between 1 and 3
```

should be `3 is not between 1 and 2`.