### PR TITLE
fix: skip --assume-installed packages

### DIFF
--- a/install.go
+++ b/install.go
@@ -68,6 +68,7 @@ func install(cmdArgs *settings.Arguments, dbExecutor db.Executor, ignoreProvider
 	var srcinfos map[string]*gosrc.Srcinfo
 	noDeps := cmdArgs.ExistsDouble("d", "nodeps")
 	noCheck := strings.Contains(config.MFlags, "--nocheck")
+	assumeInstalled := cmdArgs.GetArgs("assume-installed")
 	sysupgradeArg := cmdArgs.ExistsArg("u", "sysupgrade")
 	refreshArg := cmdArgs.ExistsArg("y", "refresh")
 	warnings := query.NewWarnings()
@@ -141,7 +142,7 @@ func install(cmdArgs *settings.Arguments, dbExecutor db.Executor, ignoreProvider
 
 	dp, err := dep.GetPool(requestTargets,
 		warnings, dbExecutor, config.Runtime.AURClient, config.Runtime.Mode,
-		ignoreProviders, settings.NoConfirm, config.Provides, config.ReBuild, config.RequestSplitN, noDeps, noCheck)
+		ignoreProviders, settings.NoConfirm, config.Provides, config.ReBuild, config.RequestSplitN, noDeps, noCheck, assumeInstalled)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes #1137 by skipping yay's dependency checks for packages provided as parameter of `--assume-installed`.

[pacman(8) documentation](https://www.archlinux.org/pacman/pacman.8.html#_transaction_options_apply_to_em_s_em_em_r_em_and_em_u_em):

> --assume-installed <package=version>
> Add a virtual package "package" with version "version" to the transaction to satisfy dependencies. This allows to disable specific dependency checks without affecting all dependency checks.

Not sure if there are other checks that need to be skipped. Let me know if I missed something.

One thing to note is that one still needs to edit [PKGBUILD files](https://wiki.archlinux.org/title/PKGBUILD#Dependencies) to remove/skip dependencies afaik.