### PR TITLE
Treat whole split-package as devel when pkgbase matches too

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -172,3 +172,7 @@ func isDevelName(name string) bool {
 
 	return strings.Contains(name, "-always-")
 }
+
+func isDevelPackage(pkg alpm.Package) bool {
+	return isDevelName(pkg.Name()) || isDevelName(pkg.Base())
+}

--- a/upgrade.go
+++ b/upgrade.go
@@ -286,7 +286,7 @@ func printLocalNewerThanAUR(
 
 		left, right := getVersionDiff(pkg.Version(), aurPkg.Version)
 
-		if !isDevelName(pkg.Name()) && alpm.VerCmp(pkg.Version(), aurPkg.Version) > 0 {
+		if !isDevelPackage(pkg) && alpm.VerCmp(pkg.Version(), aurPkg.Version) > 0 {
 			fmt.Printf("%s %s: local (%s) is newer than AUR (%s)\n",
 				yellow(bold(smallArrow)),
 				cyan(pkg.Name()),


### PR DESCRIPTION
I got false-positive reports for `linux-git` pkgbase, it provides package `linux-git-headers` and yay doesn't honor that fact that whole pkgbase is devel:

```
:: Checking development packages...
 -> linux-git-headers: local (5.6rc5.r241.g69a4d0baeeb1-1) is newer than AUR (5.6rc1.r5.g0a679e13ea30-1)
```