### PR TITLE
fixing upstream urls from git.archlinux.org to github

### DIFF
--- a/download.go
+++ b/download.go
@@ -252,9 +252,9 @@ func getPkgbuildsfromABS(pkgs []string, path string, dbExecutor db.Executor, for
 		// https://git.archlinux.org/svntogit/packages.git
 		switch pkg.DB().Name() {
 		case "core", "extra", "testing":
-			url = "https://git.archlinux.org/svntogit/packages.git"
+			url = "https://github.com/archlinux/svntogit-packages.git"
 		case "community", "multilib", "community-testing", "multilib-testing":
-			url = "https://git.archlinux.org/svntogit/community.git"
+			url = "https://github.com/archlinux/svntogit-community.git"
 		default:
 			missing = append(missing, name)
 			continue

--- a/pkg/download/abs.go
+++ b/pkg/download/abs.go
@@ -15,8 +15,8 @@ var ErrABSPackageNotFound = errors.New(gotext.Get("package not found in repos"))
 const MaxConcurrentFetch = 20
 const urlPackagePath = "/plain/trunk/PKGBUILD?"
 
-var ABSPackageURL = "https://git.archlinux.org/svntogit/packages.git"
-var ABSCommunityURL = "https://git.archlinux.org/svntogit/community.git"
+var ABSPackageURL = "https://github.com/archlinux/svntogit-packages.git"
+var ABSCommunityURL = "https://github.com/archlinux/svntogit-community.git"
 
 func getPackageURL(db, pkgName string) (string, error) {
 	values := url.Values{}

--- a/pkg/download/abs_test.go
+++ b/pkg/download/abs_test.go
@@ -46,7 +46,7 @@ func Test_getPackageURL(t *testing.T) {
 				db:      "community",
 				pkgName: "kitty",
 			},
-			want:    "https://git.archlinux.org/svntogit/community.git/plain/trunk/PKGBUILD?h=packages%2Fkitty",
+			want:    "https://github.com/archlinux/svntogit-community.git/plain/trunk/PKGBUILD?h=packages%2Fkitty",
 			wantErr: false,
 		},
 		{
@@ -55,7 +55,7 @@ func Test_getPackageURL(t *testing.T) {
 				db:      "core",
 				pkgName: "linux",
 			},
-			want:    "https://git.archlinux.org/svntogit/packages.git/plain/trunk/PKGBUILD?h=packages%2Flinux",
+			want:    "https://github.com/archlinux/svntogit-packages.git/plain/trunk/PKGBUILD?h=packages%2Flinux",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
The ABS repo is no longer found at git.archlinux.org but (to my knowledge) only on github. See #1541. This patches makes `yay -G` work again for me.