### PR TITLE
fix(config): fix unsaved config

### DIFF
--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -82,6 +82,11 @@ func (c *Configuration) Save(configPath string) error {
 
 	// https://github.com/Jguer/yay/issues/1325
 	marshalledinfo = append(marshalledinfo, '\n')
+	// https://github.com/Jguer/yay/issues/1399
+	_, err = os.Stat(path.Dir(configPath))
+	if os.IsNotExist(err) {
+		os.MkdirAll(path.Dir(configPath), 0751)
+	}
 	in, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err


### PR DESCRIPTION
issue: [When yay's path does not exist, config is not save](https://github.com/Jguer/yay/issues/1399)
fix unsaved config when yay's config path does not exist