### PR TITLE
test(build-dir): add regression tests for non-existing build dir

### DIFF
--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -227,18 +227,18 @@ func NewConfig(version string) (*Configuration, error) {
 	configPath := getConfigPath()
 	newConfig.load(configPath)
 
+	if aurdest := os.Getenv("AURDEST"); aurdest != "" {
+		newConfig.BuildDir = aurdest
+	}
+
+	newConfig.expandEnv()
+
 	if newConfig.BuildDir != systemdCache {
 		errBuildDir := initDir(newConfig.BuildDir)
 		if errBuildDir != nil {
 			return nil, errBuildDir
 		}
 	}
-
-	if aurdest := os.Getenv("AURDEST"); aurdest != "" {
-		newConfig.BuildDir = aurdest
-	}
-
-	newConfig.expandEnv()
 
 	if errPE := newConfig.setPrivilegeElevator(); errPE != nil {
 		return nil, errPE

--- a/pkg/settings/config_test.go
+++ b/pkg/settings/config_test.go
@@ -1,12 +1,82 @@
 package settings
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// GIVEN a non existing build dir in the config
+// WHEN the config is loaded
+// THEN the directory should be created
+func TestNewConfig(t *testing.T) {
+	configDir, err := os.MkdirTemp(os.TempDir(), "yay-config-home")
+	assert.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(configDir, "yay"), 0o755)
+	assert.NoError(t, err)
+
+	os.Setenv("XDG_CONFIG_HOME", configDir)
+
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "yay-cache-home")
+	assert.NoError(t, err)
+
+	config := map[string]string{"BuildDir": filepath.Join(cacheDir, "test-build-dir")}
+
+	f, err := os.Create(filepath.Join(configDir, "yay", "config.json"))
+	assert.NoError(t, err)
+
+	defer f.Close()
+
+	configJSON, _ := json.Marshal(config)
+	_, err = f.WriteString(string(configJSON))
+	assert.NoError(t, err)
+
+	newConfig, err := NewConfig("v1.0.0")
+	assert.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(cacheDir, "test-build-dir"), newConfig.BuildDir)
+
+	_, err = os.Stat(filepath.Join(cacheDir, "test-build-dir"))
+	assert.NoError(t, err)
+}
+
+// GIVEN a non existing build dir in the config and AURDEST set to a non-existing folder
+// WHEN the config is loaded
+// THEN the directory of AURDEST should be created and selected
+func TestNewConfigAURDEST(t *testing.T) {
+	configDir, err := os.MkdirTemp(os.TempDir(), "yay-config-home")
+	assert.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(configDir, "yay"), 0o755)
+	assert.NoError(t, err)
+
+	os.Setenv("XDG_CONFIG_HOME", configDir)
+
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "yay-cache-home")
+	assert.NoError(t, err)
+
+	config := map[string]string{"BuildDir": filepath.Join(cacheDir, "test-other-dir")}
+	os.Setenv("AURDEST", filepath.Join(cacheDir, "test-build-dir"))
+
+	f, err := os.Create(filepath.Join(configDir, "yay", "config.json"))
+	assert.NoError(t, err)
+
+	defer f.Close()
+
+	configJSON, _ := json.Marshal(config)
+	_, err = f.WriteString(string(configJSON))
+	assert.NoError(t, err)
+
+	newConfig, err := NewConfig("v1.0.0")
+	assert.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(cacheDir, "test-build-dir"), newConfig.BuildDir)
+
+	_, err = os.Stat(filepath.Join(cacheDir, "test-build-dir"))
+	assert.NoError(t, err)
+}
 
 // GIVEN default config
 // WHEN setPrivilegeElevator gets called

--- a/pkg/settings/dirs_test.go
+++ b/pkg/settings/dirs_test.go
@@ -1,0 +1,24 @@
+package settings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// GIVEN no user directories and sudo user
+// WHEN cache home is selected
+// THEN the selected cache home should be in the tmp dir
+func Test_getCacheHome(t *testing.T) {
+	dir, err := os.MkdirTemp(os.TempDir(), "yay-cache-home")
+	assert.NoError(t, err)
+	os.Unsetenv("XDG_CACHE_HOME")
+	os.Unsetenv("HOME")
+	os.Setenv("SUDO_USER", "test")
+	os.Setenv("TMPDIR", dir)
+	got, err := getCacheHome()
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "yay"), got)
+}


### PR DESCRIPTION
Fix #1612 and pay attention to AURDEST case and environment expansion