### PR TITLE
check len before accessing element

### DIFF
--- a/config.go
+++ b/config.go
@@ -234,21 +234,23 @@ func editor() (string, []string) {
 		}
 		fallthrough
 	case os.Getenv("EDITOR") != "":
-		editorArgs := strings.Fields(os.Getenv("EDITOR"))
-		editor, err := exec.LookPath(editorArgs[0])
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-		} else {
-			return editor, editorArgs[1:]
+		if editorArgs := strings.Fields(os.Getenv("EDITOR")); len(editorArgs) != 0 {
+			editor, err := exec.LookPath(editorArgs[0])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			} else {
+				return editor, editorArgs[1:]
+			}
 		}
 		fallthrough
 	case os.Getenv("VISUAL") != "":
-		editorArgs := strings.Fields(os.Getenv("VISUAL"))
-		editor, err := exec.LookPath(editorArgs[0])
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-		} else {
-			return editor, editorArgs[1:]
+		if editorArgs := strings.Fields(os.Getenv("VISUAL")); len(editorArgs) != 0 {
+			editor, err := exec.LookPath(editorArgs[0])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			} else {
+				return editor, editorArgs[1:]
+			}
 		}
 		fallthrough
 	default:


### PR DESCRIPTION
This PR closes https://github.com/Jguer/yay/issues/1207
In some cases, we can get into the `case:` without checking the conditions through the `fallthrough`. Then there is an appeal to a nonexistent element, which leads to panic. If check for availability before applying, we can safely `fallthrough` to `default:` block.