### PR TITLE
Add "--noconfirm" flag to usage output

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -116,6 +116,7 @@ Permanent configuration options:
     --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
     --batchinstall        Build multiple AUR packages then install them together
     --nobatchinstall      Build and install each AUR package one by one
+    --noconfirm           Do not ask for confirmation
 
     --sudo                <file>  sudo command to use
     --sudoflags           <flags> Pass arguments to sudo


### PR DESCRIPTION
When solving one problem, I was surprised that the yay does not have a flag to not ask the user any questions. After looking at the code, I realised that this flag is simply undocumented.