### PR TITLE
<Fixed 2> Translated the help display for 'yay'. And I modified the P…

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	alpm "github.com/Jguer/go-alpm/v2"
 	"github.com/leonelquinteros/gotext"
@@ -19,125 +20,160 @@ import (
 	"github.com/Jguer/yay/v10/pkg/vcs"
 )
 
+func opHelp(operation string, args ...string) string {
+	newArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		newArgs = append(newArgs, fmt.Sprintf("[%s]", arg))
+	}
+	return fmt.Sprintf("    yay %-18s %s", operation, strings.Join(newArgs, " "))
+}
+
+func opHlp2(operation string, args ...string) string {
+	newArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		newArgs = append(newArgs, fmt.Sprintf("<%s>", arg))
+	}
+	return fmt.Sprintf("    yay %-18s %s", operation, strings.Join(newArgs, " "))
+}
+
+func optionHelp(option, description string, args ...string) string {
+	newArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		newArgs = append(newArgs, fmt.Sprintf("<%s>", arg))
+	}
+	return fmt.Sprintf("    %-18s %-2s %s", option, strings.Join(newArgs, " "), description)
+}
+
+func optionHlp2(option, description string, args ...string) string {
+	newArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		newArgs = append(newArgs, fmt.Sprintf("<%s>", arg))
+	}
+	return fmt.Sprintf("    %-13s %-7s %s", option, strings.Join(newArgs, " "), description)
+}
+
+func optionHlp3(option, description string, args ...string) string {
+	newArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		newArgs = append(newArgs, fmt.Sprintf("<%s>", arg))
+	}
+	return fmt.Sprintf("    %-15s %-5s %s", option, strings.Join(newArgs, " "), description)
+}
+
 func usage() {
-	fmt.Println(`Usage:
-    yay
-    yay <operation> [...]
-    yay <package(s)>
+	fmt.Print(gotext.Get("Usage"), ":\n    yay\n")
+	fmt.Printf("    yay <%s> [...]\n", gotext.Get("operation"))
+	fmt.Printf("    yay <%s>\n", gotext.Get("package(s)"))
 
-operations:
-    yay {-h --help}
-    yay {-V --version}
-    yay {-D --database}    <options> <package(s)>
-    yay {-F --files}       [options] [package(s)]
-    yay {-Q --query}       [options] [package(s)]
-    yay {-R --remove}      [options] <package(s)>
-    yay {-S --sync}        [options] [package(s)]
-    yay {-T --deptest}     [options] [package(s)]
-    yay {-U --upgrade}     [options] <file(s)>
+	fmt.Print("\n", gotext.Get("operations"), ":\n")
+	fmt.Println(opHelp("{-h --help}"))
+	fmt.Println(opHelp("{-V --version}"))
+	fmt.Println(opHlp2("{-D --database}", gotext.Get("options"), gotext.Get("package(s)")))
+	fmt.Println(opHelp("{-F --files}", gotext.Get("options"), gotext.Get("package(s)")))
+	fmt.Println(opHelp("{-Q --query}", gotext.Get("options"), gotext.Get("package(s)")))
+	fmt.Println(opHelp("{-R --remove}", gotext.Get("options")), "<"+gotext.Get("package(s)")+">")
+	fmt.Println(opHelp("{-S --sync}", gotext.Get("options"), gotext.Get("package(s)")))
+	fmt.Println(opHelp("{-T --deptest}", gotext.Get("options"), gotext.Get("package(s)")))
+	fmt.Println(opHelp("{-U --upgrade}", gotext.Get("options")), "<"+gotext.Get("file(s)")+">")
 
-New operations:
-    yay {-Y --yay}         [options] [package(s)]
-    yay {-P --show}        [options]
-    yay {-G --getpkgbuild} [package(s)]
+	fmt.Print("\n", gotext.Get("New operations"), ":\n")
+	fmt.Println(opHelp("{-G --getpkgbuild}", gotext.Get("package(s)")))
+	fmt.Println(opHelp("{-P --show}", gotext.Get("options")))
+	fmt.Println(opHelp("{-Y --yay}", gotext.Get("options"), gotext.Get("package(s)")))
 
-If no arguments are provided 'yay -Syu' will be performed
-If no operation is provided -Y will be assumed
+	fmt.Println()
+	fmt.Println(gotext.Get("If no arguments are provided 'yay -Syu' will be performed"))
+	fmt.Println(gotext.Get("If no operation is provided -Y will be assumed"))
 
-New options:
-       --repo             Assume targets are from the repositories
-    -a --aur              Assume targets are from the AUR
+	fmt.Print("\n", gotext.Get("New options"), ":\n")
+	fmt.Println(optionHelp("--repo", gotext.Get("Assume targets are from the repositories")))
+	fmt.Println(optionHelp("-a --aur", gotext.Get("Assume targets are from the AUR")))
 
-Permanent configuration options:
-    --save                Causes the following options to be saved back to the
-                          config file when used
+	fmt.Print("\n", gotext.Get("Permanent configuration options"), ":\n")
+	fmt.Println(optionHelp("--save", gotext.Get("Causes the following options to be saved back to the")))
+	fmt.Println(optionHelp("      ", gotext.Get("config file when used")))
 
-    --aururl      <url>   Set an alternative AUR URL
-    --builddir    <dir>   Directory used to download and run PKGBUILDS
-    --absdir      <dir>   Directory used to store downloads from the ABS
-    --editor      <file>  Editor to use when editing PKGBUILDs
-    --editorflags <flags> Pass arguments to editor
-    --makepkg     <file>  makepkg command to use
-    --mflags      <flags> Pass arguments to makepkg
-    --pacman      <file>  pacman command to use
-    --git         <file>  git command to use
-    --gitflags    <flags> Pass arguments to git
-    --gpg         <file>  gpg command to use
-    --gpgflags    <flags> Pass arguments to gpg
-    --config      <file>  pacman.conf file to use
-    --makepkgconf <file>  makepkg.conf file to use
-    --nomakepkgconf       Use the default makepkg.conf
+	fmt.Println()
+	fmt.Println(optionHlp2("--aururl", gotext.Get("Set an alternative AUR URL"), gotext.Get("url")))
+	fmt.Println(optionHlp2("--builddir", gotext.Get("Directory used to download and run PKGBUILDS"), gotext.Get("dir")))
+	fmt.Println(optionHlp2("--absdir", gotext.Get("Directory used to store downloads from the ABS"), gotext.Get("dir")))
+	fmt.Println(optionHlp2("--editor", gotext.Get("Editor to use when editing PKGBUILDs"), gotext.Get("file")))
+	fmt.Println(optionHlp2("--editorflags", gotext.Get("Pass arguments to editor"), gotext.Get("flags")))
+	fmt.Println(optionHlp2("--makepkg", gotext.Get("makepkg command to use"), gotext.Get("file")))
+	fmt.Println(optionHlp2("--mflags", gotext.Get("Pass arguments to makepkg"), gotext.Get("flags")))
+	fmt.Println(optionHlp2("--pacman", gotext.Get("pacman command to use"), gotext.Get("file")))
+	fmt.Println(optionHlp2("--git", gotext.Get("git command to use"), gotext.Get("file")))
+	fmt.Println(optionHlp2("--gitflags", gotext.Get("Pass arguments to git"), gotext.Get("flags")))
+	fmt.Println(optionHlp2("--gpg", gotext.Get("gpg command to use"), gotext.Get("file")))
+	fmt.Println(optionHlp2("--gpgflags", gotext.Get("Pass arguments to gpg"), gotext.Get("flags")))
+	fmt.Println(optionHlp2("--config", gotext.Get("pacman.conf file to use"), gotext.Get("file")))
+	fmt.Println(optionHlp2("--makepkgconf", gotext.Get("makepkg.conf file to use"), gotext.Get("file")))
+	fmt.Println(optionHelp("--nomakepkgconf", gotext.Get("Use the default makepkg.conf")))
+	fmt.Println(optionHlp3("--requestsplitn", gotext.Get("Max amount of packages to query per AUR request"), "n"))
+	fmt.Println(optionHelp("--completioninterval ", gotext.Get("Time in days to refresh completion cache"), "n"))
+	fmt.Println(optionHlp2("--sortby", gotext.Get("Sort AUR results by a specific field during search"), gotext.Get("field")))
+	fmt.Println(optionHlp2("--searchby", gotext.Get("Search for packages using a specified field"), gotext.Get("field")))
+	fmt.Println(optionHlp3("--answerclean", gotext.Get("Set a predetermined answer for the clean build menu"), "a"))
+	fmt.Println(optionHlp3("--answerdiff", gotext.Get("Set a predetermined answer for the diff menu"), "a"))
+	fmt.Println(optionHlp3("--answeredit", gotext.Get("Set a predetermined answer for the edit pkgbuild menu"), "a"))
+	fmt.Println(optionHlp3("--answerupgrade", gotext.Get("Set a predetermined answer for the upgrade menu"), "a"))
+	fmt.Println(optionHelp("--noanswerclean", gotext.Get("Unset the answer for the clean build menu")))
+	fmt.Println(optionHelp("--noanswerdiff", gotext.Get("Unset the answer for the edit diff menu")))
+	fmt.Println(optionHelp("--noansweredit", gotext.Get("Unset the answer for the edit pkgbuild menu")))
+	fmt.Println(optionHelp("--noanswerupgrade", gotext.Get("Unset the answer for the upgrade menu")))
+	fmt.Println(optionHelp("--cleanmenu", gotext.Get("Give the option to clean build PKGBUILDS")))
+	fmt.Println(optionHelp("--diffmenu", gotext.Get("Give the option to show diffs for build files")))
+	fmt.Println(optionHelp("--editmenu", gotext.Get("Give the option to edit/view PKGBUILDS")))
+	fmt.Println(optionHelp("--upgrademenu", gotext.Get("Show a detailed list of updates with the option to skip any")))
+	fmt.Println(optionHelp("--nocleanmenu", gotext.Get("Don't clean build PKGBUILDS")))
+	fmt.Println(optionHelp("--nodiffmenu", gotext.Get("Don't show diffs for build files")))
+	fmt.Println(optionHelp("--noeditmenu", gotext.Get("Don't edit/view PKGBUILDS")))
+	fmt.Println(optionHelp("--noupgrademenu", gotext.Get("Don't show the upgrade menu")))
+	fmt.Println(optionHelp("--askremovemake", gotext.Get("Ask to remove makedepends after install")))
+	fmt.Println(optionHelp("--removemake", gotext.Get("Remove makedepends after install")))
+	fmt.Println(optionHelp("--noremovemake", gotext.Get("Don't remove makedepends after install")))
+	fmt.Println(optionHelp("--cleanafter", gotext.Get("Remove package sources after successful install")))
+	fmt.Println(optionHelp("--nocleanafter", gotext.Get("Do not remove package sources after successful build")))
+	fmt.Println(optionHelp("--bottomup", gotext.Get("Shows AUR's packages first and then repository's")))
+	fmt.Println(optionHelp("--topdown", gotext.Get("Shows repository's packages first and then AUR's")))
+	fmt.Println(optionHelp("--devel", gotext.Get("Check development packages during sysupgrade")))
+	fmt.Println(optionHelp("--nodevel", gotext.Get("Do not check development packages")))
+	fmt.Println(optionHelp("--rebuild", gotext.Get("Always build target packages")))
+	fmt.Println(optionHelp("--rebuildall", gotext.Get("Always build all AUR packages")))
+	fmt.Println(optionHelp("--norebuild", gotext.Get("Skip package build if in cache and up to date")))
+	fmt.Println(optionHelp("--rebuildtree", gotext.Get("Always build all AUR packages even if installed")))
+	fmt.Println(optionHelp("--redownload", gotext.Get("Always download pkgbuilds of targets")))
+	fmt.Println(optionHelp("--noredownload", gotext.Get("Skip pkgbuild download if in cache and up to date")))
+	fmt.Println(optionHelp("--redownloadall", gotext.Get("Always download pkgbuilds of all AUR packages")))
+	fmt.Println(optionHelp("--provides", gotext.Get("Look for matching providers when searching for packages")))
+	fmt.Println(optionHelp("--noprovides", gotext.Get("Just look for packages by pkgname")))
+	fmt.Println(optionHelp("--pgpfetch", gotext.Get("Prompt to import PGP keys from PKGBUILDs")))
+	fmt.Println(optionHelp("--nopgpfetch", gotext.Get("Don't prompt to import PGP keys")))
+	fmt.Println(optionHelp("--useask", gotext.Get("Automatically resolve conflicts using pacman's ask flag")))
+	fmt.Println(optionHelp("--nouseask", gotext.Get("Confirm conflicts manually during the install")))
+	fmt.Println(optionHelp("--combinedupgrade", gotext.Get("Refresh then perform the repo and AUR upgrade together")))
+	fmt.Println(optionHelp("--batchinstall", gotext.Get("Build multiple AUR packages then install them together")))
+	fmt.Println(optionHelp("--nobatchinstall", gotext.Get("Build and install each AUR package one by one")))
+	fmt.Println(optionHlp2("--sudo", gotext.Get("sudo command to use"), gotext.Get("file")))
+	fmt.Println(optionHlp2("--sudoflags", gotext.Get("Pass arguments to sudo"), gotext.Get("flags")))
+	fmt.Println(optionHelp("--sudoloop", gotext.Get("Loop sudo calls in the background to avoid timeout")))
+	fmt.Println(optionHelp("--nosudoloop", gotext.Get("Do not loop sudo calls in the background")))
+	fmt.Println(optionHelp("--timeupdate", gotext.Get("Check packages' AUR page for changes during sysupgrade")))
+	fmt.Println(optionHelp("--notimeupdate", gotext.Get("Do not check packages' AUR page for changes")))
 
-    --requestsplitn <n>   Max amount of packages to query per AUR request
-    --completioninterval  <n> Time in days to refresh completion cache
-    --sortby    <field>   Sort AUR results by a specific field during search
-    --searchby  <field>   Search for packages using a specified field
-    --answerclean   <a>   Set a predetermined answer for the clean build menu
-    --answerdiff    <a>   Set a predetermined answer for the diff menu
-    --answeredit    <a>   Set a predetermined answer for the edit pkgbuild menu
-    --answerupgrade <a>   Set a predetermined answer for the upgrade menu
-    --noanswerclean       Unset the answer for the clean build menu
-    --noanswerdiff        Unset the answer for the edit diff menu
-    --noansweredit        Unset the answer for the edit pkgbuild menu
-    --noanswerupgrade     Unset the answer for the upgrade menu
-    --cleanmenu           Give the option to clean build PKGBUILDS
-    --diffmenu            Give the option to show diffs for build files
-    --editmenu            Give the option to edit/view PKGBUILDS
-    --upgrademenu         Show a detailed list of updates with the option to skip any
-    --nocleanmenu         Don't clean build PKGBUILDS
-    --nodiffmenu          Don't show diffs for build files
-    --noeditmenu          Don't edit/view PKGBUILDS
-    --noupgrademenu       Don't show the upgrade menu
-    --askremovemake       Ask to remove makedepends after install
-    --removemake          Remove makedepends after install
-    --noremovemake        Don't remove makedepends after install
+	fmt.Print("\n", gotext.Get("show specific options"), ":\n")
+	fmt.Println(optionHelp("-c --complete", gotext.Get("Used for completions")))
+	fmt.Println(optionHelp("-d --defaultconfig", gotext.Get("Print default yay configuration")))
+	fmt.Println(optionHelp("-g --currentconfig", gotext.Get("Print current yay configuration")))
+	fmt.Println(optionHelp("-s --stats", gotext.Get("Display system package statistics")))
+	fmt.Println(optionHelp("-w --news", gotext.Get("Print arch news")))
 
-    --cleanafter          Remove package sources after successful install
-    --nocleanafter        Do not remove package sources after successful build
-    --bottomup            Shows AUR's packages first and then repository's
-    --topdown             Shows repository's packages first and then AUR's
+	fmt.Print("\n", gotext.Get("yay specific options"), ":\n")
+	fmt.Println(optionHelp("-c --clean", gotext.Get("Remove unneeded dependencies")))
+	fmt.Println(optionHelp("--gendb", gotext.Get("Generates development package DB used for updating")))
 
-    --devel               Check development packages during sysupgrade
-    --nodevel             Do not check development packages
-    --rebuild             Always build target packages
-    --rebuildall          Always build all AUR packages
-    --norebuild           Skip package build if in cache and up to date
-    --rebuildtree         Always build all AUR packages even if installed
-    --redownload          Always download pkgbuilds of targets
-    --noredownload        Skip pkgbuild download if in cache and up to date
-    --redownloadall       Always download pkgbuilds of all AUR packages
-    --provides            Look for matching providers when searching for packages
-    --noprovides          Just look for packages by pkgname
-    --pgpfetch            Prompt to import PGP keys from PKGBUILDs
-    --nopgpfetch          Don't prompt to import PGP keys
-    --useask              Automatically resolve conflicts using pacman's ask flag
-    --nouseask            Confirm conflicts manually during the install
-    --combinedupgrade     Refresh then perform the repo and AUR upgrade together
-    --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
-    --batchinstall        Build multiple AUR packages then install them together
-    --nobatchinstall      Build and install each AUR package one by one
-
-    --sudo                <file>  sudo command to use
-    --sudoflags           <flags> Pass arguments to sudo
-    --sudoloop            Loop sudo calls in the background to avoid timeout
-    --nosudoloop          Do not loop sudo calls in the background
-
-    --timeupdate          Check packages' AUR page for changes during sysupgrade
-    --notimeupdate        Do not check packages' AUR page for changes
-
-show specific options:
-    -c --complete         Used for completions
-    -d --defaultconfig    Print default yay configuration
-    -g --currentconfig    Print current yay configuration
-    -s --stats            Display system package statistics
-    -w --news             Print arch news
-
-yay specific options:
-    -c --clean            Remove unneeded dependencies
-       --gendb            Generates development package DB used for updating
-
-getpkgbuild specific options:
-    -f --force            Force download for existing ABS packages`)
+	fmt.Print("\n", gotext.Get("getpkgbuild specific options"), ":\n")
+	fmt.Println(optionHelp("-f --force", gotext.Get("Force download for existing ABS packages")))
 }
 
 func handleCmd(cmdArgs *settings.Arguments, dbExecutor db.Executor) error {

--- a/po/en.po
+++ b/po/en.po
@@ -11,6 +11,407 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr "%s already exists. Use -f/--force to overwrite"
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr "Unable to clean:"
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr "Always build all AUR packages even if installed"
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr "Always build all AUR packages"
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr "Always build target packages"
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr "Always download pkgbuilds of all AUR packages"
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr "Always download pkgbuilds of targets"
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr "Ask to remove makedepends after install"
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr "Assume targets are from the AUR"
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr "Assume targets are from the repositories"
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr "Automatically resolve conflicts using pacman's ask flag"
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr "Build and install each AUR package one by one"
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr "Build multiple AUR packages then install them together"
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr "Causes the following options to be saved back to the"
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr "Check development packages during sysupgrade"
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr "Check packages' AUR page for changes during sysupgrade"
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr "Confirm conflicts manually during the install"
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr "Directory used to download and run PKGBUILDS"
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr "Directory used to store downloads from the ABS"
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr "Display system package statistics"
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr "Do not check development packages"
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr "Do not check packages' AUR page for changes"
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr "Do not loop sudo calls in the background"
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr "Do not remove package sources after successful build"
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr "Don't clean build PKGBUILDS"
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr "Don't edit/view PKGBUILDS"
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr "Don't prompt to import PGP keys"
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr "Don't remove makedepends after install"
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr "Don't show diffs for build files"
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr "Don't show the upgrade menu"
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr "Editor to use when editing PKGBUILDs"
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr "Force download for existing ABS packages"
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr "Generates development package DB used for updating"
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr "Give the option to clean build PKGBUILDS"
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr "Give the option to edit/view PKGBUILDS"
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr "Give the option to show diffs for build files"
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr "If no arguments are provided 'yay -Syu' will be performed"
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr "If no operation is provided -Y will be assumed"
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr "Just look for packages by pkgname"
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr "Look for matching providers when searching for packages"
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr "Loop sudo calls in the background to avoid timeout"
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr "Max amount of packages to query per AUR request"
+
+#: cmd.go:79
+msgid "New operations"
+msgstr "New operations"
+
+#: cmd.go:88
+msgid "New options"
+msgstr "New options"
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr "Pass arguments to editor"
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr "Pass arguments to git"
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr "Pass arguments to gpg"
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr "Pass arguments to makepkg"
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr "Pass arguments to sudo"
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr "Permanent configuration options"
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr "Print arch news"
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr "Print current yay configuration"
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr "Print default yay configuration"
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr "Prompt to import PGP keys from PKGBUILDs"
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr "Refresh then perform the repo and AUR upgrade together"
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr "Remove makedepends after install"
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr "Remove package sources after successful install"
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr "Remove unneeded dependencies"
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr "Search for packages using a specified field"
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr "Set a predetermined answer for the clean build menu"
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr "Set a predetermined answer for the diff menu"
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr "Set a predetermined answer for the edit pkgbuild menu"
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr "Set a predetermined answer for the upgrade menu"
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr "Set an alternative AUR URL"
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr "Show a detailed list of updates with the option to skip any"
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr "Shows AUR's packages first and then repository's"
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr "Shows repository's packages first and then AUR's"
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr "Skip package build if in cache and up to date"
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr "Skip pkgbuild download if in cache and up to date"
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr "Sort AUR results by a specific field during search"
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr "Time in days to refresh completion cache"
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr "Unset the answer for the clean build menu"
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr "Unset the answer for the edit diff menu"
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr "Unset the answer for the edit pkgbuild menu"
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr "Unset the answer for the upgrade menu"
+
+#: cmd.go:64
+msgid "Usage"
+msgstr "Usage"
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr "Use the default makepkg.conf"
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr "Used for completions"
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr "config file when used"
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr "dir"
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr "field"
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr "file"
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr "file(s)"
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr "flags"
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr "getpkgbuild specific options"
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr "git command to use"
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr "gpg command to use"
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr "makepkg command to use"
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr "makepkg.conf file to use"
+
+#: cmd.go:65
+msgid "operation"
+msgstr "operation"
+
+#: cmd.go:68
+msgid "operations"
+msgstr "operations"
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr "options"
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr "package(s)"
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr "pacman command to use"
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr "pacman.conf file to use"
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr "show specific options"
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr "sudo command to use"
+
+#: cmd.go:97
+msgid "url"
+msgstr "url"
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr "yay specific options"
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Build Files Exist)"

--- a/po/es.po
+++ b/po/es.po
@@ -12,6 +12,407 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Archivos de compilación existen)"

--- a/po/eu.po
+++ b/po/eu.po
@@ -12,6 +12,407 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Konpilazio fitxategiak existitzen dira)"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -13,6 +13,407 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Fichiers de compilation existants)"
@@ -184,11 +585,11 @@ msgstr "Afficher les diffs ?"
 
 #: clean.go:91
 msgid "Do you want to remove ALL AUR packages from cache?"
-msgstr "Êtes-vous sûr de vouloir supprimer TOUS les paquets AUR du cache ?"
+msgstr "Êtes-vous sûr de vouloir supprimer TOUS les paquets AUR du cache ?"
 
 #: clean.go:108
 msgid "Do you want to remove ALL untracked AUR files?"
-msgstr "Êtes-vous sûr de vouloir supprimer TOUS les fichiers AUR non suivis ?"
+msgstr "Êtes-vous sûr de vouloir supprimer TOUS les fichiers AUR non suivis ?"
 
 #: clean.go:93
 msgid "Do you want to remove all other AUR packages from cache?"
@@ -289,7 +690,7 @@ msgstr "Obsolète"
 
 #: keys.go:115
 msgid "PGP keys need importing:"
-msgstr "Clés PGP dont l'import est nécessaire :"
+msgstr "Clés PGP dont l'import est nécessaire :"
 
 #: install.go:874
 msgid "PKGBUILD up to date, Skipping (%d/%d): %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,16 +1,416 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2020-07-13 21:09+0900\n"
-"Language-Team: English\n"
+"PO-Revision-Date: 2020-10-20 07:00+0900\n"
+"Last-Translator: FuRuYa7\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 2.3\n"
-"POT-Creation-Date: \n"
-"Last-Translator: Yamada Hayao\n"
-"Language: ja\n"
+"X-Generator: xgotext\n"
+
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr "%s はすでに存在します。-f/--force で上書きできます"
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr "消去できません:"
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr "インストール済みでも、常にすべてのAURパッケージをビルド"
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr "常にすべてのAUR パッケージをビルド"
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr "常にターゲットパッケージをビルド"
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr "常にすべてのAURパッケージのPKGBUILD をダウンロード"
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr "常にターゲットのPKGBUILD をダウンロード"
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr "インストール後にmake 時の依存関係を削除するか尋ねます"
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr "ターゲットがAUR にあると想定します"
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr "ターゲットが公式リポジトリにあると想定します"
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr "pacman の質問フラグを使用して競合を自動的に解決"
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr "各AUR パッケージを1つずつビルドしてインストール"
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr "複数のAUR パッケージをビルドして一緒にインストール"
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr "次のオプションを使うと、設定ファイルに"
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr "sysupgrade 中に開発パッケージをチェック"
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr "sysupgrade 中に、AUR のパッケージの変更をチェック"
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr "インストール中に手動で競合を確認"
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr "PKGBUILD のダウンロードと実行に使うディレクトリ"
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr "ABS からのダウンロードの保存に使うディレクトリ"
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr "システムのパッケージの統計情報を表示"
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr "開発パッケージをチェックしません"
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr "AUR のパッケージの変更をチェックしません"
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr "バックグラウンドでsudo 呼出しをループしません"
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr "インストール後にパッケージソースを削除しません"
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr "PKGBUILD をクリーンビルドしません"
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr "PKGBUILD を編集/表示しません"
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr "PGP キーのインポートを要求しません"
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr "インストール後にmake 時の依存関係を削除しません"
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr "PKGBUILD ファイルの差異を表示しません"
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr "アップグレードメニューを表示しません"
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr "PKGBUILD を編集するときに使うエディタ"
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr "既存のABS パッケージを強制ダウンロード"
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr "アップデートに使用する開発パッケージDB を生成"
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr "PKGBUILD をクリーンビルドするオプションを提供"
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr "PKGBUILD を編集/表示するオプションを提供"
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr "PKGBUILD ファイルの差異を表示するオプションを提供"
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr "引数を指定しない場合は、「yay -Syu」が実行されます"
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr "オペレーションを指定しない場合は、「-Y」が指定されたことになります"
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr "パッケージ名でパッケージを探すだけです"
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr "パッケージの検索で一致するプロバイダーを探します"
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr "バックグラウンドでsudo 呼出しをループ、タイムアウト回避"
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr "AUR リクエストごとにクエリするパッケージの最大量"
+
+#: cmd.go:79
+msgid "New operations"
+msgstr "新しいオペレーション"
+
+#: cmd.go:88
+msgid "New options"
+msgstr "新しいオプション"
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr "引数をエディタに渡します"
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr "git に引数を渡します"
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr "gpg に引数を渡します"
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr "makepkg に引数を渡します"
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr "sudo に引数を渡します"
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr "永続的な構成オプション"
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr "Arch ニュースを表示"
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr "現在のyay の設定を表示"
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr "デフォルトのyay の設定を表示"
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr "PKGBUILD からPGP キーをインポートするように要求"
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr "更新後に、リポジトリとAUR のアップグレードを一緒に実行"
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr "インストール後にmake 時の依存関係を削除"
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr "インストール後にパッケージソースを削除"
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr "不要な依存関係を削除"
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr "指定されたフィールドを使用してパッケージを検索"
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr "クリーンビルドメニューに所定の返答を設定"
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr "差異メニューに所定の返答を設定"
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr "PKGBUILD の編集メニューに所定の返答を設定"
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr "アップグレードメニューに所定の返答を設定"
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr "代替のAUR のURL を設定"
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr "更新の詳細リストを表示し、スキップするオプションを選択"
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr "初めにAUR のパッケージ、次にリポジトリのパッケージを表示"
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr "初めにリポジトリのパッケージ、次にAUR のパッケージを表示"
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr "キャッシュ内にあり最新なら、パッケージのビルドをしません"
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr "キャッシュ内にあり最新なら、PKGBUILD のダウンロードをしません"
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr "検索中にAUR の結果を特定のフィールドで並べ替え"
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr "完了キャッシュを更新するための日数"
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr "クリーンビルドメニューの返答の設定を解除"
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr "差異メニューの返答の設定を解除"
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr "PKGBUILD の編集メニューの返答の設定を解除"
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr "アップグレードメニューの返答の設定を解除"
+
+#: cmd.go:64
+msgid "Usage"
+msgstr "使用方法"
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr "デフォルトのmakepkg.conf を使用"
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr "補完を使います"
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr "保存されます。"
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr "dir"
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr "field"
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr "file"
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr "ファイル"
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr "flags"
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr "「-G --getpkgbuild」を指定したときのオプション"
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr "git コマンドを使います"
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr "gpg コマンドを使います"
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr "makepkg コマンドを使います"
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr "makepkg.conf に使うファイル"
+
+#: cmd.go:65
+msgid "operation"
+msgstr "オペレーション"
+
+#: cmd.go:68
+msgid "operations"
+msgstr "オペレーション"
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr "オプション"
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr "パッケージ"
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr "pacman コマンドを使います"
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr "pacman.conf に使うファイル"
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr "「-P --show」を指定したときのオプション"
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr "sudo コマンドを使います"
+
+#: cmd.go:97
+msgid "url"
+msgstr "URL"
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr "「-Y --yay」を指定したときのオプション"
 
 #: install.go:563
 msgid " (Build Files Exist)"
@@ -50,7 +450,7 @@ msgstr "%s [A]全て [Ab]中止 [I]インストール済み [No]未インスト�
 
 #: download.go:273
 msgid "%s already downloaded -- use -f to overwrite"
-msgstr "%s は既にダウンロードされています -- -f で上書きできます"
+msgstr "%s はすでにダウンロードされています。-f で上書きできます"
 
 #: install.go:1086
 msgid "%s already made -- skipping build"

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -13,6 +13,407 @@ msgstr ""
 "|| n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 #, fuzzy
 msgid " (Build Files Exist)"

--- a/po/pt.po
+++ b/po/pt.po
@@ -9,6 +9,407 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Ficheiros de compilação existem)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -11,6 +11,407 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: xgotext\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (Arquivos de Build Existem)"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -12,6 +12,407 @@ msgstr ""
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3.1\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (файлы сборки существуют)"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -12,6 +12,407 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
+#: download.go:200
+msgid "%s already exists. Use -f/--force to overwrite"
+msgstr ""
+
+#: clean.go:177
+msgid "Unable to clean:"
+msgstr ""
+
+#: cmd.go:144
+msgid "Always build all AUR packages even if installed"
+msgstr ""
+
+#: cmd.go:142
+msgid "Always build all AUR packages"
+msgstr ""
+
+#: cmd.go:141
+msgid "Always build target packages"
+msgstr ""
+
+#: cmd.go:147
+msgid "Always download pkgbuilds of all AUR packages"
+msgstr ""
+
+#: cmd.go:145
+msgid "Always download pkgbuilds of targets"
+msgstr ""
+
+#: cmd.go:132
+msgid "Ask to remove makedepends after install"
+msgstr ""
+
+#: cmd.go:90
+msgid "Assume targets are from the AUR"
+msgstr ""
+
+#: cmd.go:89
+msgid "Assume targets are from the repositories"
+msgstr ""
+
+#: cmd.go:152
+msgid "Automatically resolve conflicts using pacman's ask flag"
+msgstr ""
+
+#: cmd.go:156
+msgid "Build and install each AUR package one by one"
+msgstr ""
+
+#: cmd.go:155
+msgid "Build multiple AUR packages then install them together"
+msgstr ""
+
+#: cmd.go:93
+# The first half of "Causes the following options to be saved back to the config file when used"
+msgid "Causes the following options to be saved back to the"
+msgstr ""
+
+#: cmd.go:139
+msgid "Check development packages during sysupgrade"
+msgstr ""
+
+#: cmd.go:161
+msgid "Check packages' AUR page for changes during sysupgrade"
+msgstr ""
+
+#: cmd.go:153
+msgid "Confirm conflicts manually during the install"
+msgstr ""
+
+#: cmd.go:98
+msgid "Directory used to download and run PKGBUILDS"
+msgstr ""
+
+#: cmd.go:99
+msgid "Directory used to store downloads from the ABS"
+msgstr ""
+
+#: cmd.go:168
+msgid "Display system package statistics"
+msgstr ""
+
+#: cmd.go:140
+msgid "Do not check development packages"
+msgstr ""
+
+#: cmd.go:162
+msgid "Do not check packages' AUR page for changes"
+msgstr ""
+
+#: cmd.go:160
+msgid "Do not loop sudo calls in the background"
+msgstr ""
+
+#: cmd.go:136
+msgid "Do not remove package sources after successful build"
+msgstr ""
+
+#: cmd.go:128
+msgid "Don't clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:130
+msgid "Don't edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:151
+msgid "Don't prompt to import PGP keys"
+msgstr ""
+
+#: cmd.go:134
+msgid "Don't remove makedepends after install"
+msgstr ""
+
+#: cmd.go:129
+msgid "Don't show diffs for build files"
+msgstr ""
+
+#: cmd.go:131
+msgid "Don't show the upgrade menu"
+msgstr ""
+
+#: cmd.go:100
+msgid "Editor to use when editing PKGBUILDs"
+msgstr ""
+
+#: cmd.go:176
+msgid "Force download for existing ABS packages"
+msgstr ""
+
+#: cmd.go:173
+msgid "Generates development package DB used for updating"
+msgstr ""
+
+#: cmd.go:124
+msgid "Give the option to clean build PKGBUILDS"
+msgstr ""
+
+#: cmd.go:126
+msgid "Give the option to edit/view PKGBUILDS"
+msgstr ""
+
+#: cmd.go:125
+msgid "Give the option to show diffs for build files"
+msgstr ""
+
+#: cmd.go:85
+msgid "If no arguments are provided 'yay -Syu' will be performed"
+msgstr ""
+
+#: cmd.go:86
+msgid "If no operation is provided -Y will be assumed"
+msgstr ""
+
+#: cmd.go:149
+msgid "Just look for packages by pkgname"
+msgstr ""
+
+#: cmd.go:148
+msgid "Look for matching providers when searching for packages"
+msgstr ""
+
+#: cmd.go:159
+msgid "Loop sudo calls in the background to avoid timeout"
+msgstr ""
+
+#: cmd.go:112
+msgid "Max amount of packages to query per AUR request"
+msgstr ""
+
+#: cmd.go:79
+msgid "New operations"
+msgstr ""
+
+#: cmd.go:88
+msgid "New options"
+msgstr ""
+
+#: cmd.go:101
+msgid "Pass arguments to editor"
+msgstr ""
+
+#: cmd.go:106
+msgid "Pass arguments to git"
+msgstr ""
+
+#: cmd.go:108
+msgid "Pass arguments to gpg"
+msgstr ""
+
+#: cmd.go:103
+msgid "Pass arguments to makepkg"
+msgstr ""
+
+#: cmd.go:158
+msgid "Pass arguments to sudo"
+msgstr ""
+
+#: cmd.go:92
+msgid "Permanent configuration options"
+msgstr ""
+
+#: cmd.go:169
+msgid "Print arch news"
+msgstr ""
+
+#: cmd.go:167
+msgid "Print current yay configuration"
+msgstr ""
+
+#: cmd.go:166
+msgid "Print default yay configuration"
+msgstr ""
+
+#: cmd.go:150
+msgid "Prompt to import PGP keys from PKGBUILDs"
+msgstr ""
+
+#: cmd.go:154
+msgid "Refresh then perform the repo and AUR upgrade together"
+msgstr ""
+
+#: cmd.go:133
+msgid "Remove makedepends after install"
+msgstr ""
+
+#: cmd.go:135
+msgid "Remove package sources after successful install"
+msgstr ""
+
+#: cmd.go:172
+msgid "Remove unneeded dependencies"
+msgstr ""
+
+#: cmd.go:115
+msgid "Search for packages using a specified field"
+msgstr ""
+
+#: cmd.go:116
+msgid "Set a predetermined answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:117
+msgid "Set a predetermined answer for the diff menu"
+msgstr ""
+
+#: cmd.go:118
+msgid "Set a predetermined answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:119
+msgid "Set a predetermined answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:97
+msgid "Set an alternative AUR URL"
+msgstr ""
+
+#: cmd.go:127
+msgid "Show a detailed list of updates with the option to skip any"
+msgstr ""
+
+#: cmd.go:137
+msgid "Shows AUR's packages first and then repository's"
+msgstr ""
+
+#: cmd.go:138
+msgid "Shows repository's packages first and then AUR's"
+msgstr ""
+
+#: cmd.go:143
+msgid "Skip package build if in cache and up to date"
+msgstr ""
+
+#: cmd.go:146
+msgid "Skip pkgbuild download if in cache and up to date"
+msgstr ""
+
+#: cmd.go:114
+msgid "Sort AUR results by a specific field during search"
+msgstr ""
+
+#: cmd.go:113
+msgid "Time in days to refresh completion cache"
+msgstr ""
+
+#: cmd.go:120
+msgid "Unset the answer for the clean build menu"
+msgstr ""
+
+#: cmd.go:121
+msgid "Unset the answer for the edit diff menu"
+msgstr ""
+
+#: cmd.go:122
+msgid "Unset the answer for the edit pkgbuild menu"
+msgstr ""
+
+#: cmd.go:123
+msgid "Unset the answer for the upgrade menu"
+msgstr ""
+
+#: cmd.go:64
+msgid "Usage"
+msgstr ""
+
+#: cmd.go:111
+msgid "Use the default makepkg.conf"
+msgstr ""
+
+#: cmd.go:165
+msgid "Used for completions"
+msgstr ""
+
+#: cmd.go:94
+# The second half of "Causes the following options to be saved back to the config file when used"
+msgid "config file when used"
+msgstr ""
+
+#: cmd.go:98 cmd.go:99
+msgid "dir"
+msgstr ""
+
+#: cmd.go:114 cmd.go:115
+msgid "field"
+msgstr ""
+
+#: cmd.go:100 cmd.go:102 cmd.go:104 cmd.go:105 cmd.go:107 cmd.go:109 cmd.go:110
+#: cmd.go:157
+msgid "file"
+msgstr ""
+
+#: cmd.go:77
+msgid "file(s)"
+msgstr ""
+
+#: cmd.go:101 cmd.go:103 cmd.go:106 cmd.go:108 cmd.go:158
+msgid "flags"
+msgstr ""
+
+#: cmd.go:175
+msgid "getpkgbuild specific options"
+msgstr ""
+
+#: cmd.go:105
+msgid "git command to use"
+msgstr ""
+
+#: cmd.go:107
+msgid "gpg command to use"
+msgstr ""
+
+#: cmd.go:102
+msgid "makepkg command to use"
+msgstr ""
+
+#: cmd.go:110
+msgid "makepkg.conf file to use"
+msgstr ""
+
+#: cmd.go:65
+msgid "operation"
+msgstr ""
+
+#: cmd.go:68
+msgid "operations"
+msgstr ""
+
+#: cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76 cmd.go:77
+#: cmd.go:81 cmd.go:82
+msgid "options"
+msgstr ""
+
+#: cmd.go:66 cmd.go:71 cmd.go:72 cmd.go:73 cmd.go:74 cmd.go:75 cmd.go:76
+#: cmd.go:80 cmd.go:82
+msgid "package(s)"
+msgstr ""
+
+#: cmd.go:104
+msgid "pacman command to use"
+msgstr ""
+
+#: cmd.go:109
+msgid "pacman.conf file to use"
+msgstr ""
+
+#: cmd.go:164
+msgid "show specific options"
+msgstr ""
+
+#: cmd.go:157
+msgid "sudo command to use"
+msgstr ""
+
+#: cmd.go:97
+msgid "url"
+msgstr ""
+
+#: cmd.go:171
+msgid "yay specific options"
+msgstr ""
+
 #: install.go:563
 msgid " (Build Files Exist)"
 msgstr " (构建文件已存在)"


### PR DESCRIPTION
Fixed an error in "golangci-lint"

Fixed the 'cmd.go' file. In addition, the translated part of the help display was added to all PO files, and only 'en.po' and 'ja.po' were translated in the help display part.