### PR TITLE
Add --mitmsslcert option

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -149,6 +149,10 @@ func handleCmd(cmdArgs *settings.Arguments, dbExecutor db.Executor) error {
 		sudoLoopBackground()
 	}
 
+	if config.MitmSSLCert != "" {
+		addMitmSSLCert(config.MitmSSLCert)
+	}
+
 	switch cmdArgs.Op {
 	case "V", "version":
 		handleVersion()

--- a/completions/bash
+++ b/completions/bash
@@ -76,7 +76,7 @@ _yay() {
           nocleanmenu nodiffmenu noupgrademenu provides noprovides pgpfetch nopgpfetch
           useask nouseask combinedupgrade nocombinedupgrade aur repo makepkgconf
           nomakepkgconf askremovemake removemake noremovemake completioninterval aururl
-          searchby batchinstall nobatchinstall'
+          searchby batchinstall nobatchinstall mitmsslcert'
     'b d h q r v')
   yays=('clean gendb' 'c')
   show=('complete defaultconfig currentconfig stats  news' 'c d g s w')

--- a/completions/fish
+++ b/completions/fish
@@ -242,3 +242,4 @@ complete -c $progname -n "not $noopt" -l mflags -d 'Pass the following options t
 complete -c $progname -n "not $noopt" -l gpgflags -d 'Pass the following options to gpg' -f
 complete -c $progname -n "not $noopt" -l sudoloop -d 'Loop sudo calls in the background to avoid timeout' -f
 complete -c $progname -n "not $noopt" -l nosudoloop -d 'Do not loop sudo calls in the background' -f
+complete -c $progname -n "not $noopt" -l mitmsslcert -d 'Trust the following additional SSL certificate' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -108,6 +108,7 @@ _pacman_opts_common=(
 	'--sortby[Sort AUR results by a specific field during search]'
 	'--batchinstall[Build multiple AUR packages then install them together]'
 	'--nobatchinstall[Build and install each AUR package one by one]'
+	'--mitmsslcert[Trust the following additional SSL certificate]'
 )
 
 # options for passing to _arguments: options for --upgrade commands

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -508,6 +508,12 @@ builds.
 .B \-\-nosudoloop
 Do not loop sudo calls in the background.
 
+.TP
+.B \-\-mitmsslcert <certfile>
+Add the PEM-formatted SSL certificate(s) in the given file to the certificate
+pool. This can enable downloads in networks where HTTPS connections are
+intercepted like in some corporate networks.
+
 .SH EXAMPLES
 .TP
 yay \fIfoo\fR

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -53,6 +53,7 @@ type Configuration struct {
 	RemoveMake         string   `json:"removemake"`
 	SudoBin            string   `json:"sudobin"`
 	SudoFlags          string   `json:"sudoflags"`
+	MitmSSLCert        string   `json:"mitmsslcert"`
 	RequestSplitN      int      `json:"requestsplitn"`
 	SearchMode         int      `json:"-"`
 	SortMode           int      `json:"sortmode"`
@@ -112,6 +113,7 @@ func (c *Configuration) expandEnv() {
 	c.GpgBin = os.ExpandEnv(c.GpgBin)
 	c.SudoBin = os.ExpandEnv(c.SudoBin)
 	c.SudoFlags = os.ExpandEnv(c.SudoFlags)
+	c.MitmSSLCert = os.ExpandEnv(c.MitmSSLCert)
 	c.ReDownload = os.ExpandEnv(c.ReDownload)
 	c.ReBuild = os.ExpandEnv(c.ReBuild)
 	c.AnswerClean = os.ExpandEnv(c.AnswerClean)
@@ -157,6 +159,7 @@ func DefaultConfig() *Configuration {
 		GpgBin:             "gpg",
 		SudoBin:            "sudo",
 		SudoFlags:          "",
+		MitmSSLCert:        "",
 		TimeUpdate:         false,
 		RequestSplitN:      150,
 		ReDownload:         "no",


### PR DESCRIPTION
This is a draft for implementing a fix for jguer/yay#137 and jguer/yay#1386 ...

Two remarks:

* I'd appreciate feedback on code style and location. (Not sure where everything is supposed to go, this option should take effect pretty early in the code, so it's not buried very much, but maybe it's too central?)
* I have not tested this yet, I will probably do that on the weekend, using this approach: https://docs.mitmproxy.org/stable/howto-transparent-vms/ to simulate a corporate network HTTPS MITM.
