### PR TITLE
Add low priority option [v3]

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -116,6 +116,9 @@ Permanent configuration options:
     --timeupdate          Check packages' AUR page for changes during sysupgrade
     --notimeupdate        Do not check packages' AUR page for changes
 
+    --lowpriority         Use lowest CPU and IO priorities
+    --nolowpriority       Do not use lowest CPU and IO priorities
+
 show specific options:
     -c --complete         Used for completions
     -d --defaultconfig    Print default yay configuration

--- a/completions/fish
+++ b/completions/fish
@@ -242,3 +242,5 @@ complete -c $progname -n "not $noopt" -l mflags -d 'Pass the following options t
 complete -c $progname -n "not $noopt" -l gpgflags -d 'Pass the following options to gpg' -f
 complete -c $progname -n "not $noopt" -l sudoloop -d 'Loop sudo calls in the background to avoid timeout' -f
 complete -c $progname -n "not $noopt" -l nosudoloop -d 'Do not loop sudo calls in the background' -f
+complete -c $progname -n "not $noopt" -l lowpriority -d 'Use lowest CPU and IO priorities' -f
+complete -c $progname -n "not $noopt" -l nolowpriority -d 'Do not use lowest CPU and IO priorities' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -106,6 +106,8 @@ _pacman_opts_common=(
 	'--sortby[Sort AUR results by a specific field during search]'
 	'--batchinstall[Build multiple AUR packages then install them together]'
 	'--nobatchinstall[Build and install each AUR package one by one]'
+	'--lowpriority[Use lowest CPU and IO priorities]'
+	'--nolowpriority[Do not use lowest CPU and IO priorities]'
 )
 
 # options for passing to _arguments: options for --upgrade commands

--- a/config.go
+++ b/config.go
@@ -79,6 +79,7 @@ type Configuration struct {
 	EditMenu           bool   `json:"editmenu"`
 	CombinedUpgrade    bool   `json:"combinedupgrade"`
 	UseAsk             bool   `json:"useask"`
+	LowPriority        bool   `json:"lowpriority"`
 }
 
 var version = "9.4.2"
@@ -184,6 +185,7 @@ func defaultSettings() *Configuration {
 		EditMenu:           false,
 		UseAsk:             false,
 		CombinedUpgrade:    false,
+		LowPriority:        false,
 	}
 
 	if os.Getenv("XDG_CACHE_HOME") != "" {

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -452,6 +452,15 @@ another package, install all the packages in the install queue.
 Always install AUR packages immediately after building them.
 
 .TP
+.B \-\-lowpriority
+Use lowest CPU and IO priorities. Set process nice to +19 and ionice class to
+idle. Useful for background updates.
+
+.TP
+.B \-\-nolowpriority
+Do not use lowest CPU and IO priorities. Use process default priorities.
+
+.TP
 .B \-\-rebuild
 Always build target packages even when a copy is available in cache.
 

--- a/install.go
+++ b/install.go
@@ -61,6 +61,18 @@ func install(parser *arguments) (err error) {
 
 	warnings := makeWarnings()
 
+	if config.LowPriority {
+		ecode := setPriority(prioProcess, 0, 19)
+		if ecode != 0 {
+			return fmt.Errorf("Error unable to set CPU priority")
+		}
+
+		ecode = ioPrioSet(ioprioWhoProcess, 0, ioprioPrioValue(ioprioClassIdle, 7))
+		if ecode != 0 {
+			return fmt.Errorf("Error unable to set IO priority")
+		}
+	}
+
 	if mode == modeAny || mode == modeRepo {
 		if config.CombinedUpgrade {
 			if parser.existsArg("y", "refresh") {

--- a/parser.go
+++ b/parser.go
@@ -449,6 +449,7 @@ func isArg(arg string) bool {
 	case "news":
 	case "gendb":
 	case "currentconfig":
+	case "lowpriority":
 	default:
 		return false
 	}
@@ -606,6 +607,10 @@ func handleConfig(option, value string) bool {
 		config.RemoveMake = "no"
 	case "askremovemake":
 		config.RemoveMake = "ask"
+	case "lowpriority":
+		config.LowPriority = true
+	case "nolowpriority":
+		config.LowPriority = false
 	default:
 		return false
 	}

--- a/parser.go
+++ b/parser.go
@@ -450,6 +450,7 @@ func isArg(arg string) bool {
 	case "gendb":
 	case "currentconfig":
 	case "lowpriority":
+	case "nolowpriority":
 	default:
 		return false
 	}

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"syscall"
 	"unicode"
 )
 
@@ -76,4 +77,22 @@ func LessRunes(iRunes, jRunes []rune) bool {
 	}
 
 	return len(iRunes) < len(jRunes)
+}
+
+const ioprioClassIdle = 3
+const ioprioWhoProcess = 1
+const ioprioClassShift = 13
+
+func ioprioPrioValue(class, data int) int { return ((class) << ioprioClassShift) | data }
+
+func ioPrioSet(which, who, ioprio int) int {
+	ecode, _, _ := syscall.Syscall(syscall.SYS_IOPRIO_SET, uintptr(which), uintptr(who), uintptr(ioprio))
+	return int(ecode)
+}
+
+const prioProcess = 0
+
+func setPriority(which, who, prio int) int {
+	ecode, _, _ := syscall.Syscall(syscall.SYS_SETPRIORITY, uintptr(which), uintptr(who), uintptr(prio))
+	return int(ecode)
 }


### PR DESCRIPTION
Low priority will make yay and all child process use the lowest possible
CPU and IO priority (nice +19, ionice class idle).

Useful for background build updates.

Signed-off-by: Vinicius Tinti <viniciustinti@gmail.com>