### PR TITLE
Also install `*-debug` packages if built by makepkg

### DIFF
--- a/install.go
+++ b/install.go
@@ -1119,6 +1119,14 @@ func buildInstallPkgbuilds(dp *depPool, do *depOrder, srcinfos map[string]*gosrc
 				return fmt.Errorf("Could not find PKGDEST for: %s", name)
 			}
 
+			if _, err := os.Stat(pkgdest); os.IsNotExist(err) {
+				if optional {
+					return nil
+				}
+
+				return fmt.Errorf("PKGDEST for %s listed by makepkg, but does not exist: %s", name, pkgdest)
+			}
+
 			arguments.addTarget(pkgdest)
 			if parser.existsArg("asdeps", "asdep") {
 				deps = append(deps, name)

--- a/install.go
+++ b/install.go
@@ -1112,11 +1112,11 @@ func buildInstallPkgbuilds(dp *depPool, do *depOrder, srcinfos map[string]*gosrc
 		doAddTarget := func(name string, optional bool) error {
 			pkgdest, ok := pkgdests[name]
 			if !ok {
-				if !optional {
-					return fmt.Errorf("Could not find PKGDEST for: %s", name)
+				if optional {
+					return nil
 				}
 
-				return nil
+				return fmt.Errorf("Could not find PKGDEST for: %s", name)
 			}
 
 			arguments.addTarget(pkgdest)

--- a/install.go
+++ b/install.go
@@ -1114,9 +1114,9 @@ func buildInstallPkgbuilds(dp *depPool, do *depOrder, srcinfos map[string]*gosrc
 			if !ok {
 				if !optional {
 					return fmt.Errorf("Could not find PKGDEST for: %s", name)
-				} else {
-					return nil
 				}
+
+				return nil
 			}
 
 			arguments.addTarget(pkgdest)


### PR DESCRIPTION
Make `yay` also install the separate `*-debug` packages which are created if both the `debug` and `strip` options are set in `makepkg.conf`.

This fixes #1190.

Also note: I don't usually code go, and just tried to follow the conventions of elsewhere in the file.