### PR TITLE
Updated Readme to include note about dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,13 @@ If you are migrating from another AUR helper, you can simply install Yay with th
 Alternatively, the initial installation of Yay can be done by cloning the PKGBUILD and
 building with makepkg:
 
+Make sure you have the `base-devel` package group installed
+
 ```sh
 git clone https://aur.archlinux.org/yay.git
 cd yay
 makepkg -si
 ```
-
-Note: If you are having an issue with `makepkg` ensure you have the `base-devel` packages installed.
-
-`pacman -S base-devel`
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ cd yay
 makepkg -si
 ```
 
+Note: If you are having an issue with `makepkg` ensure you have the `base-devel` packages installed.
+
+`pacman -S base-devel`
+
 ## Support
 
 All support related to Yay should be requested via GitHub issues. Since Yay is not

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are migrating from another AUR helper, you can simply install Yay with th
 Alternatively, the initial installation of Yay can be done by cloning the PKGBUILD and
 building with makepkg:
 
-Make sure you have the `base-devel` package group installed
+Before you begin, make sure you have the `base-devel` package group installed.
 
 ```sh
 git clone https://aur.archlinux.org/yay.git


### PR DESCRIPTION
Per issue #1142 I've added a note to the readme to let users know they'll need to install `base-devel`.