### PR TITLE
Prefer user-defined GOPROXY in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 export GO111MODULE=on
-export GOPROXY=https://proxy.golang.org
+GOPROXY ?= https://proxy.golang.org
+export GOPROXY
 
 BUILD_TAG = devel
 ARCH ?= $(shell uname -m)


### PR DESCRIPTION
Related issue: #1209 

Use `GOPROXY` if it's set, otherwise default to `https://proxy.golang.org`.