### PR TITLE
Only remove VCS if the package was removed successfully

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -281,7 +281,7 @@ func handleSync() error {
 }
 
 func handleRemove() error {
-	var err = show(passToPacman(cmdArgs))
+    err := show(passToPacman(cmdArgs))
 	if err == nil {
 		removeVCSPackage(cmdArgs.targets)
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -281,7 +281,7 @@ func handleSync() error {
 }
 
 func handleRemove() error {
-    err := show(passToPacman(cmdArgs))
+	err := show(passToPacman(cmdArgs))
 	if err == nil {
 		removeVCSPackage(cmdArgs.targets)
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -281,8 +281,12 @@ func handleSync() error {
 }
 
 func handleRemove() error {
-	removeVCSPackage(cmdArgs.targets)
-	return show(passToPacman(cmdArgs))
+	var err = show(passToPacman(cmdArgs))
+	if err == nil {
+		removeVCSPackage(cmdArgs.targets)
+	}
+
+	return err
 }
 
 // NumberMenu presents a CLI for selecting packages to install.


### PR DESCRIPTION
Only call removeVCSPackage if the package removal was successful. This closes #1011 