### PR TITLE
unsaved config when yay's config path does not exist

### DIFF
--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -85,8 +85,8 @@ func (c *Configuration) Save(configPath string) error {
 	marshalledinfo = append(marshalledinfo, '\n')
 	// https://github.com/Jguer/yay/issues/1399
 	// fix: unsaved config when yay's config path does not exist
-	if _, err := os.Stat(filepath.Dir(configPath)); os.IsNotExist(err) {
-		if err := os.MkdirAll(path.Dir(configPath), 0761); err != nil {
+	if _, err = os.Stat(filepath.Dir(configPath)); os.IsNotExist(err) {
+		if err = os.MkdirAll(path.Dir(configPath), 0761); err != nil {
 			return err
 		}
 	}

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -82,6 +83,12 @@ func (c *Configuration) Save(configPath string) error {
 
 	// https://github.com/Jguer/yay/issues/1325
 	marshalledinfo = append(marshalledinfo, '\n')
+	// https://github.com/Jguer/yay/issues/1399
+	// fix: unsaved config when yay's config path does not exist
+	_, err = os.Stat(path.Dir(configPath))
+	if os.IsNotExist(err) {
+		os.MkdirAll(path.Dir(configPath), 0761)
+	}
 	in, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -85,9 +85,12 @@ func (c *Configuration) Save(configPath string) error {
 	marshalledinfo = append(marshalledinfo, '\n')
 	// https://github.com/Jguer/yay/issues/1399
 	// fix: unsaved config when yay's config path does not exist
-	_, err = os.Stat(path.Dir(configPath))
+	_, err = os.Stat(filepath.Dir(configPath))
 	if os.IsNotExist(err) {
-		os.MkdirAll(path.Dir(configPath), 0761)
+		err := os.MkdirAll(path.Dir(configPath), 0761)
+		if err != nil {
+			return err
+		}
 	}
 	in, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -85,7 +85,7 @@ func (c *Configuration) Save(configPath string) error {
 	marshalledinfo = append(marshalledinfo, '\n')
 	// https://github.com/Jguer/yay/issues/1399
 	// fix: unsaved config when yay's config path does not exist
-	if _, err = os.Stat(filepath.Dir(configPath)); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Dir(configPath)); os.IsNotExist(err) {
 		if err = os.MkdirAll(path.Dir(configPath), 0761); err != nil {
 			return err
 		}

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -85,10 +85,8 @@ func (c *Configuration) Save(configPath string) error {
 	marshalledinfo = append(marshalledinfo, '\n')
 	// https://github.com/Jguer/yay/issues/1399
 	// fix: unsaved config when yay's config path does not exist
-	_, err = os.Stat(filepath.Dir(configPath))
-	if os.IsNotExist(err) {
-		err := os.MkdirAll(path.Dir(configPath), 0761)
-		if err != nil {
+	if _, err := os.Stat(filepath.Dir(configPath)); os.IsNotExist(err) {
+		if err := os.MkdirAll(path.Dir(configPath), 0761); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
issue: [When yay's path does not exist, config is not save](https://github.com/Jguer/yay/issues/1399)
fix: unsaved config when yay's config path does not exist