### PR TITLE
Clarfiy Out Of Date Message

### DIFF
--- a/print.go
+++ b/print.go
@@ -39,7 +39,7 @@ func (warnings *aurWarnings) print() {
 	}
 
 	if len(warnings.OutOfDate) > 0 {
-		fmt.Print(bold(yellow(smallArrow)) + " Out Of Date AUR Packages:")
+		fmt.Print(bold(yellow(smallArrow)) + " Flagged Out Of Date AUR Packages:")
 		for _, name := range warnings.OutOfDate {
 			fmt.Print("  " + cyan(name))
 		}


### PR DESCRIPTION
The existing message was a bit confusing and made me think that the AUR package 
had an update pending which Yay refused to do. I realized instead that the package is
actually *flagged* out of date on the AUR.

I then realized there is a section in the README specifically about this confusion.

So, by prefixing the word "Flagged" I think the slight confusion can be eliminated, and the 
README section possibly removed.