### PR TITLE
fix: adjust translations

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -378,7 +378,7 @@ msgstr "Los siguientes paquetes no son compatibles con su arquitectura:"
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "Existen %d paquetes que proveen %s:"
+msgstr "Existen %d paquetes que proveen %s:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/eu.po
+++ b/po/eu.po
@@ -377,7 +377,7 @@ msgstr "Ondorengo paketeak ez dira zure arkitekturarekin bateragarriak:"
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "%d hornitzaile eskuragarri %s -entzat:"
+msgstr "%d hornitzaile eskuragarri %s -entzat:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -378,7 +378,7 @@ msgstr "Les paquets suivants ne sont pas compatibles avec votre architecture :"
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "Il existe %d fournisseurs disponibles pour %s :"
+msgstr "Il existe %d fournisseurs disponibles pour %s :\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/ja.po
+++ b/po/ja.po
@@ -374,7 +374,7 @@ msgstr "以下のパッケージはあなたの使っているアーキテクチ
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "%d 個のパッケージが %s を提供しています:"
+msgstr "%d 個のパッケージが %s を提供しています:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -383,7 +383,7 @@ msgstr "Te paczki nie są kompatybilne z architekturą Twojego systemu:"
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "Jest %d możliwych źródeł dla %s:"
+msgstr "Jest %d możliwych źródeł dla %s:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/pt.po
+++ b/po/pt.po
@@ -374,7 +374,7 @@ msgstr "Os seguintes pacotes não são compatíveis com a sua arquitetura:"
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "Existem %d provedores disponíveis para %s:"
+msgstr "Existem %d provedores disponíveis para %s:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -375,7 +375,7 @@ msgstr "Os seguintes pacotes não são compatíveis com a sua arquitetura:"
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "Há %d provedores disponíveis para %s:"
+msgstr "Há %d provedores disponíveis para %s:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -379,7 +379,7 @@ msgstr "Следующие пакеты несовместимы с вашей �
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "Доступно %d источников для %s:"
+msgstr "Доступно %d источников для %s:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -374,7 +374,7 @@ msgstr "以下软件包与您的体系架构不兼容:"
 
 #: callbacks.go:36 print.go:492
 msgid "There are %d providers available for %s:\n"
-msgstr "有 %d 个提供者可用于 %s:"
+msgstr "有 %d 个提供者可用于 %s:\n"
 
 #: exec.go:72
 msgid "There may be another Pacman instance running. Waiting..."


### PR DESCRIPTION
Add missing newlines to translations to avoid the following compilation error:
```
po/pl_PL.po:386: 'msgid' and 'msgstr' entries do not both end with '\n'
msgfmt: found 1 fatal error
make: *** [Makefile:145: po/pl_PL.mo] Error 1
```

fixes #1329