### PR TITLE
Fix "%s is up to date -- skipping" message formatting

### DIFF
--- a/install.go
+++ b/install.go
@@ -1070,7 +1070,7 @@ func buildInstallPkgbuilds(
 					return errors.New(gotext.Get("error making: %s", err))
 				}
 
-				fmt.Fprintln(os.Stdout, gotext.Get("%s is up to date -- skipping"), cyan(pkg+"-"+pkgVersion))
+				fmt.Fprintln(os.Stdout, gotext.Get("%s is up to date -- skipping", cyan(pkg+"-"+pkgVersion)))
 				continue
 			}
 		}


### PR DESCRIPTION
%s is not substituted because the argument is not in the argument list.