### PR TITLE
Use BuildDir instead of cacheHome to store PKGBUILDS with -G

### DIFF
--- a/download.go
+++ b/download.go
@@ -299,12 +299,12 @@ func getPkgbuildsfromABS(pkgs []string, path string) (bool, error) {
 
 	download := func(pkg string, url string) {
 		defer wg.Done()
-		if _, err := gitDownloadABS(url, cacheHome, pkg); err != nil {
+		if _, err := gitDownloadABS(url, config.BuildDir, pkg); err != nil {
 			errs.Add(fmt.Errorf("%s Failed to get pkgbuild: %s: %s", bold(red(arrow)), bold(cyan(pkg)), bold(red(err.Error()))))
 			return
 		}
 
-		_, stderr, err := capture(exec.Command("ln", "-s", filepath.Join(cacheHome, pkg, "trunk"), filepath.Join(path, pkg)))
+		_, stderr, err := capture(exec.Command("ln", "-s", filepath.Join(config.BuildDir, pkg, "trunk"), filepath.Join(path, pkg)))
 		mux.Lock()
 		downloaded++
 		if err != nil {
@@ -326,6 +326,6 @@ func getPkgbuildsfromABS(pkgs []string, path string) (bool, error) {
 	}
 
 	wg.Wait()
-	errs.Add(os.RemoveAll(filepath.Join(cacheHome, "packages")))
+	errs.Add(os.RemoveAll(filepath.Join(config.BuildDir, "packages")))
 	return len(missing) != 0, errs.Return()
 }


### PR DESCRIPTION
`BuildDir` resolves to same place as `cacheHome` by default but it's configurable which helps in case user want to chose different directory to store PKGBUILDS.