### PR TITLE
List `-debug` packages missing from AUR separately (Split Debug Package Support)

### DIFF
--- a/pkg/query/aur_warnings.go
+++ b/pkg/query/aur_warnings.go
@@ -46,8 +46,8 @@ func (warnings *AURWarnings) Print() {
 }
 
 func filterDebugPkgs(names []string) (normal, debug []string) {
-	normal = make([]string, 0)
-	debug = make([]string, 0)
+	normal = make([]string, 0, len(names))
+	debug = make([]string, 0, len(names))
 
 	for _, name := range names {
 		if strings.HasSuffix(name, "-debug") {

--- a/pkg/query/aur_warnings.go
+++ b/pkg/query/aur_warnings.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/leonelquinteros/gotext"
 
@@ -21,9 +22,16 @@ func NewWarnings() *AURWarnings {
 }
 
 func (warnings *AURWarnings) Print() {
-	if len(warnings.Missing) > 0 {
+	normalMissing, debugMissing := filterDebugPkgs(warnings.Missing)
+
+	if len(normalMissing) > 0 {
 		text.Warn(gotext.Get("Missing AUR Packages:"))
-		printRange(warnings.Missing)
+		printRange(normalMissing)
+	}
+
+	if len(debugMissing) > 0 {
+		text.Warn(gotext.Get("Missing AUR Debug Packages:"))
+		printRange(debugMissing)
 	}
 
 	if len(warnings.Orphans) > 0 {
@@ -35,6 +43,21 @@ func (warnings *AURWarnings) Print() {
 		text.Warn(gotext.Get("Flagged Out Of Date AUR Packages:"))
 		printRange(warnings.OutOfDate)
 	}
+}
+
+func filterDebugPkgs(names []string) (normal, debug []string) {
+	normal = make([]string, 0)
+	debug = make([]string, 0)
+
+	for _, name := range names {
+		if strings.HasSuffix(name, "-debug") {
+			debug = append(debug, name)
+		} else {
+			normal = append(normal, name)
+		}
+	}
+
+	return
 }
 
 func printRange(names []string) {


### PR DESCRIPTION
This PR makes it so `-debug` packages created via the `(debug strip)` makepkg option combination are listed separately from regular packages in the "Missing AUR Packages" warning.

The rationale for this is, that if someone uses this option combination, every AUR package will have a `$pkgbase-debug` counterpart containing source files and debug symbols. These `$pkgbase-debug` packages obviously do not exist in the AUR, so are always listed in the "Missing AUR Packages" warning, making legitimately missing packages hard to spot.

Since there is no way (that I know of) to identify these debug packages other than by their name, this invariably will lead to false-positives (e.g. `python-flask-debug`, `dosbox-debug`, or `godot-debug`), which is why I opted to show them as a separate warning rather than dropping them entirely from the list.

As for the implementation, this small patch just separates the packages directly in the print function, which works well, but admittedly is a bit ugly.

I appreciate discussion on whether `yay` actually wants to handle this, and/or if `-debug` packages should get some way to identify them properly (this would require upstream changes to `makepkg` and possibly `pacman`). Split Debug Packages are currently not very well supported in general, and also not documented in many places. I have marked the PR as [RFC] until the design is clear.

(As an added note, yay grew support for installing these `-debug` packages in PR #1191, also by me)