### PR TITLE
Have "make build" build be the default again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ RELEASE_DIR := ${PKGNAME}_${VERSION}_${ARCH}
 PACKAGE := $(RELEASE_DIR).tar.gz
 SOURCES ?= $(shell find . -name "*.go" -type f ! -path "./vendor/*")
 
-.PHONY: all
-all: | clean release
-
 .PHONY: default
 default: build
+
+.PHONY: all
+all: | clean release
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
It's been a while since I built yay manually so I'm not sure when this change was made.

But given how the default rule is still there I assume this change was accidental. The first rule is the default, the actual name `default` has no special meaning.