### PR TITLE
Remove tar support

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -192,10 +192,8 @@ func cleanUntracked() error {
 		}
 
 		dir := filepath.Join(config.BuildDir, file.Name())
-		if shouldUseGit(dir) {
-			if err := show(passToGit(dir, "clean", "-fx")); err != nil {
-				return err
-			}
+		if err := show(passToGit(dir, "clean", "-fx")); err != nil {
+			return err
 		}
 	}
 
@@ -208,21 +206,14 @@ func cleanAfter(bases []Base) {
 	for i, base := range bases {
 		dir := filepath.Join(config.BuildDir, base.Pkgbase())
 
-		if shouldUseGit(dir) {
-			fmt.Printf(bold(cyan("::")+" Cleaning (%d/%d): %s\n"), i+1, len(bases), cyan(dir))
-			_, stderr, err := capture(passToGit(dir, "reset", "--hard", "HEAD"))
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error resetting %s: %s", base.String(), stderr)
-			}
+		fmt.Printf(bold(cyan("::")+" Cleaning (%d/%d): %s\n"), i+1, len(bases), cyan(dir))
+		_, stderr, err := capture(passToGit(dir, "reset", "--hard", "HEAD"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error resetting %s: %s", base.String(), stderr)
+		}
 
-			if err := show(passToGit(dir, "clean", "-fx")); err != nil {
-				fmt.Fprintln(os.Stderr, err)
-			}
-		} else {
-			fmt.Printf(bold(cyan("::")+" Deleting (%d/%d): %s\n"), i+1, len(bases), cyan(dir))
-			if err := os.RemoveAll(dir); err != nil {
-				fmt.Fprintln(os.Stderr, err)
-			}
+		if err := show(passToGit(dir, "clean", "-fx")); err != nil {
+			fmt.Fprintln(os.Stderr, err)
 		}
 	}
 }

--- a/cmd.go
+++ b/cmd.go
@@ -51,7 +51,6 @@ Permanent configuration options:
     --makepkg     <file>  makepkg command to use
     --mflags      <flags> Pass arguments to makepkg
     --pacman      <file>  pacman command to use
-    --tar         <file>  bsdtar command to use
     --git         <file>  git command to use
     --gitflags    <flags> Pass arguments to git
     --gpg         <file>  gpg command to use
@@ -91,8 +90,6 @@ Permanent configuration options:
 
     --devel               Check development packages during sysupgrade
     --nodevel             Do not check development packages
-    --gitclone            Use git clone for PKGBUILD retrieval
-    --nogitclone          Never use git clone for PKGBUILD retrieval
     --rebuild             Always build target packages
     --rebuildall          Always build all AUR packages
     --norebuild           Skip package build if in cache and up to date
@@ -131,7 +128,7 @@ yay specific options:
        --gendb            Generates development package DB used for updating
 
 getpkgbuild specific options:
-    -f --force            Force download for existing tar packages
+    -f --force            Force download for existing ABS packages
 
 If no arguments are provided 'yay -Syu' will be performed
 If no operation is provided -Y will be assumed`)

--- a/completions/fish
+++ b/completions/fish
@@ -172,7 +172,7 @@ complete -c $progname -n "$show" -s w -l news -d 'Print arch news' -f
 complete -c $progname -n "$show" -s q -l quiet -d 'Do not print news description' -f
 
 # Getpkgbuild options
-complete -c $progname -n "$getpkgbuild" -s f -l force -d 'Force download for existing tar packages' -f
+complete -c $progname -n "$getpkgbuild" -s f -l force -d 'Force download for existing ABS packages' -f
 complete -c $progname -n "$getpkgbuild" -xa "$listall"
 
 # Premenent configuration settings
@@ -217,8 +217,6 @@ complete -c $progname -n "not $noopt" -l topdown -d 'Shows repository packages f
 complete -c $progname -n "not $noopt" -l bottomup -d 'Shows aur packages first and then repository' -f
 complete -c $progname -n "not $noopt" -l devel -d 'Check -git/-svn/-hg development version' -f
 complete -c $progname -n "not $noopt" -l nodevel -d 'Disable development version checking' -f
-complete -c $progname -n "not $noopt" -l gitclone -d 'Use git to download and update PKGBUILDs' -f
-complete -c $progname -n "not $noopt" -l nogitclone -d 'Download and update PKGBUILDs using tarballs' -f
 complete -c $progname -n "not $noopt" -l cleanafter -d 'Clean package sources after successful build' -f
 complete -c $progname -n "not $noopt" -l nocleanafter -d 'Disable package sources cleaning' -f
 complete -c $progname -n "not $noopt" -l timeupdate -d 'Check package modification date and version' -f

--- a/config.go
+++ b/config.go
@@ -45,7 +45,6 @@ type Configuration struct {
 	MakepkgConf        string `json:"makepkgconf"`
 	PacmanBin          string `json:"pacmanbin"`
 	PacmanConf         string `json:"pacmanconf"`
-	TarBin             string `json:"tarbin"`
 	ReDownload         string `json:"redownload"`
 	ReBuild            string `json:"rebuild"`
 	BatchInstall       bool   `json:"batchinstall"`
@@ -72,7 +71,6 @@ type Configuration struct {
 	NoConfirm          bool   `json:"-"`
 	Devel              bool   `json:"devel"`
 	CleanAfter         bool   `json:"cleanAfter"`
-	GitClone           bool   `json:"gitclone"`
 	Provides           bool   `json:"provides"`
 	PGPFetch           bool   `json:"pgpfetch"`
 	UpgradeMenu        bool   `json:"upgrademenu"`
@@ -165,7 +163,6 @@ func defaultSettings() *Configuration {
 		SortBy:             "votes",
 		SearchBy:           "name-desc",
 		SudoLoop:           false,
-		TarBin:             "bsdtar",
 		GitBin:             "git",
 		GpgBin:             "gpg",
 		SudoBin:            "sudo",
@@ -180,7 +177,6 @@ func defaultSettings() *Configuration {
 		AnswerEdit:         "",
 		AnswerUpgrade:      "",
 		RemoveMake:         "ask",
-		GitClone:           true,
 		Provides:           true,
 		UpgradeMenu:        true,
 		CleanMenu:          true,
@@ -212,7 +208,6 @@ func (config *Configuration) expandEnv() {
 	config.GitFlags = os.ExpandEnv(config.GitFlags)
 	config.SortBy = os.ExpandEnv(config.SortBy)
 	config.SearchBy = os.ExpandEnv(config.SearchBy)
-	config.TarBin = os.ExpandEnv(config.TarBin)
 	config.GitBin = os.ExpandEnv(config.GitBin)
 	config.GpgBin = os.ExpandEnv(config.GpgBin)
 	config.SudoBin = os.ExpandEnv(config.SudoBin)

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -31,8 +31,8 @@ Perform yay specific print operations.
 
 .TP
 .B \-G, \-\-getpkgbuild
-Downloads PKGBUILD from ABS or AUR. ABS pkgbuilds are always downloaded using
-tarballs and taken from trunk. The ABS can only be used for Arch Linux repositories
+Downloads PKGBUILD from ABS or AUR. The ABS can only be used for Arch Linux
+repositories
 
 .RE
 If no arguments are provided 'yay \-Syu' will be performed.
@@ -47,9 +47,8 @@ These operations are extended to support both AUR and repo packages.
 .TP
 .B \-Sc
 Yay will also clean cached AUR package and any untracked Files in the
-cache. Untracked files cleaning only works for packages downloaded
-using gitclone. Cleaning untracked files will wipe any downloaded
-sources or built packages but will keep already downloaded vcs sources.
+cache. Cleaning untracked files will wipe any downloaded sources or
+built packages but will keep already downloaded vcs sources.
 
 .TP
 .B \-R
@@ -132,9 +131,8 @@ Only show titles when printing news.
 .SH GETPKGBUILD OPTIONS (APPLY TO \-G AND \-\-GETPKGBUILD)
 .TP
 .B \-f, \-\-force
-Force download for packages that already exist in the current directory. This
-ensures directories are not accidentally overwritten. This option is not needed
-for git based downloads as \fBgit pull\fR already has safety mechanisms.
+Force download for ABS packages that already exist in the current directory. This
+ensures directories are not accidentally overwritten.
 
 .SH PERMANENT CONFIGURATION SETTINGS
 .TP
@@ -356,26 +354,12 @@ a list of packages into yay (see \fBexamples\fR).
 Do not check for development packages updates during sysupgrade.
 
 .TP
-.B \-\-gitclone
-Use git to download and update PKGBUILDs. PKGBUILDs previously downloaded
-using tarball will continue to use tarballs until the package is clean
-built. Similarly, PKGBUILDs managed with git will continue to use git until
-the package is clean built..
-
-.TP
-.B \-\-nogitclone
-Download and update PKGBUILDs using tarballs. The above conditions about
-previously installed packages still apply.
-
-.TP
 .B \-\-cleanafter
-Remove package sources after successful Install.
+Remove untracked files after installation.
 
-For packages downloaded through git, untracked files are removed with the
-exception of directories. This allows VCS packages to easily pull an update
+Untracked files are removed with the exception of directories.
+This allows VCS packages to easily pull an update
 instead of having to re clone the entire repo.
-
-For packages downloaded via tarball, the entire directory is deleted.
 
 .TP
 .B \-\-nocleanafter

--- a/parser.go
+++ b/parser.go
@@ -406,8 +406,6 @@ func isArg(arg string) bool {
 	case "noansweredit":
 	case "answerupgrade":
 	case "noanswerupgrade":
-	case "gitclone":
-	case "nogitclone":
 	case "gpgflags":
 	case "mflags":
 	case "gitflags":
@@ -418,7 +416,6 @@ func isArg(arg string) bool {
 	case "makepkgconf":
 	case "nomakepkgconf":
 	case "pacman":
-	case "tar":
 	case "git":
 	case "gpg":
 	case "sudo":
@@ -528,10 +525,6 @@ func handleConfig(option, value string) bool {
 		config.AnswerUpgrade = value
 	case "noanswerupgrade":
 		config.AnswerUpgrade = ""
-	case "gitclone":
-		config.GitClone = true
-	case "nogitclone":
-		config.GitClone = false
 	case "gpgflags":
 		config.GpgFlags = value
 	case "mflags":
@@ -554,8 +547,6 @@ func handleConfig(option, value string) bool {
 		config.MakepkgConf = ""
 	case "pacman":
 		config.PacmanBin = value
-	case "tar":
-		config.TarBin = value
 	case "git":
 		config.GitBin = value
 	case "gpg":
@@ -695,7 +686,6 @@ func hasParam(arg string) bool {
 	case "makepkg":
 	case "makepkgconf":
 	case "pacman":
-	case "tar":
 	case "git":
 	case "gpg":
 	case "sudo":


### PR DESCRIPTION
tar is slower and harder to diff. I doubt any one still uses it intentially.

There's a chance some people have not cleared their cache in two years
and still have tar based packages around. But forcing them to clear
their cache is not a big deal at all.