### PR TITLE
Add go to list of dependencies in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ building with makepkg:
 Before you begin, make sure you have the `base-devel` package group installed.
 
 ```sh
-pacman -S --needed git base-devel
+pacman -S --needed git base-devel go
 git clone https://aur.archlinux.org/yay.git
 cd yay
 makepkg -si


### PR DESCRIPTION
I just installed arch onto a new machine today; I wanted yay to install my current editor of choice and noticed that I needed `go` to run makepkg.