### PR TITLE
remove percent sign from popularity in `yay -Ss`

### DIFF
--- a/print.go
+++ b/print.go
@@ -85,7 +85,7 @@ func (q aurQuery) printSearch(start int) {
 		toprint += bold(colorHash("aur")) + "/" + bold(q[i].Name) +
 			" " + cyan(q[i].Version) +
 			bold(" (+"+strconv.Itoa(q[i].NumVotes)) +
-			" " + bold(strconv.FormatFloat(q[i].Popularity, 'f', 2, 64)+"%) ")
+			" " + bold(strconv.FormatFloat(q[i].Popularity, 'f', 2, 64)+") ")
 
 		if q[i].Maintainer == "" {
 			toprint += bold(red(gotext.Get("(Orphaned)"))) + " "


### PR DESCRIPTION
The popularity in the AUR is no percentage, therefore the percent sign is rather confusing there.
In `yay -Si`, the popularity is shown correctly as a normal number.
I have looked for other occurences of the percent sign, but there still may be one.