### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -102,7 +101,7 @@ func cleanAUR(ctx context.Context, keepInstalled, keepCurrent, removeAll bool, d
 
 	remotePackages, _ := query.GetRemotePackages(dbExecutor)
 
-	files, err := ioutil.ReadDir(config.BuildDir)
+	files, err := os.ReadDir(config.BuildDir)
 	if err != nil {
 		return err
 	}
@@ -167,7 +166,7 @@ func cleanAUR(ctx context.Context, keepInstalled, keepCurrent, removeAll bool, d
 func cleanUntracked(ctx context.Context) error {
 	fmt.Println(gotext.Get("removing untracked AUR files from cache..."))
 
-	files, err := ioutil.ReadDir(config.BuildDir)
+	files, err := os.ReadDir(config.BuildDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/download/abs.go
+++ b/pkg/download/abs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/leonelquinteros/gotext"
@@ -75,7 +75,7 @@ func ABSPKGBUILD(httpClient httpRequestDoer, dbName, pkgName string) ([]byte, er
 
 	defer resp.Body.Close()
 
-	pkgBuild, err := ioutil.ReadAll(resp.Body)
+	pkgBuild, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/download/abs_test.go
+++ b/pkg/download/abs_test.go
@@ -3,7 +3,6 @@ package download
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -220,7 +219,7 @@ func TestABSPKGBUILDRepo(t *testing.T) {
 // THEN a pull command should be formed
 func TestABSPKGBUILDRepoExistsPerms(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	os.MkdirAll(filepath.Join(dir, "linux", ".git"), 0o777)

--- a/pkg/download/aur.go
+++ b/pkg/download/aur.go
@@ -3,7 +3,7 @@ package download
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -31,7 +31,7 @@ func AURPKGBUILD(httpClient httpRequestDoer, pkgName, aurURL string) ([]byte, er
 
 	defer resp.Body.Close()
 
-	pkgBuild, err := ioutil.ReadAll(resp.Body)
+	pkgBuild, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/download/aur_test.go
+++ b/pkg/download/aur_test.go
@@ -3,7 +3,6 @@ package download
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -99,7 +98,7 @@ func TestAURPKGBUILDRepo(t *testing.T) {
 // THEN a pull command should be formed
 func TestAURPKGBUILDRepoExistsPerms(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	os.MkdirAll(filepath.Join(dir, "yay-bin", ".git"), 0o777)
@@ -122,7 +121,7 @@ func TestAURPKGBUILDRepoExistsPerms(t *testing.T) {
 
 func TestAURPKGBUILDRepos(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	os.MkdirAll(filepath.Join(dir, "yay-bin", ".git"), 0o777)

--- a/pkg/download/unified_test.go
+++ b/pkg/download/unified_test.go
@@ -2,7 +2,6 @@ package download
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -21,7 +20,7 @@ import (
 // THEN all should be found and cloned, except the repo one
 func TestPKGBUILDReposDefinedDBPull(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	os.MkdirAll(filepath.Join(dir, "yay", ".git"), 0o777)
@@ -53,7 +52,7 @@ func TestPKGBUILDReposDefinedDBPull(t *testing.T) {
 // THEN all should be found and cloned
 func TestPKGBUILDReposDefinedDBClone(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	targets := []string{"core/yay", "yay-bin", "yay-git"}
@@ -83,7 +82,7 @@ func TestPKGBUILDReposDefinedDBClone(t *testing.T) {
 // THEN all should be found and cloned
 func TestPKGBUILDReposClone(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	targets := []string{"yay", "yay-bin", "yay-git"}
@@ -113,7 +112,7 @@ func TestPKGBUILDReposClone(t *testing.T) {
 // THEN all aur be found and cloned
 func TestPKGBUILDReposNotFound(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	targets := []string{"extra/yay", "yay-bin", "yay-git"}
@@ -143,7 +142,7 @@ func TestPKGBUILDReposNotFound(t *testing.T) {
 // THEN only repo should be cloned
 func TestPKGBUILDReposRepoMode(t *testing.T) {
 	t.Parallel()
-	dir, _ := ioutil.TempDir("/tmp/", "yay-test")
+	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
 	defer os.RemoveAll(dir)
 
 	targets := []string{"yay", "yay-bin", "yay-git"}

--- a/pkg/news/news.go
+++ b/pkg/news/news.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -74,7 +74,7 @@ func PrintNewsFeed(ctx context.Context, client *http.Client, cutOffDate time.Tim
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/news/news_test.go
+++ b/pkg/news/news_test.go
@@ -2,7 +2,7 @@ package news
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -119,7 +119,7 @@ func TestPrintNewsFeed(t *testing.T) {
 			assert.NoError(t, err)
 
 			w.Close()
-			out, _ := ioutil.ReadAll(r)
+			out, _ := io.ReadAll(r)
 			cupaloy.SnapshotT(t, out)
 			os.Stdout = rescueStdout
 		})

--- a/pkg/pgp/keys_test.go
+++ b/pkg/pgp/keys_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -48,7 +48,7 @@ func newPkg(basename string) *aur.Pkg {
 func getPgpKey(key string) string {
 	var buffer bytes.Buffer
 
-	if contents, err := ioutil.ReadFile(path.Join("testdata", key)); err == nil {
+	if contents, err := os.ReadFile(path.Join("testdata", key)); err == nil {
 		buffer.WriteString("-----BEGIN PGP PUBLIC KEY BLOCK-----\n")
 		buffer.WriteString("Version: SKS 1.1.6\n")
 		buffer.WriteString("Comment: Hostname: yay\n\n")
@@ -71,7 +71,7 @@ func startPgpKeyServer() *http.Server {
 }
 
 func TestImportKeys(t *testing.T) {
-	keyringDir, err := ioutil.TempDir("/tmp", "yay-test-keyring")
+	keyringDir, err := os.MkdirTemp("/tmp", "yay-test-keyring")
 	if err != nil {
 		t.Fatalf("Unable to init test keyring %q: %v\n", keyringDir, err)
 	}
@@ -150,7 +150,7 @@ func makeSrcinfo(pkgbase string, pgpkeys ...string) *gosrc.Srcinfo {
 }
 
 func TestCheckPgpKeys(t *testing.T) {
-	keyringDir, err := ioutil.TempDir("/tmp", "yay-test-keyring")
+	keyringDir, err := os.MkdirTemp("/tmp", "yay-test-keyring")
 	if err != nil {
 		t.Fatalf("Unable to init test keyring: %v\n", err)
 	}
@@ -255,7 +255,7 @@ func TestCheckPgpKeys(t *testing.T) {
 				}
 
 				w.Close()
-				out, _ := ioutil.ReadAll(r)
+				out, _ := io.ReadAll(r)
 				os.Stdout = rescueStdout
 
 				splitLines := strings.Split(string(out), "\n")

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sync"
@@ -262,7 +261,7 @@ func TestInfoStore_Update(t *testing.T) {
 		},
 	}
 
-	file, err := ioutil.TempFile("/tmp", "yay-vcs-test")
+	file, err := os.CreateTemp("/tmp", "yay-vcs-test")
 	assert.NoError(t, err)
 	defer os.Remove(file.Name())
 
@@ -326,7 +325,7 @@ func TestInfoStore_Remove(t *testing.T) {
 		},
 	}
 
-	file, err := ioutil.TempFile("/tmp", "yay-vcs-test")
+	file, err := os.CreateTemp("/tmp", "yay-vcs-test")
 	assert.NoError(t, err)
 	defer os.Remove(file.Name())
 


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.