### PR TITLE
Update yay.8 to supress troff warning

### DIFF
--- a/doc/yay.8
+++ b/doc/yay.8
@@ -1,4 +1,3 @@
-'\ t
 .TH "YAY" "8" "2019\-10\-21" "Yay v9.4+" "Yay Manual"
 .nh
 .ad l


### PR DESCRIPTION
When running `man yay > /dev/null`, the system reports 
```
troff: <standard input>:1: name expected (got '\ '): treated as missing
```
The culprit appears to be the first line in the yay.8 file. This PR fixes this problem.
