### PR TITLE
Fill fields of CmdBuilder with options specified in commandline

### DIFF
--- a/pkg/settings/parser.go
+++ b/pkg/settings/parser.go
@@ -817,8 +817,14 @@ func (a *Arguments) ParseCommandLine(config *Configuration) error {
 	}
 
 	a.extractYayOptions(config)
-	config.Runtime.CmdBuilder.MakepkgFlags = strings.Fields(config.MFlags)
-	config.Runtime.CmdBuilder.GitFlags = strings.Fields(config.GitFlags)
+
+	cmdBuilder := config.Runtime.CmdBuilder
+	cmdBuilder.GitBin = config.GitBin
+	cmdBuilder.GitFlags = strings.Fields(config.GitFlags)
+	cmdBuilder.MakepkgFlags = strings.Fields(config.MFlags)
+	cmdBuilder.MakepkgConfPath = config.MakepkgConf
+	cmdBuilder.MakepkgBin = config.MakepkgBin
+
 	return nil
 }
 


### PR DESCRIPTION
Command line options such like `--git` and `--makepkgconf` seem not to be applied since `exe.CmdBuilder` was introduced.
This is partially fixed by #1398, but rest of fields have not been passed to git/makepkg yet.

This PR fixes problems above.
Fixes #1409 