### PR TITLE
<Fixed> Translated the help display for 'yay'. And I modified the PO …

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -20,124 +20,468 @@ import (
 )
 
 func usage() {
-	fmt.Println(`Usage:
-    yay
-    yay <operation> [...]
-    yay <package(s)>
+	fmt.Printf(gotext.Get("Usage"))
+	fmt.Printf(":\n")
 
-operations:
-    yay {-h --help}
-    yay {-V --version}
-    yay {-D --database}    <options> <package(s)>
-    yay {-F --files}       [options] [package(s)]
-    yay {-Q --query}       [options] [package(s)]
-    yay {-R --remove}      [options] <package(s)>
-    yay {-S --sync}        [options] [package(s)]
-    yay {-T --deptest}     [options] [package(s)]
-    yay {-U --upgrade}     [options] <file(s)>
+	fmt.Printf("    yay\n")
 
-New operations:
-    yay {-Y --yay}         [options] [package(s)]
-    yay {-P --show}        [options]
-    yay {-G --getpkgbuild} [package(s)]
+	fmt.Printf("    yay <")
+	fmt.Printf(gotext.Get("operation"))
+	fmt.Printf("> [...]\n")
 
-If no arguments are provided 'yay -Syu' will be performed
-If no operation is provided -Y will be assumed
+	fmt.Printf("    yay <")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf(">\n\n")
 
-New options:
-       --repo             Assume targets are from the repositories
-    -a --aur              Assume targets are from the AUR
+	fmt.Printf(gotext.Get("operations"))
+	fmt.Printf(":\n")
 
-Permanent configuration options:
-    --save                Causes the following options to be saved back to the
-                          config file when used
+	fmt.Printf("    yay {-h --help}\n")
+	fmt.Printf("    yay {-V --version}\n")
 
-    --aururl      <url>   Set an alternative AUR URL
-    --builddir    <dir>   Directory used to download and run PKGBUILDS
-    --absdir      <dir>   Directory used to store downloads from the ABS
-    --editor      <file>  Editor to use when editing PKGBUILDs
-    --editorflags <flags> Pass arguments to editor
-    --makepkg     <file>  makepkg command to use
-    --mflags      <flags> Pass arguments to makepkg
-    --pacman      <file>  pacman command to use
-    --git         <file>  git command to use
-    --gitflags    <flags> Pass arguments to git
-    --gpg         <file>  gpg command to use
-    --gpgflags    <flags> Pass arguments to gpg
-    --config      <file>  pacman.conf file to use
-    --makepkgconf <file>  makepkg.conf file to use
-    --nomakepkgconf       Use the default makepkg.conf
+	fmt.Printf("    yay {-D --database}    <")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("> <")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf(">\n")
 
-    --requestsplitn <n>   Max amount of packages to query per AUR request
-    --completioninterval  <n> Time in days to refresh completion cache
-    --sortby    <field>   Sort AUR results by a specific field during search
-    --searchby  <field>   Search for packages using a specified field
-    --answerclean   <a>   Set a predetermined answer for the clean build menu
-    --answerdiff    <a>   Set a predetermined answer for the diff menu
-    --answeredit    <a>   Set a predetermined answer for the edit pkgbuild menu
-    --answerupgrade <a>   Set a predetermined answer for the upgrade menu
-    --noanswerclean       Unset the answer for the clean build menu
-    --noanswerdiff        Unset the answer for the edit diff menu
-    --noansweredit        Unset the answer for the edit pkgbuild menu
-    --noanswerupgrade     Unset the answer for the upgrade menu
-    --cleanmenu           Give the option to clean build PKGBUILDS
-    --diffmenu            Give the option to show diffs for build files
-    --editmenu            Give the option to edit/view PKGBUILDS
-    --upgrademenu         Show a detailed list of updates with the option to skip any
-    --nocleanmenu         Don't clean build PKGBUILDS
-    --nodiffmenu          Don't show diffs for build files
-    --noeditmenu          Don't edit/view PKGBUILDS
-    --noupgrademenu       Don't show the upgrade menu
-    --askremovemake       Ask to remove makedepends after install
-    --removemake          Remove makedepends after install
-    --noremovemake        Don't remove makedepends after install
+	fmt.Printf("    yay {-F --files}       [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("] [")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf("]\n")
 
-    --cleanafter          Remove package sources after successful install
-    --nocleanafter        Do not remove package sources after successful build
-    --bottomup            Shows AUR's packages first and then repository's
-    --topdown             Shows repository's packages first and then AUR's
+	fmt.Printf("    yay {-Q --query}       [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("] [")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf("]\n")
 
-    --devel               Check development packages during sysupgrade
-    --nodevel             Do not check development packages
-    --rebuild             Always build target packages
-    --rebuildall          Always build all AUR packages
-    --norebuild           Skip package build if in cache and up to date
-    --rebuildtree         Always build all AUR packages even if installed
-    --redownload          Always download pkgbuilds of targets
-    --noredownload        Skip pkgbuild download if in cache and up to date
-    --redownloadall       Always download pkgbuilds of all AUR packages
-    --provides            Look for matching providers when searching for packages
-    --noprovides          Just look for packages by pkgname
-    --pgpfetch            Prompt to import PGP keys from PKGBUILDs
-    --nopgpfetch          Don't prompt to import PGP keys
-    --useask              Automatically resolve conflicts using pacman's ask flag
-    --nouseask            Confirm conflicts manually during the install
-    --combinedupgrade     Refresh then perform the repo and AUR upgrade together
-    --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
-    --batchinstall        Build multiple AUR packages then install them together
-    --nobatchinstall      Build and install each AUR package one by one
+	fmt.Printf("    yay {-R --remove}      [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("] [")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf("]\n")
 
-    --sudo                <file>  sudo command to use
-    --sudoflags           <flags> Pass arguments to sudo
-    --sudoloop            Loop sudo calls in the background to avoid timeout
-    --nosudoloop          Do not loop sudo calls in the background
+	fmt.Printf("    yay {-S --sync}        [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("] [")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf("]\n")
 
-    --timeupdate          Check packages' AUR page for changes during sysupgrade
-    --notimeupdate        Do not check packages' AUR page for changes
+	fmt.Printf("    yay {-T --deptest}     [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("] [")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf("]\n")
 
-show specific options:
-    -c --complete         Used for completions
-    -d --defaultconfig    Print default yay configuration
-    -g --currentconfig    Print current yay configuration
-    -s --stats            Display system package statistics
-    -w --news             Print arch news
+	fmt.Printf("    yay {-U --upgrade}     [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("] <")
+	fmt.Printf(gotext.Get("file(s)"))
+	fmt.Printf(">\n\n")
 
-yay specific options:
-    -c --clean            Remove unneeded dependencies
-       --gendb            Generates development package DB used for updating
+	fmt.Printf(gotext.Get("New operations"))
+	fmt.Printf(":\n")
 
-getpkgbuild specific options:
-    -f --force            Force download for existing ABS packages`)
+	fmt.Printf("    yay {-Y --yay}         [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("] [")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf("]\n")
+
+	fmt.Printf("    yay {-P --show}        [")
+	fmt.Printf(gotext.Get("options"))
+	fmt.Printf("]\n")
+
+	fmt.Printf("    yay {-G --getpkgbuild} [")
+	fmt.Printf(gotext.Get("package(s)"))
+	fmt.Printf("]\n\n")
+
+	fmt.Printf(gotext.Get("If no arguments are provided 'yay -Syu' will be performed"))
+	fmt.Printf("\n")
+
+	fmt.Printf(gotext.Get("If no operation is provided -Y will be assumed"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf(gotext.Get("New options"))
+	fmt.Printf(":\n")
+
+	fmt.Printf("       --repo             ")
+	fmt.Printf(gotext.Get("Assume targets are from the repositories"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    -a --aur              ")
+	fmt.Printf(gotext.Get("Assume targets are from the AUR"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf(gotext.Get("Permanent configuration options"))
+	fmt.Printf(":\n")
+
+	fmt.Printf("    --save                ")
+	fmt.Printf(gotext.Get("Causes the following options to be saved back to the"))
+	fmt.Printf("\n")
+
+	fmt.Printf("                          ")
+	fmt.Printf(gotext.Get("config file when used"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf("    --aururl      ")
+	fmt.Printf(gotext.Get("<url>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Set an alternative AUR URL"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --builddir    ")
+	fmt.Printf(gotext.Get("<dir>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Directory used to download and run PKGBUILDS"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --absdir      ")
+	fmt.Printf(gotext.Get("<dir>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Directory used to store downloads from the ABS"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --editor      ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("Editor to use when editing PKGBUILDs"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --editorflags ")
+	fmt.Printf(gotext.Get("<flags>"))
+	fmt.Printf(" ")
+	fmt.Printf(gotext.Get("Pass arguments to editor"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --makepkg     ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("makepkg command to use"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --mflags      ")
+	fmt.Printf(gotext.Get("<flags>"))
+	fmt.Printf(" ")
+	fmt.Printf(gotext.Get("Pass arguments to makepkg"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --pacman      ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("pacman command to use"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --git         ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("git command to use"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --gitflags    ")
+	fmt.Printf(gotext.Get("<flags>"))
+	fmt.Printf(" ")
+	fmt.Printf(gotext.Get("Pass arguments to git"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --gpg         ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("gpg command to use"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --gpgflags    ")
+	fmt.Printf(gotext.Get("<flags>"))
+	fmt.Printf(" ")
+	fmt.Printf(gotext.Get("Pass arguments to gpg"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --config      ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("pacman.conf file to use"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --makepkgconf ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("makepkg.conf file to use"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nomakepkgconf       ")
+	fmt.Printf(gotext.Get("Use the default makepkg.conf"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf("    --requestsplitn ")
+	fmt.Printf(gotext.Get("<n>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Max amount of packages to query per AUR request"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --completioninterval  ")
+	fmt.Printf(gotext.Get("<n>"))
+	fmt.Printf(" ")
+	fmt.Printf(gotext.Get("Time in days to refresh completion cache"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --sortby    ")
+	fmt.Printf(gotext.Get("<field>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Sort AUR results by a specific field during search"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --searchby  ")
+	fmt.Printf(gotext.Get("<field>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Search for packages using a specified field"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --answerclean   ")
+	fmt.Printf(gotext.Get("<a>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Set a predetermined answer for the clean build menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --answerdiff    ")
+	fmt.Printf(gotext.Get("<a>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Set a predetermined answer for the diff menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --answeredit    ")
+	fmt.Printf(gotext.Get("<a>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Set a predetermined answer for the edit pkgbuild menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --answerupgrade ")
+	fmt.Printf(gotext.Get("<a>"))
+	fmt.Printf("   ")
+	fmt.Printf(gotext.Get("Set a predetermined answer for the upgrade menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noanswerclean       ")
+	fmt.Printf(gotext.Get("Unset the answer for the clean build menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noanswerdiff        ")
+	fmt.Printf(gotext.Get("Unset the answer for the edit diff menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noansweredit        ")
+	fmt.Printf(gotext.Get("Unset the answer for the edit pkgbuild menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noanswerupgrade     ")
+	fmt.Printf(gotext.Get("Unset the answer for the upgrade menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --cleanmenu           ")
+	fmt.Printf(gotext.Get("Give the option to clean build PKGBUILDS"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --diffmenu            ")
+	fmt.Printf(gotext.Get("Give the option to show diffs for build files"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --editmenu            ")
+	fmt.Printf(gotext.Get("Give the option to edit/view PKGBUILDS"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --upgrademenu         ")
+	fmt.Printf(gotext.Get("Show a detailed list of updates with the option to skip any"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nocleanmenu         ")
+	fmt.Printf(gotext.Get("Don't clean build PKGBUILDS"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nodiffmenu          ")
+	fmt.Printf(gotext.Get("Don't show diffs for build files"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noeditmenu          ")
+	fmt.Printf(gotext.Get("Don't edit/view PKGBUILDS"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noupgrademenu       ")
+	fmt.Printf(gotext.Get("Don't show the upgrade menu"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --askremovemake       ")
+	fmt.Printf(gotext.Get("Ask to remove makedepends after install"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --removemake          ")
+	fmt.Printf(gotext.Get("Remove makedepends after install"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noremovemake        ")
+	fmt.Printf(gotext.Get("Don't remove makedepends after install"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf("    --cleanafter          ")
+	fmt.Printf(gotext.Get("Remove package sources after successful install"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nocleanafter        ")
+	fmt.Printf(gotext.Get("Do not remove package sources after successful build"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --bottomup            ")
+	fmt.Printf(gotext.Get("Shows AUR's packages first and then repository's"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --topdown             ")
+	fmt.Printf(gotext.Get("Shows repository's packages first and then AUR's"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf("    --devel               ")
+	fmt.Printf(gotext.Get("Check development packages during sysupgrade"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nodevel             ")
+	fmt.Printf(gotext.Get("Do not check development packages"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --rebuild             ")
+	fmt.Printf(gotext.Get("Always build target packages"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --rebuildall          ")
+	fmt.Printf(gotext.Get("Always build all AUR packages"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --norebuild           ")
+	fmt.Printf(gotext.Get("Skip package build if in cache and up to date"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --rebuildtree         ")
+	fmt.Printf(gotext.Get("Always build all AUR packages even if installed"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --redownload          ")
+	fmt.Printf(gotext.Get("Always download pkgbuilds of targets"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noredownload        ")
+	fmt.Printf(gotext.Get("Skip pkgbuild download if in cache and up to date"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --redownloadall       ")
+	fmt.Printf(gotext.Get("Always download pkgbuilds of all AUR packages"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --provides            ")
+	fmt.Printf(gotext.Get("Look for matching providers when searching for packages"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --noprovides          ")
+	fmt.Printf(gotext.Get("Just look for packages by pkgname"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --pgpfetch            ")
+	fmt.Printf(gotext.Get("Prompt to import PGP keys from PKGBUILDs"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nopgpfetch          ")
+	fmt.Printf(gotext.Get("Don't prompt to import PGP keys"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --useask              ")
+	fmt.Printf(gotext.Get("Automatically resolve conflicts using pacman's ask flag"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nouseask            ")
+	fmt.Printf(gotext.Get("Confirm conflicts manually during the install"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --combinedupgrade     ")
+	fmt.Printf(gotext.Get("Refresh then perform the repo and AUR upgrade together"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nocombinedupgrade   ")
+	fmt.Printf(gotext.Get("Perform the repo upgrade and AUR upgrade separately"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --batchinstall        ")
+	fmt.Printf(gotext.Get("Build multiple AUR packages then install them together"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nobatchinstall      ")
+	fmt.Printf(gotext.Get("Build and install each AUR package one by one"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf("    --sudo                ")
+	fmt.Printf(gotext.Get("<file>"))
+	fmt.Printf("  ")
+	fmt.Printf(gotext.Get("sudo command to use"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --sudoflags           ")
+	fmt.Printf(gotext.Get("<flags>"))
+	fmt.Printf(" ")
+	fmt.Printf(gotext.Get("Pass arguments to sudo"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --sudoloop            ")
+	fmt.Printf(gotext.Get("Loop sudo calls in the background to avoid timeout"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --nosudoloop          ")
+	fmt.Printf(gotext.Get("Do not loop sudo calls in the background"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf("    --timeupdate          ")
+	fmt.Printf(gotext.Get("Check packages' AUR page for changes during sysupgrade"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    --notimeupdate        ")
+	fmt.Printf(gotext.Get("Do not check packages' AUR page for changes"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf(gotext.Get("show specific options"))
+	fmt.Printf(":\n")
+
+	fmt.Printf("    -c --complete         ")
+	fmt.Printf(gotext.Get("Used for completions"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    -d --defaultconfig    ")
+	fmt.Printf(gotext.Get("Print default yay configuration"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    -g --currentconfig    ")
+	fmt.Printf(gotext.Get("Print current yay configuration"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    -s --stats            ")
+	fmt.Printf(gotext.Get("Display system package statistics"))
+	fmt.Printf("\n")
+
+	fmt.Printf("    -w --news             ")
+	fmt.Printf(gotext.Get("Print arch news"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf(gotext.Get("yay specific options"))
+	fmt.Printf(":\n")
+
+	fmt.Printf("    -c --clean            ")
+	fmt.Printf(gotext.Get("Remove unneeded dependencies"))
+	fmt.Printf("\n")
+
+	fmt.Printf("       --gendb            ")
+	fmt.Printf(gotext.Get("Generates development package DB used for updating"))
+	fmt.Printf("\n\n")
+
+	fmt.Printf(gotext.Get("getpkgbuild specific options"))
+	fmt.Printf(":\n")
+
+	fmt.Printf("    -f --force            ")
+	fmt.Printf(gotext.Get("Force download for existing ABS packages"))
+	fmt.Printf("\n")
 }
 
 func handleCmd(cmdArgs *settings.Arguments, dbExecutor db.Executor) error {

--- a/po/en.po
+++ b/po/en.po
@@ -11,6 +11,409 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr "<a>"
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr "<dir>"
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr "<field>"
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr "<file>"
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr "<flags>"
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr "<n>"
+
+#: cmd.go:130
+msgid "<url>"
+msgstr "<url>"
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr "Always build all AUR packages even if installed"
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr "Always build all AUR packages"
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr "Always build target packages"
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr "Always download pkgbuilds of all AUR packages"
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr "Always download pkgbuilds of targets"
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr "Ask to remove makedepends after install"
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr "Assume targets are from the AUR"
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr "Assume targets are from the repositories"
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr "Automatically resolve conflicts using pacman's ask flag"
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr "Build and install each AUR package one by one"
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr "Build multiple AUR packages then install them together"
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr "Causes the following options to be saved back to the"
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr "Check development packages during sysupgrade"
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr "Check packages' AUR page for changes during sysupgrade"
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr "Confirm conflicts manually during the install"
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr "Directory used to download and run PKGBUILDS"
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr "Directory used to store downloads from the ABS"
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr "Display system package statistics"
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr "Do not check development packages"
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr "Do not check packages' AUR page for changes"
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr "Do not loop sudo calls in the background"
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr "Do not remove package sources after successful build"
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr "Don't clean build PKGBUILDS"
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr "Don't edit/view PKGBUILDS"
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr "Don't prompt to import PGP keys"
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr "Don't remove makedepends after install"
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr "Don't show diffs for build files"
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr "Don't show the upgrade menu"
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr "Editor to use when editing PKGBUILDs"
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr "Force download for existing ABS packages"
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr "Generates development package DB used for updating"
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr "Give the option to clean build PKGBUILDS"
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr "Give the option to edit/view PKGBUILDS"
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr "Give the option to show diffs for build files"
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr "If no arguments are provided 'yay -Syu' will be performed"
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr "If no operation is provided -Y will be assumed"
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr "Just look for packages by pkgname"
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr "Look for matching providers when searching for packages"
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr "Loop sudo calls in the background to avoid timeout"
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr "Max amount of packages to query per AUR request"
+
+#: cmd.go:84
+msgid "New operations"
+msgstr "New operations"
+
+#: cmd.go:107
+msgid "New options"
+msgstr "New options"
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr "Pass arguments to editor"
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr "Pass arguments to git"
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr "Pass arguments to gpg"
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr "Pass arguments to makepkg"
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr "Pass arguments to sudo"
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr "Perform the repo upgrade and AUR upgrade separately"
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr "Permanent configuration options"
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr "Print arch news"
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr "Print current yay configuration"
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr "Print default yay configuration"
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr "Prompt to import PGP keys from PKGBUILDs"
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr "Refresh then perform the repo and AUR upgrade together"
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr "Remove makedepends after install"
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr "Remove package sources after successful install"
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr "Remove unneeded dependencies"
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr "Search for packages using a specified field"
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr "Set a predetermined answer for the clean build menu"
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr "Set a predetermined answer for the diff menu"
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr "Set a predetermined answer for the edit pkgbuild menu"
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr "Set a predetermined answer for the upgrade menu"
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr "Set an alternative AUR URL"
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr "Show a detailed list of updates with the option to skip any"
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr "Shows AUR's packages first and then repository's"
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr "Shows repository's packages first and then AUR's"
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr "Skip package build if in cache and up to date"
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr "Skip pkgbuild download if in cache and up to date"
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr "Sort AUR results by a specific field during search"
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr "Time in days to refresh completion cache"
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr "Unset the answer for the clean build menu"
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr "Unset the answer for the edit diff menu"
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr "Unset the answer for the edit pkgbuild menu"
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr "Unset the answer for the upgrade menu"
+
+#: cmd.go:23
+msgid "Usage"
+msgstr "Usage"
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr "Use the default makepkg.conf"
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr "Used for completions"
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr "config file when used"
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr "file(s)"
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr "getpkgbuild specific options"
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr "git command to use"
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr "gpg command to use"
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr "makepkg command to use"
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr "makepkg.conf file to use"
+
+#: cmd.go:29
+msgid "operation"
+msgstr "operation"
+
+#: cmd.go:36
+msgid "operations"
+msgstr "operations"
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr "options"
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr "package(s)"
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr "pacman command to use"
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr "pacman.conf file to use"
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr "show specific options"
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr "sudo command to use"
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr "yay specific options"
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Build Files Exist)"

--- a/po/es.po
+++ b/po/es.po
@@ -12,6 +12,409 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Archivos de compilación existen)"

--- a/po/eu.po
+++ b/po/eu.po
@@ -12,6 +12,409 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Konpilazio fitxategiak existitzen dira)"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -13,6 +13,409 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Fichiers de compilation existants)"
@@ -184,11 +587,11 @@ msgstr "Afficher les diffs ?"
 
 #: clean.go:91
 msgid "Do you want to remove ALL AUR packages from cache?"
-msgstr "Êtes-vous sûr de vouloir supprimer TOUS les paquets AUR du cache ?"
+msgstr "Êtes-vous sûr de vouloir supprimer TOUS les paquets AUR du cache ?"
 
 #: clean.go:108
 msgid "Do you want to remove ALL untracked AUR files?"
-msgstr "Êtes-vous sûr de vouloir supprimer TOUS les fichiers AUR non suivis ?"
+msgstr "Êtes-vous sûr de vouloir supprimer TOUS les fichiers AUR non suivis ?"
 
 #: clean.go:93
 msgid "Do you want to remove all other AUR packages from cache?"
@@ -289,7 +692,7 @@ msgstr "Obsolète"
 
 #: keys.go:115
 msgid "PGP keys need importing:"
-msgstr "Clés PGP dont l'import est nécessaire :"
+msgstr "Clés PGP dont l'import est nécessaire :"
 
 #: install.go:874
 msgid "PKGBUILD up to date, Skipping (%d/%d): %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,16 +1,418 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2020-07-13 21:09+0900\n"
-"Language-Team: English\n"
+"PO-Revision-Date: 2020-10-05 10:43+0900\n"
+"Last-Translator: FuRuYa7\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 2.3\n"
-"POT-Creation-Date: \n"
-"Last-Translator: Yamada Hayao\n"
-"Language: ja\n"
+"X-Generator: xgotext\n"
+
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr "<a>"
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr "<dir>"
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr "<field>"
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr "<file>"
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr "<flags>"
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr "<n>"
+
+#: cmd.go:130
+msgid "<url>"
+msgstr "<URL>"
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr "インストールされている場合でも、常にすべてのAURパッケージをビルド"
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr "常にすべてのAUR パッケージをビルド"
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr "常にターゲットパッケージをビルド"
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr "常にすべてのAURパッケージのPKGBUILD をダウンロード"
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr "常にターゲットのPKGBUILD をダウンロード"
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr "インストール後にmake 時の依存関係を削除するか尋ねます"
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr "ターゲットがAUR にあると想定します"
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr "ターゲットが公式リポジトリにあると想定します"
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr "pacman の質問フラグを使用して競合を自動的に解決します"
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr "各AUR パッケージを1つずつビルドしてインストール"
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr "複数のAUR パッケージをビルドして一緒にインストール"
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr "次のオプションを使用すると、設定ファイルに"
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr "sysupgrade 中に開発パッケージをチェック"
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr "sysupgrade 中に、AUR のパッケージの変更をチェック"
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr "インストール中に手動で競合を確認"
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr "PKGBUILD のダウンロードと実行に使用されるディレクトリ"
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr "ABS からのダウンロードを保存するために使用されるディレクトリ"
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr "システムのパッケージの統計情報を表示"
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr "開発パッケージをチェックしません"
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr "AUR のパッケージの変更をチェックしません"
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr "バックグラウンドでsudo 呼び出しをループしません"
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr "インストールが成功した後にパッケージソースを削除しません"
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr "PKGBUILD をクリーンビルドしません"
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr "PKGBUILD を編集/表示しません"
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr "PGP キーのインポートを要求しません"
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr "インストール後にmake 時の依存関係を削除しません"
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr "PKGBUILD ファイルの差異を表示しません"
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr "アップグレードメニューを表示しません"
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr "PKGBUILD を編集するときに使用するエディタ"
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr "既存のABS パッケージを強制ダウンロード"
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr "アップデートに使用する開発パッケージDB を生成"
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr "PKGBUILD をクリーンビルドするオプションを提供"
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr "PKGBUILD を編集/表示するオプションを提供"
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr "PKGBUILD ファイルの差異を表示するオプションを提供"
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr "引数を指定しない場合、「yay -Syu」が実行されます"
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr "オペレーションを指定しない場合、「-Y」と想定します"
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr "パッケージ名でパッケージを探すだけです"
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr "パッケージを検索するときに一致するプロバイダーを探します"
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr "バックグラウンドでsudo 呼び出しをループして、タイムアウトを回避"
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr "AUR リクエストごとにクエリするパッケージの最大量"
+
+#: cmd.go:84
+msgid "New operations"
+msgstr "新しいオペレーション"
+
+#: cmd.go:107
+msgid "New options"
+msgstr "新しいオプション"
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr "引数をエディタに渡します"
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr "git に引数を渡します"
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr "gpg に引数を渡します"
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr "makepkg に引数を渡します"
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr "sudo に引数を渡します"
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr "リポジトリのアップグレードとAUR のアップグレードを個別に実行"
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr "永続的な構成オプション"
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr "Arch ニュースを表示"
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr "現在のyay の設定を表示"
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr "デフォルトのyay の設定を表示"
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr "PKGBUILD からPGP キーをインポートするように要求"
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr "更新してから、リポジトリとAUR のアップグレードを一緒に実行"
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr "インストール後にmake 時の依存関係を削除"
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr "インストールが成功した後にパッケージソースを削除"
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr "不要な依存関係を削除"
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr "指定されたフィールドを使用してパッケージを検索"
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr "クリーンビルドメニューに所定の返答を設定"
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr "差異メニューに所定の返答を設定"
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr "PKGBUILD の編集メニューに所定の返答を設定"
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr "アップグレードメニューに所定の返答を設定"
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr "代替のAUR のURL を設定"
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr "更新の詳細リストを表示し、スキップするオプションを選択します"
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr "最初にAUR のパッケージを表示し、次にリポジトリのパッケージを表示"
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr "最初にリポジトリのパッケージを表示し、次にAUR のパッケージを表示"
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr "キャッシュ内にあり、最新の場合、パッケージのビルドをスキップ"
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr "キャッシュ内にあり、最新の場合、PKGBUILD のダウンロードをスキップ"
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr "検索中にAUR の結果を特定のフィールドで並べ替え"
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr "完了キャッシュを更新するための日数"
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr "クリーンビルドメニューの返答の設定を解除"
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr "差異メニューに所定の返答を設定"
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr "PKGBUILD の編集メニューに所定の返答を設定"
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr "アップグレードメニューに所定の返答を設定"
+
+#: cmd.go:23
+msgid "Usage"
+msgstr "使用方法"
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr "デフォルトのmakepkg.conf を使用"
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr "補完を使います"
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr "保存されます。"
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr "ファイル"
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr "getpkgbuild の特定のオプション"
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr "git コマンドを使います"
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr "gpg コマンドを使います"
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr "makepkg コマンドを使います"
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr "makepkg.conf に使うファイル"
+
+#: cmd.go:29
+msgid "operation"
+msgstr "オペレーション"
+
+#: cmd.go:36
+msgid "operations"
+msgstr "オペレーション"
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr "オプション"
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr "パッケージ"
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr "pacman コマンドを使います"
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr "pacman.conf に使うファイル"
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr "表示の特定のオプション"
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr "sudo コマンドを使います"
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr "yay の特定のオプション"
 
 #: install.go:563
 msgid " (Build Files Exist)"

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -13,6 +13,409 @@ msgstr ""
 "|| n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 #, fuzzy
 msgid " (Build Files Exist)"

--- a/po/pt.po
+++ b/po/pt.po
@@ -9,6 +9,409 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Ficheiros de compilação existem)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -11,6 +11,409 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: xgotext\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Arquivos de Build Existem)"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -12,6 +12,409 @@ msgstr ""
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3.1\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (файлы сборки существуют)"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -12,6 +12,409 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
+#: cmd.go:242 cmd.go:248 cmd.go:254 cmd.go:260
+msgid "<a>"
+msgstr ""
+
+#: cmd.go:136 cmd.go:142
+msgid "<dir>"
+msgstr ""
+
+#: cmd.go:230 cmd.go:236
+msgid "<field>"
+msgstr ""
+
+#: cmd.go:148 cmd.go:160 cmd.go:172 cmd.go:178 cmd.go:190 cmd.go:202 cmd.go:208
+#: cmd.go:418
+msgid "<file>"
+msgstr ""
+
+#: cmd.go:154 cmd.go:166 cmd.go:184 cmd.go:196 cmd.go:424
+msgid "<flags>"
+msgstr ""
+
+#: cmd.go:218 cmd.go:224
+msgid "<n>"
+msgstr ""
+
+#: cmd.go:130
+msgid "<url>"
+msgstr ""
+
+#: cmd.go:362
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:354
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:350
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:374
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:366
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:314
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:115
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:111
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:394
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:414
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:410
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:122
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:342
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:438
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:398
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:138
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:144
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:461
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:346
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:442
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:434
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:330
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:298
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:306
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:390
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:322
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:302
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:310
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:150
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:483
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:476
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:282
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:290
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:286
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:101
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:104
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:382
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:378
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:430
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:220
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:84
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:107
+msgid "New options"
+msgstr ""
+
+#: cmd.go:156
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:186
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:198
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:168
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:426
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:406
+msgid "Perform the repo upgrade and AUR upgrade separately"
+msgstr ""
+
+#: cmd.go:118
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:465
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:457
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:453
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:386
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:402
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:318
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:326
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:472
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:238
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:244
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:250
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:256
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:262
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:132
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:294
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:334
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:338
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:358
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:370
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:232
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:226
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:266
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:270
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:274
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:278
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:23
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:214
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:449
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:126
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:81
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:479
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:180
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:192
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:162
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:210
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:29
+msgid "operation"
+msgstr ""
+
+#: cmd.go:36
+msgid "operations"
+msgstr ""
+
+#: cmd.go:43 cmd.go:49 cmd.go:55 cmd.go:61 cmd.go:67 cmd.go:73 cmd.go:79
+#: cmd.go:88 cmd.go:94
+msgid "options"
+msgstr ""
+
+#: cmd.go:33 cmd.go:45 cmd.go:51 cmd.go:57 cmd.go:63 cmd.go:69 cmd.go:75
+#: cmd.go:90 cmd.go:98
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:174
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:204
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:445
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:420
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:468
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (构建文件已存在)"


### PR DESCRIPTION
(#1378) Fixed. The translation range has been narrowed down. I failed to send a modified version of the source, so I resent the PR from another clone. 

Fixed the 'cmd.go' file. In addition, the translated part of the help display was added to all PO files, and only 'en.po' and 'ja.po' were translated in the help display part.