### PR TITLE
Enforce lint in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ RUN pacman -Syu --overwrite=* --needed --noconfirm \
     gcc gnupg libldap go git tar make awk linux-api-headers pacman-contrib && paccache -rfk0
 
 # Dependency for linting
-RUN go get -u golang.org/x/lint/golint && mv /root/go/bin/golint /bin/
-
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /bin v1.20.0
+RUN go get golang.org/x/lint/golint && mv /root/go/bin/golint /bin/
 
 ENV ARCH=$BUILD_ARCH
 ADD . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN pacman -Syu --overwrite=* --needed --noconfirm \
     gcc gnupg libldap go git tar make awk linux-api-headers pacman-contrib && paccache -rfk0
 
 # Dependency for linting
-RUN go get golang.org/x/lint/golint && mv /root/go/bin/golint /bin/
+RUN go get -u golang.org/x/lint/golint && mv /root/go/bin/golint /bin/
+
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /bin v1.20.0
 
 ENV ARCH=$BUILD_ARCH
 ADD . .

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ test-vendor: vendor
 		exit 1; \
 	fi;
 
+.PHONY: lint
+lint: 
+	golangci-lint run
+	golint -set_exit_status . ./pkg/...
+
 .PHONY: fmt
 fmt:
 	#go fmt -mod=vendor $(GOFILES) ./... Doesn't work yet but will be supported soon

--- a/callbacks.go
+++ b/callbacks.go
@@ -25,7 +25,7 @@ func questionCallback(question alpm.QuestionAny) {
 
 	size := 0
 
-	qp.Providers(alpmHandle).ForEach(func(pkg alpm.Package) error {
+	_ = qp.Providers(alpmHandle).ForEach(func(pkg alpm.Package) error {
 		size++
 		return nil
 	})
@@ -36,7 +36,7 @@ func questionCallback(question alpm.QuestionAny) {
 	size = 1
 	var db string
 
-	qp.Providers(alpmHandle).ForEach(func(pkg alpm.Package) error {
+	_ = qp.Providers(alpmHandle).ForEach(func(pkg alpm.Package) error {
 		thisDB := pkg.DB().Name()
 
 		if db != thisDB {

--- a/clean.go
+++ b/clean.go
@@ -23,7 +23,10 @@ func removeVCSPackage(pkgs []string) {
 	}
 
 	if updated {
-		saveVCSInfo()
+		err := saveVCSInfo()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}
 }
 
@@ -42,13 +45,16 @@ func cleanDependencies(removeOptional bool) error {
 }
 
 // CleanRemove sends a full removal command to pacman with the pkgName slice
-func cleanRemove(pkgNames []string) (err error) {
+func cleanRemove(pkgNames []string) error {
 	if len(pkgNames) == 0 {
 		return nil
 	}
 
 	arguments := makeArguments()
-	arguments.addArg("R")
+	err := arguments.addArg("R")
+	if err != nil {
+		return err
+	}
 	arguments.addTarget(pkgNames...)
 
 	return show(passToPacman(arguments))
@@ -212,7 +218,9 @@ func cleanAfter(bases []Base) {
 				fmt.Fprintf(os.Stderr, "error resetting %s: %s", base.String(), stderr)
 			}
 
-			show(passToGit(dir, "clean", "-fx"))
+			if err := show(passToGit(dir, "clean", "-fx")); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
 		} else {
 			fmt.Printf(bold(cyan("::")+" Deleting (%d/%d): %s\n"), i+1, len(bases), cyan(dir))
 			if err := os.RemoveAll(dir); err != nil {

--- a/depCheck.go
+++ b/depCheck.go
@@ -33,7 +33,7 @@ func (dp *depPool) checkInnerConflict(name string, conflict string, conflicts ty
 }
 
 func (dp *depPool) checkForwardConflict(name string, conflict string, conflicts types.MapStringSet) {
-	dp.LocalDB.PkgCache().ForEach(func(pkg alpm.Package) error {
+	_ = dp.LocalDB.PkgCache().ForEach(func(pkg alpm.Package) error {
 		if pkg.Name() == name || dp.hasPackage(pkg.Name()) {
 			return nil
 		}
@@ -88,7 +88,7 @@ func (dp *depPool) checkInnerConflicts(conflicts types.MapStringSet) {
 	}
 
 	for _, pkg := range dp.Repo {
-		pkg.Conflicts().ForEach(func(conflict alpm.Depend) error {
+		_ = pkg.Conflicts().ForEach(func(conflict alpm.Depend) error {
 			dp.checkInnerConflict(pkg.Name(), conflict.String(), conflicts)
 			return nil
 		})
@@ -103,7 +103,7 @@ func (dp *depPool) checkForwardConflicts(conflicts types.MapStringSet) {
 	}
 
 	for _, pkg := range dp.Repo {
-		pkg.Conflicts().ForEach(func(conflict alpm.Depend) error {
+		_ = pkg.Conflicts().ForEach(func(conflict alpm.Depend) error {
 			dp.checkForwardConflict(pkg.Name(), conflict.String(), conflicts)
 			return nil
 		})
@@ -111,12 +111,12 @@ func (dp *depPool) checkForwardConflicts(conflicts types.MapStringSet) {
 }
 
 func (dp *depPool) checkReverseConflicts(conflicts types.MapStringSet) {
-	dp.LocalDB.PkgCache().ForEach(func(pkg alpm.Package) error {
+	_ = dp.LocalDB.PkgCache().ForEach(func(pkg alpm.Package) error {
 		if dp.hasPackage(pkg.Name()) {
 			return nil
 		}
 
-		pkg.Conflicts().ForEach(func(conflict alpm.Depend) error {
+		_ = pkg.Conflicts().ForEach(func(conflict alpm.Depend) error {
 			dp.checkReverseConflict(pkg.Name(), conflict.String(), conflicts)
 			return nil
 		})
@@ -243,7 +243,7 @@ func (dp *depPool) _checkMissing(dep string, stack []string, missing *missing) {
 	repoPkg := dp.findSatisfierRepo(dep)
 	if repoPkg != nil {
 		missing.Good.Set(dep)
-		repoPkg.Depends().ForEach(func(repoDep alpm.Depend) error {
+		_ = repoPkg.Depends().ForEach(func(repoDep alpm.Depend) error {
 			if _, err := dp.LocalDB.PkgCache().FindSatisfier(repoDep.String()); err == nil {
 				missing.Good.Set(repoDep.String())
 				return nil

--- a/depOrder.go
+++ b/depOrder.go
@@ -94,7 +94,7 @@ func (do *depOrder) orderPkgRepo(pkg *alpm.Package, dp *depPool, runtime bool) {
 	}
 	delete(dp.Repo, pkg.Name())
 
-	pkg.Depends().ForEach(func(dep alpm.Depend) (err error) {
+	_ = pkg.Depends().ForEach(func(dep alpm.Depend) (err error) {
 		repoPkg := dp.findSatisfierRepo(dep.String())
 		if repoPkg != nil {
 			do.orderPkgRepo(repoPkg, dp, runtime)

--- a/depOrder.go
+++ b/depOrder.go
@@ -6,16 +6,20 @@ import (
 	rpc "github.com/mikkeloscar/aur"
 )
 
+// Base is an AUR base package
 type Base []*rpc.Pkg
 
+// Pkgbase returns the first base package.
 func (b Base) Pkgbase() string {
 	return b[0].PackageBase
 }
 
+// Version returns the first base package version.
 func (b Base) Version() string {
 	return b[0].Version
 }
 
+// URLPath returns the first base package URL.
 func (b Base) URLPath() string {
 	return b[0].URLPath
 }

--- a/depPool.go
+++ b/depPool.go
@@ -138,7 +138,7 @@ func (dp *depPool) ResolveTargets(pkgs []string) error {
 			group := dp.SyncDB.FindGroupPkgs(target.Name)
 			if !group.Empty() {
 				dp.Groups = append(dp.Groups, target.String())
-				group.ForEach(func(pkg alpm.Package) error {
+				_ = group.ForEach(func(pkg alpm.Package) error {
 					dp.Explicit.Set(pkg.Name())
 					return nil
 				})
@@ -329,7 +329,7 @@ func (dp *depPool) resolveAURPackages(pkgs types.StringSet, explicit bool) error
 func (dp *depPool) ResolveRepoDependency(pkg *alpm.Package) {
 	dp.Repo[pkg.Name()] = pkg
 
-	pkg.Depends().ForEach(func(dep alpm.Depend) (err error) {
+	_ = pkg.Depends().ForEach(func(dep alpm.Depend) (err error) {
 		//have satisfier in dep tree: skip
 		if dp.hasSatisfier(dep.String()) {
 			return

--- a/download.go
+++ b/download.go
@@ -284,7 +284,7 @@ func getPkgbuildsfromABS(pkgs []string, path string) (bool, error) {
 				pkg = db.Pkg(name)
 			}
 		} else {
-			dbList.ForEach(func(db alpm.DB) error {
+			_ = dbList.ForEach(func(db alpm.DB) error {
 				if pkg = db.Pkg(name); pkg != nil {
 					return fmt.Errorf("")
 				}

--- a/keys_test.go
+++ b/keys_test.go
@@ -29,7 +29,10 @@ func init() {
 			data = getPgpKey(matches[1])
 		}
 		w.Header().Set("Content-Type", "application/pgp-keys")
-		w.Write([]byte(data))
+		_, err := w.Write([]byte(data))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	})
 }
 
@@ -54,7 +57,10 @@ func startPgpKeyServer() *http.Server {
 	srv := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", gpgServerPort)}
 
 	go func() {
-		srv.ListenAndServe()
+		err := srv.ListenAndServe()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}()
 	return srv
 }
@@ -70,7 +76,12 @@ func TestImportKeys(t *testing.T) {
 	config.GpgFlags = fmt.Sprintf("--homedir %s --keyserver 127.0.0.1", keyringDir)
 
 	server := startPgpKeyServer()
-	defer server.Shutdown(context.TODO())
+	defer func() {
+		err := server.Shutdown(context.TODO())
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+	}()
 
 	casetests := []struct {
 		keys      []string
@@ -143,7 +154,12 @@ func TestCheckPgpKeys(t *testing.T) {
 	config.GpgFlags = fmt.Sprintf("--homedir %s --keyserver 127.0.0.1", keyringDir)
 
 	server := startPgpKeyServer()
-	defer server.Shutdown(context.TODO())
+	defer func() {
+		err := server.Shutdown(context.TODO())
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+	}()
 
 	casetests := []struct {
 		pkgs      Base

--- a/main.go
+++ b/main.go
@@ -214,7 +214,10 @@ func main() {
 	exitOnError(initConfig())
 	exitOnError(cmdArgs.parseCommandLine())
 	if shouldSaveConfig {
-		config.saveConfig()
+		err := config.saveConfig()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}
 	config.expandEnv()
 	exitOnError(initBuildDir())

--- a/parser.go
+++ b/parser.go
@@ -757,7 +757,11 @@ func (parser *arguments) parseCommandLine() (err error) {
 	usedNext := false
 
 	if len(args) < 1 {
-		parser.parseShortOption("-Syu", "")
+		_, err = parser.parseShortOption("-Syu", "")
+		if err != nil {
+			return
+		}
+
 	} else {
 		for k, arg := range args {
 			var nextArg string

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -36,7 +36,10 @@ func Update(alpmHandle *alpm.Handle, aurURL string, cacheDir string, interval in
 	info, err := os.Stat(path)
 
 	if os.IsNotExist(err) || (interval != -1 && time.Since(info.ModTime()).Hours() >= float64(interval*24)) || force {
-		os.MkdirAll(filepath.Dir(path), 0755)
+		errd := os.MkdirAll(filepath.Dir(path), 0755)
+		if errd != nil {
+			return errd
+		}
 		out, errf := os.Create(path)
 		if errf != nil {
 			return errf

--- a/query.go
+++ b/query.go
@@ -265,7 +265,7 @@ func queryRepo(pkgInputN []string) (s repoQuery, err error) {
 		return
 	}
 
-	dbList.ForEach(func(db alpm.DB) error {
+	_ = dbList.ForEach(func(db alpm.DB) error {
 		if len(pkgInputN) == 0 {
 			pkgs := db.PkgCache()
 			s = append(s, pkgs.Slice()...)
@@ -353,13 +353,13 @@ func hangingPackages(removeOptional bool) (hanging []string, err error) {
 			safePackages[pkg.Name()] = 0
 		}
 
-		pkg.Provides().ForEach(func(dep alpm.Depend) error {
+		_ = pkg.Provides().ForEach(func(dep alpm.Depend) error {
 			provides.Add(dep.Name, pkg.Name())
 			return nil
 		})
 		return nil
 	}
-	packages.ForEach(setupResources)
+	_ = packages.ForEach(setupResources)
 
 	iterateAgain := true
 	processDependencies := func(pkg alpm.Package) error {
@@ -394,20 +394,20 @@ func hangingPackages(removeOptional bool) (hanging []string, err error) {
 			return nil
 		}
 
-		pkg.Depends().ForEach(markDependencies)
+		_ = pkg.Depends().ForEach(markDependencies)
 		if !removeOptional {
-			pkg.OptionalDepends().ForEach(markDependencies)
+			_ = pkg.OptionalDepends().ForEach(markDependencies)
 		}
 		return nil
 	}
 
 	for iterateAgain {
 		iterateAgain = false
-		packages.ForEach(processDependencies)
+		_ = packages.ForEach(processDependencies)
 	}
 
 	// Build list of packages to be removed
-	packages.ForEach(func(pkg alpm.Package) error {
+	_ = packages.ForEach(func(pkg alpm.Package) error {
 		if safePackages[pkg.Name()] == 0 {
 			hanging = append(hanging, pkg.Name())
 		}

--- a/testdata/travis.sh
+++ b/testdata/travis.sh
@@ -13,7 +13,7 @@ docker build --build-arg BUILD_ARCH=${ARCH} --target builder_env -t yay-builder_
 docker build --build-arg BUILD_ARCH=${ARCH} --target builder -t yay-builder .
 
 # Our unit test and packaging container
-docker run --name yay-go-tests yay-builder_env:latest make test
+docker run --name yay-go-tests yay-builder_env:latest make test && golint && golangci-lint run
 docker rm yay-go-tests
 
 # docker run yay-builder make lint

--- a/upgrade.go
+++ b/upgrade.go
@@ -302,10 +302,15 @@ func upRepo(local []alpm.Package) (upSlice, error) {
 		return slice, err
 	}
 
-	defer alpmHandle.TransRelease()
+	defer func() {
+		err = alpmHandle.TransRelease()
+	}()
 
-	alpmHandle.SyncSysupgrade(cmdArgs.existsDouble("u", "sysupgrade"))
-	alpmHandle.TransGetAdd().ForEach(func(pkg alpm.Package) error {
+	err = alpmHandle.SyncSysupgrade(cmdArgs.existsDouble("u", "sysupgrade"))
+	if err != nil {
+		return slice, err
+	}
+	_ = alpmHandle.TransGetAdd().ForEach(func(pkg alpm.Package) error {
 		localVer := "-"
 
 		if localPkg := localDB.Pkg(pkg.Name()); localPkg != nil {


### PR DESCRIPTION
This commit enables linting by golint and golangci-lint (until golint actually works in golangci-lint again) in github actions.

Changes had to be done to bring the project up to linted standard which mostly included comments on exported functions (Important after more modules are popped out) and `errcheck` issues which are the most sensitive part of this PR. 