### PR TITLE
Move abs cloning to it's own directory

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ type targetMode int
 type Configuration struct {
 	AURURL             string `json:"aururl"`
 	BuildDir           string `json:"buildDir"`
+	ABSDir             string `json:"absdir"`
 	Editor             string `json:"editor"`
 	EditorFlags        string `json:"editorflags"`
 	MakepkgBin         string `json:"makepkgbin"`
@@ -143,6 +144,7 @@ func defaultSettings() *Configuration {
 	config := &Configuration{
 		AURURL:             "https://aur.archlinux.org",
 		BuildDir:           "$HOME/.cache/yay",
+		ABSDir:             "$HOME/.cache/yay/abs",
 		CleanAfter:         false,
 		Editor:             "",
 		EditorFlags:        "",

--- a/download.go
+++ b/download.go
@@ -103,7 +103,12 @@ func gitHasDiff(path string, name string) (bool, error) {
 
 // TODO: yay-next passes args through the header, use that to unify ABS and AUR
 func gitDownloadABS(url string, path string, name string) (bool, error) {
-	_, err := os.Stat(filepath.Join(path, name))
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = os.Stat(filepath.Join(path, name))
 	if os.IsNotExist(err) {
 		cmd := passToGit(path, "clone", "--no-progress", "--single-branch",
 			"-b", "packages/"+name, url, name)
@@ -340,7 +345,7 @@ func getPkgbuildsfromABS(pkgs []string, path string) (bool, error) {
 
 	download := func(pkg string, url string) {
 		defer wg.Done()
-		if _, err := gitDownloadABS(url, config.BuildDir, pkg); err != nil {
+		if _, err := gitDownloadABS(url, config.ABSDir, pkg); err != nil {
 			errs.Add(fmt.Errorf("%s Failed to get pkgbuild: %s: %s", bold(red(arrow)), bold(cyan(pkg)), bold(red(err.Error()))))
 			return
 		}

--- a/parser.go
+++ b/parser.go
@@ -537,6 +537,8 @@ func handleConfig(option, value string) bool {
 		config.GitFlags = value
 	case "builddir":
 		config.BuildDir = value
+	case "absdir":
+		config.ABSDir = value
 	case "editor":
 		config.Editor = value
 	case "editorflags":
@@ -680,6 +682,7 @@ func hasParam(arg string) bool {
 	case "gpgflags":
 	case "gitflags":
 	case "builddir":
+	case "absdir":
 	case "editor":
 	case "editorflags":
 	case "makepkg":


### PR DESCRIPTION
As mentioned it is possible for stuff to clash in cache if you were to
-G a package from the repos, then -S an AUR package by the same name. To
avoid that give abs cloning its own directory.

It is still possible for a clash to occur if there was a package named
abs. However currently there is not.

Idealy the aur cloning would also get it's own subdir, but that will
invalidate everyone's cache so leaving it for a time with more breaking
changes.

This is also under its own config option so that AURDEST does not
interfere with it.