### PR TITLE
Improve print format under non-English localization

### DIFF
--- a/pkg/text/print.go
+++ b/pkg/text/print.go
@@ -50,5 +50,5 @@ func PrintInfoValue(str, value string) {
 		value = gotext.Get("None")
 	}
 
-	fmt.Fprintf(os.Stdout, bold("%-16s%s")+" %s\n", str, ":", value)
+	fmt.Fprintf(os.Stdout, bold("%-16s\t%s")+" %s\n", str, ":", value)
 }


### PR DESCRIPTION
Under the localization of Chinese, the current print format of `yay -Si` is a little strange, and I tried to improve it.
Perhaps this is not the best solution, but I am not very familiar with the `printf` format.