### PR TITLE
adds option for fuzzy finder instead of just number menu

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -112,9 +112,9 @@ Permanent configuration options:
     --combinedupgrade     Refresh then perform the repo and AUR upgrade together
     --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
     --batchinstall        Build multiple AUR packages then install them together
-	--nobatchinstall      Build and install each AUR package one by one
-	--fuzzy            Use fuzzy finding instead of number selection
-	--nofuzzy          Use number selection instead of fuzzy finding
+    --nobatchinstall      Build and install each AUR package one by one
+    --fuzzy               Use fuzzy finding instead of number selection
+    --nofuzzy             Use number selection instead of fuzzy finding
 
     --sudo                <file>  sudo command to use
     --sudoflags           <flags> Pass arguments to sudo

--- a/cmd.go
+++ b/cmd.go
@@ -460,20 +460,6 @@ func displayFuzzyMenu(pkgS []string) (err error) {
 	}
 
 	q := make([]interface{}, lenaq+lenpq)
-	for i, a := range aq {
-		if reverse {
-			q[lenpq+lenaq-i-1] = a
-		} else {
-			q[i] = a
-		}
-	}
-	for i, p := range pq {
-		if reverse {
-			q[lenpq-i-1] = p
-		} else {
-			q[lenaq+i] = p
-		}
-	}
 
 	localDB, _ := alpmHandle.LocalDB()
 
@@ -481,17 +467,17 @@ func displayFuzzyMenu(pkgS []string) (err error) {
 		var text string
 		if reverse {
 			if i < lenpq {
-				text = format(pq[lenpq-i-1], i)
+				text = format(&pq[lenpq-i-1], i)
 			} else {
 				j := i - lenpq
-				text = formatAur(aq[lenaq-j-1], i, localDB)
+				text = formatAur(&aq[lenaq-j-1], i, localDB)
 			}
 		} else {
 			if i < lenaq {
-				text = formatAur(aq[i], i, localDB)
+				text = formatAur(&aq[i], i, localDB)
 			} else {
 				j := i - lenaq
-				text = format(pq[j], i)
+				text = format(&pq[j], i)
 			}
 		}
 		return text

--- a/completions/bash
+++ b/completions/bash
@@ -74,7 +74,7 @@ _yay() {
           sortby answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
           noansweredit noanswerupgrade cleanmenu diffmenu editmenu upgrademenu cleanafter nocleanafter
           nocleanmenu nodiffmenu noupgrademenu provides noprovides pgpfetch nopgpfetch
-          useask nouseask combinedupgrade nocombinedupgrade aur repo makepkgconf
+          useask nouseask fuzzy nofuzzy combinedupgrade nocombinedupgrade aur repo makepkgconf
           nomakepkgconf askremovemake removemake noremovemake completioninterval aururl
           searchby batchinstall nobatchinstall'
     'b d h q r v')

--- a/completions/fish
+++ b/completions/fish
@@ -230,6 +230,8 @@ complete -c $progname -n "not $noopt" -l pgpfetch -d 'Prompt to import PGP keys 
 complete -c $progname -n "not $noopt" -l nopgpfetch -d 'Do not prompt to import PGP keys' -f
 complete -c $progname -n "not $noopt" -l useask -d 'Automatically resolve conflicts using pacmans ask flag' -f
 complete -c $progname -n "not $noopt" -l nouseask -d 'Confirm conflicts manually during the install' -f
+complete -c $progname -n "not $noopt" -l fuzzy -d 'Use fuzzy finding instead of number selection' -f
+complete -c $progname -n "not $noopt" -l nofuzzy -d 'Use number selection instead of fuzzy finding' -f
 complete -c $progname -n "not $noopt" -l combinedupgrade -d 'Refresh then perform the repo and AUR upgrade together' -f
 complete -c $progname -n "not $noopt" -l nocombinedupgrade -d 'Perform the repo upgrade and AUR upgrade separately' -f
 complete -c $progname -n "not $noopt" -l batchinstall -d 'Build multiple AUR packages then install them together' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -79,6 +79,8 @@ _pacman_opts_common=(
 
 	'--bottomup[Show AUR packages first]'
 	'--topdown[Show repository packages first]'
+	'--fuzzy[Use fuzzy finding instead of number selection]
+	'--nofuzzy[Use number selection instead of fuzzy finding]'
 	'--devel[Check -git/-svn/-hg development version]'
 	'--nodevel[Disable development version checking]'
 	'--cleanafter[Clean package sources after successful build]'

--- a/config.go
+++ b/config.go
@@ -79,9 +79,10 @@ type Configuration struct {
 	CombinedUpgrade    bool   `json:"combinedupgrade"`
 	UseAsk             bool   `json:"useask"`
 	BatchInstall       bool   `json:"batchinstall"`
+	Fuzzy              bool   `json:"fuzzy"`
 }
 
-var yayVersion = "9.4.3"
+var yayVersion = "9.4.4"
 
 // configFileName holds the name of the config file.
 const configFileName string = "config.json"
@@ -185,6 +186,7 @@ func defaultSettings() *Configuration {
 		EditMenu:           false,
 		UseAsk:             false,
 		CombinedUpgrade:    false,
+		Fuzzy:              false,
 	}
 
 	if os.Getenv("XDG_CACHE_HOME") != "" {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/Jguer/go-alpm v0.0.0-20200405152916-a3feea4322e9
 	github.com/Morganamilo/go-pacmanconf v0.0.0-20180910220353-9c5265e1b14f
 	github.com/Morganamilo/go-srcinfo v1.0.0
+	github.com/ktr0731/go-fuzzyfinder v0.2.1
 	github.com/mikkeloscar/aur v0.0.0-20200113170522-1cb4e2949656
 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
 	golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,18 @@ github.com/Morganamilo/go-pacmanconf v0.0.0-20180910220353-9c5265e1b14f h1:ptFKy
 github.com/Morganamilo/go-pacmanconf v0.0.0-20180910220353-9c5265e1b14f/go.mod h1:Hk55m330jNiwxRodIlMCvw5iEyoRUCIY64W1p9D+tHc=
 github.com/Morganamilo/go-srcinfo v1.0.0 h1:Wh4nEF+HJWo+29hnxM18Q2hi+DUf0GejS13+Wg+dzmI=
 github.com/Morganamilo/go-srcinfo v1.0.0/go.mod h1:MP6VGY1NNpVUmYIEgoM9acix95KQqIRyqQ0hCLsyYUY=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/ktr0731/go-fuzzyfinder v0.2.1 h1:YR9LXobzd9N+RVU9j4ASc0kWktTyJnkTex8Y6TW99f0=
+github.com/ktr0731/go-fuzzyfinder v0.2.1/go.mod h1:1BUWoT8siOp5n8ns8S6rtfTVigx/dvPPUJuu79nixgo=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mikkeloscar/aur v0.0.0-20200113170522-1cb4e2949656 h1:j679+jxcDkCFblYk+I+G71HQTFxM3PacYbVCiYmhRhU=
 github.com/mikkeloscar/aur v0.0.0-20200113170522-1cb4e2949656/go.mod h1:nYOKcK8tIj69ZZ8uDOWoiT+L25NvlOQaraDqTec/idA=
+github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1 h1:lh3PyZvY+B9nFliSGTn5uFuqQQJGuNrD0MLCokv09ag=
+github.com/nsf/termbox-go v0.0.0-20200418040025-38ba6e5628f1/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79 h1:IaQbIIB2X/Mp/DKctl6ROxz1KyMlKp4uyvL6+kQ7C88=
 golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -16,3 +26,4 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 h1:5B6i6EAiSYyejWfvc5Rc9BbI3rzIsrrXfAQBWnYfn+w=
 golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/parser.go
+++ b/parser.go
@@ -435,6 +435,8 @@ func isArg(arg string) bool {
 	case "noeditmenu":
 	case "useask":
 	case "nouseask":
+	case "fuzzy":
+	case "nofuzzy":
 	case "combinedupgrade":
 	case "nocombinedupgrade":
 	case "a", "aur":
@@ -590,6 +592,10 @@ func handleConfig(option, value string) bool {
 		config.UseAsk = true
 	case "nouseask":
 		config.UseAsk = false
+	case "fuzzy":
+		config.Fuzzy = true
+	case "nofuzzy":
+		config.Fuzzy = false
 	case "combinedupgrade":
 		config.CombinedUpgrade = true
 	case "nocombinedupgrade":

--- a/print.go
+++ b/print.go
@@ -14,7 +14,8 @@ import (
 
 	rpc "github.com/mikkeloscar/aur"
 
-	alpm "github.com/Jguer/go-alpm"
+	"github.com/Jguer/go-alpm"
+
 	"github.com/Jguer/yay/v9/pkg/intrange"
 	"github.com/Jguer/yay/v9/pkg/stringset"
 )
@@ -106,7 +107,7 @@ func (q aurQuery) printSearch(start int) {
 	}
 }
 
-func formatAur(pkg rpc.Pkg, i int, localDB *alpm.DB) string {
+func formatAur(pkg *rpc.Pkg, i int, localDB *alpm.DB) string {
 	toprint := magenta(strconv.Itoa(i+1)+" ") +
 		bold(
 			colorHash("aur"),
@@ -183,7 +184,7 @@ func (s repoQuery) printSearch() {
 }
 
 // PrintSearch receives a RepoSearch type and outputs pretty text.
-func format(res alpm.Package, i int) string {
+func format(res *alpm.Package, i int) string {
 	toprint := magenta(strconv.Itoa(i+1)+" ") +
 		bold(
 			colorHash(res.DB().Name()),


### PR DESCRIPTION
Using --fuzzy, packages are presented using https://github.com/ktr0731/go-fuzzyfinder (a library that is similar to fzf). Multiple packages can be selected using tab.

String formatting could use some improvement. The fuzzy finder doesn't support multiline so descriptions are on the same line. Also could use better documentation, I'm unsure of what to put.

Fuzzy finder also can present extra information about the current hover. Perhaps it could be used to show aur comments, or some other information