### PR TITLE
Add error handler on saveConfig

### DIFF
--- a/config.go
+++ b/config.go
@@ -126,18 +126,19 @@ var hideMenus = false
 
 // SaveConfig writes yay config to file.
 func (config *Configuration) saveConfig() error {
-	marshalledinfo, _ := json.MarshalIndent(config, "", "\t")
+	marshalledinfo, err := json.MarshalIndent(config, "", "\t")
+	if err != nil {
+		return err
+	}
 	in, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
-	_, err = in.Write(marshalledinfo)
-	if err != nil {
+	if _, err = in.Write(marshalledinfo); err != nil {
 		return err
 	}
-	err = in.Sync()
-	return err
+	return in.Sync()
 }
 
 func defaultSettings() *Configuration {


### PR DESCRIPTION
I think that should be good to add error handler on `saveConfig()` function