### PR TITLE
Change depsolver to not use a preallocated slice to get make only deps.

### DIFF
--- a/depOrder.go
+++ b/depOrder.go
@@ -115,7 +115,7 @@ func (do *depOrder) HasMake() bool {
 }
 
 func (do *depOrder) getMake() []string {
-	makeOnly := make([]string, 0, len(do.Aur)+len(do.Repo)-len(do.Runtime))
+	makeOnly := []string{}
 
 	for _, base := range do.Aur {
 		for _, pkg := range base {


### PR DESCRIPTION
Makes it "slower" but fixes issues where cap would return less than 0.

Fixes #857