### PR TITLE
fix(yay): mirror pacman return codes on run error

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main // import "github.com/Jguer/yay"
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 	"github.com/leonelquinteros/gotext"
@@ -135,10 +136,19 @@ func main() {
 
 	defer dbExecutor.Cleanup()
 	err = handleCmd(cmdArgs, db.Executor(dbExecutor))
+
 	if err != nil {
 		if str := err.Error(); str != "" {
 			fmt.Fprintln(os.Stderr, str)
 		}
+
+		if exitError, ok := err.(*exec.ExitError); ok {
+			// mirror pacman exit code when applicable
+			ret = exitError.ExitCode()
+			return
+		}
+
+		// fallback
 		ret = 1
 		return
 	}


### PR DESCRIPTION
makepkg expects pacman-alikes to return 127 (missing dependency)
when called with -T as argument. yay does not behave like this since
it overwrite the return value with 1 in every case.

This commit will test for ExitCode errors and return the called
applications error code instead of 1, when possible. This gets yay
closer to be used as pacman alternative for makepkg with

```
PACMAN=yay makepkg -s
```

It is however still not possible for yay to be used this way, since makepkg will call 
yay as root. This prevents yay from installing packages from aur (and rightfully so). 

fixes  Jguer/yay#1455