### PR TITLE
Fix #1279: Error not git repository on yay -Sc

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -196,12 +196,18 @@ func cleanUntracked() error {
 		}
 
 		dir := filepath.Join(config.BuildDir, file.Name())
-		if err := show(passToGit(dir, "clean", "-fx")); err != nil {
-			return err
+		if isGitRepository(dir) {
+			if err := show(passToGit(dir, "clean", "-fx")); err != nil {
+				return err
+			}
 		}
 	}
-
 	return nil
+}
+
+func isGitRepository(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return !os.IsNotExist(err)
 }
 
 func cleanAfter(bases []Base) {


### PR DESCRIPTION
This PR include a simple validation to check if a folder is a git repository before to clean.

This validation make sense to all scenarios of yay? Sorry if something here make no sense, I'm starting with yay source code.