### PR TITLE
feat(search): add optional setting that formats each search result on a single line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,9 @@ All code should be formatted through `go fmt`. This tool will automatically
 format code for you. We recommend, however, that you write code in the proper
 style and use `go fmt` only to catch mistakes.
 
+`make lint` will check your code against `go fmt`. You may need to install
+[`golangci-lint`] as a dependency.
+
 Use [pre-commit](https://pre-commit.com/) to validate your commits against the various
 linters configured for this repository.
 
@@ -77,3 +80,5 @@ linters configured for this repository.
 
 Run `make test` to test Yay. This command will verify that the code is
 formatted correctly, run the code through `go vet`, and run unit tests.
+
+[`golangci-lint`]: https://github.com/golangci/golangci-lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,9 +70,6 @@ All code should be formatted through `go fmt`. This tool will automatically
 format code for you. We recommend, however, that you write code in the proper
 style and use `go fmt` only to catch mistakes.
 
-`make lint` will check your code against `go fmt`. You may need to install
-[`golangci-lint`] as a dependency.
-
 Use [pre-commit](https://pre-commit.com/) to validate your commits against the various
 linters configured for this repository.
 
@@ -80,5 +77,3 @@ linters configured for this repository.
 
 Run `make test` to test Yay. This command will verify that the code is
 formatted correctly, run the code through `go vet`, and run unit tests.
-
-[`golangci-lint`]: https://github.com/golangci/golangci-lint

--- a/cmd.go
+++ b/cmd.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	alpm "github.com/Jguer/go-alpm/v2"
@@ -99,6 +100,8 @@ Permanent configuration options:
     --nocleanafter        Do not remove package sources after successful build
     --bottomup            Shows AUR's packages first and then repository's
     --topdown             Shows repository's packages first and then AUR's
+    --singlelineresults   List each search result on its own line
+    --doublelineresults   List each search result on two lines, like pacman
 
     --devel               Check development packages during sysupgrade
     --nodevel             Do not check development packages
@@ -119,8 +122,6 @@ Permanent configuration options:
     --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
     --batchinstall        Build multiple AUR packages then install them together
     --nobatchinstall      Build and install each AUR package one by one
-    --singlelineresults   List each search result on its own line
-    --doublelineresults   List each search result on two lines, like pacman
 
     --sudo                <file>  sudo command to use
     --sudoflags           <flags> Pass arguments to sudo
@@ -356,11 +357,11 @@ func handleRemove(ctx context.Context, cmdArgs *parser.Arguments, localCache *vc
 
 // NumberMenu presents a CLI for selecting packages to install.
 func displayNumberMenu(ctx context.Context, pkgS []string, dbExecutor db.Executor, cmdArgs *parser.Arguments) error {
-	queryBuilder := query.NewSourceQueryBuilder(config.SortMode, config.SortBy, config.Runtime.Mode, config.SearchBy)
+	queryBuilder := query.NewSourceQueryBuilder(config.SortMode, config.SortBy, config.Runtime.Mode, config.SearchBy, config.SingleLineResults)
 
 	queryBuilder.Execute(ctx, dbExecutor, config.Runtime.AURClient, pkgS)
 
-	if err := queryBuilder.Results(dbExecutor, query.NumberMenu); err != nil {
+	if err := queryBuilder.Results(os.Stdout, dbExecutor, query.NumberMenu); err != nil {
 		return err
 	}
 

--- a/cmd.go
+++ b/cmd.go
@@ -119,6 +119,8 @@ Permanent configuration options:
     --nocombinedupgrade   Perform the repo upgrade and AUR upgrade separately
     --batchinstall        Build multiple AUR packages then install them together
     --nobatchinstall      Build and install each AUR package one by one
+    --singlelineresults   List each search result on its own line
+    --doublelineresults   List each search result on two lines, like pacman
 
     --sudo                <file>  sudo command to use
     --sudoflags           <flags> Pass arguments to sudo

--- a/completions/bash
+++ b/completions/bash
@@ -70,13 +70,13 @@ _yay() {
   common=('arch cachedir color config confirm dbpath debug gpgdir help hookdir logfile
           noconfirm noprogressbar noscriptlet quiet root verbose
           makepkg pacman git gpg gpgflags config requestsplitn sudoloop nosudoloop
-          redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild
-          sortby answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
+          redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild sortby
+          singlelineresults doublelineresults answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
           noansweredit noanswerupgrade cleanmenu diffmenu editmenu upgrademenu cleanafter nocleanafter
           nocleanmenu nodiffmenu noupgrademenu provides noprovides pgpfetch nopgpfetch
           useask nouseask combinedupgrade nocombinedupgrade aur repo makepkgconf
           nomakepkgconf askremovemake removemake noremovemake completioninterval aururl
-          searchby batchinstall nobatchinstall singlelineresults doublelineresults'
+          searchby batchinstall nobatchinstall'
     'b d h q r v')
   yays=('clean gendb' 'c')
   show=('complete defaultconfig currentconfig stats news' 'c d g s w')

--- a/completions/bash
+++ b/completions/bash
@@ -76,7 +76,7 @@ _yay() {
           nocleanmenu nodiffmenu noupgrademenu provides noprovides pgpfetch nopgpfetch
           useask nouseask combinedupgrade nocombinedupgrade aur repo makepkgconf
           nomakepkgconf askremovemake removemake noremovemake completioninterval aururl
-          searchby batchinstall nobatchinstall'
+          searchby batchinstall nobatchinstall singlelineresults doublelineresults'
     'b d h q r v')
   yays=('clean gendb' 'c')
   show=('complete defaultconfig currentconfig stats news' 'c d g s w')

--- a/completions/fish
+++ b/completions/fish
@@ -237,6 +237,8 @@ complete -c $progname -n "not $noopt" -l combinedupgrade -d 'Refresh then perfor
 complete -c $progname -n "not $noopt" -l nocombinedupgrade -d 'Perform the repo upgrade and AUR upgrade separately' -f
 complete -c $progname -n "not $noopt" -l batchinstall -d 'Build multiple AUR packages then install them together' -f
 complete -c $progname -n "not $noopt" -l nobatchinstall -d 'Build and install each AUR package one by one' -f
+complete -c $progname -n "not $noopt" -l singlelineresults -d 'List each search result on its own line' -f
+complete -c $progname -n "not $noopt" -l doublelineresults -d 'List each search result on two lines, like pacman' -f
 complete -c $progname -n "not $noopt" -l rebuild -d 'Always build target packages' -f
 complete -c $progname -n "not $noopt" -l rebuildall -d 'Always build all AUR packages' -f
 complete -c $progname -n "not $noopt" -l rebuildtree -d 'Always build all AUR packages even if installed' -f

--- a/completions/fish
+++ b/completions/fish
@@ -218,6 +218,8 @@ complete -c $progname -n "not $noopt" -l removemake -d 'Remove make deps after i
 complete -c $progname -n "not $noopt" -l noremovemake -d 'Do not remove make deps after install' -f
 complete -c $progname -n "not $noopt" -l topdown -d 'Shows repository packages first and then aur' -f
 complete -c $progname -n "not $noopt" -l bottomup -d 'Shows aur packages first and then repository' -f
+complete -c $progname -n "not $noopt" -l singlelineresults -d 'List each search result on its own line' -f
+complete -c $progname -n "not $noopt" -l doublelineresults -d 'List each search result on two lines, like pacman' -f
 complete -c $progname -n "not $noopt" -l devel -d 'Check -git/-svn/-hg development version' -f
 complete -c $progname -n "not $noopt" -l nodevel -d 'Disable development version checking' -f
 complete -c $progname -n "not $noopt" -l cleanafter -d 'Clean package sources after successful build' -f
@@ -237,8 +239,6 @@ complete -c $progname -n "not $noopt" -l combinedupgrade -d 'Refresh then perfor
 complete -c $progname -n "not $noopt" -l nocombinedupgrade -d 'Perform the repo upgrade and AUR upgrade separately' -f
 complete -c $progname -n "not $noopt" -l batchinstall -d 'Build multiple AUR packages then install them together' -f
 complete -c $progname -n "not $noopt" -l nobatchinstall -d 'Build and install each AUR package one by one' -f
-complete -c $progname -n "not $noopt" -l singlelineresults -d 'List each search result on its own line' -f
-complete -c $progname -n "not $noopt" -l doublelineresults -d 'List each search result on two lines, like pacman' -f
 complete -c $progname -n "not $noopt" -l rebuild -d 'Always build target packages' -f
 complete -c $progname -n "not $noopt" -l rebuildall -d 'Always build all AUR packages' -f
 complete -c $progname -n "not $noopt" -l rebuildtree -d 'Always build all AUR packages even if installed' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -79,6 +79,8 @@ _pacman_opts_common=(
 
 	'--bottomup[Show AUR packages first]'
 	'--topdown[Show repository packages first]'
+	'--singlelineresults[List each search result on its own line]'
+	'--doublelineresults[List each search result on two lines, like pacman]'
 	'--devel[Check -git/-svn/-hg development version]'
 	'--nodevel[Disable development version checking]'
 	'--cleanafter[Clean package sources after successful build]'
@@ -108,8 +110,6 @@ _pacman_opts_common=(
 	'--sortby[Sort AUR results by a specific field during search]'
 	'--batchinstall[Build multiple AUR packages then install them together]'
 	'--nobatchinstall[Build and install each AUR package one by one]'
-	'--singlelineresults[List each search result on its own line]'
-	'--doublelineresults[List each search result on two lines, like pacman]'
 )
 
 # options for passing to _arguments: options for --upgrade commands

--- a/completions/zsh
+++ b/completions/zsh
@@ -108,6 +108,8 @@ _pacman_opts_common=(
 	'--sortby[Sort AUR results by a specific field during search]'
 	'--batchinstall[Build multiple AUR packages then install them together]'
 	'--nobatchinstall[Build and install each AUR package one by one]'
+	'--singlelineresults[List each search result on its own line]'
+	'--doublelineresults[List each search result on two lines, like pacman]'
 )
 
 # options for passing to _arguments: options for --upgrade commands

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -450,6 +450,16 @@ another package, install all the packages in the install queue.
 Always install AUR packages immediately after building them.
 
 .TP
+.B \-\-singlelineresults
+Override pacman's usual double-line search result format and list each result
+on its own line.
+
+.TP
+.B \-\-doublelineresults
+Follow pacman's double-line search result format and list each result using
+two lines.
+
+.TP
 .B \-\-rebuild
 Always build target packages even when a copy is available in cache.
 

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -336,6 +336,16 @@ Display repository packages first and then AUR packages.
 Show AUR packages first and then repository packages.
 
 .TP
+.B \-\-singlelineresults
+Override pacman's usual double-line search result format and list each result
+on its own line.
+
+.TP
+.B \-\-doublelineresults
+Follow pacman's double-line search result format and list each result using
+two lines.
+
+.TP
 .B \-\-devel
 During sysupgrade also check AUR development packages for updates. Currently
 only Git packages are supported.
@@ -448,16 +458,6 @@ another package, install all the packages in the install queue.
 .TP
 .B \-\-nobatchinstall
 Always install AUR packages immediately after building them.
-
-.TP
-.B \-\-singlelineresults
-Override pacman's usual double-line search result format and list each result
-on its own line.
-
-.TP
-.B \-\-doublelineresults
-Follow pacman's double-line search result format and list each result using
-two lines.
 
 .TP
 .B \-\-rebuild

--- a/go.sum
+++ b/go.sum
@@ -34,12 +34,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac h1:oN6lz7iLW/YC7un8pq+9bOLyXrprv2+DKfkJY+2LJJw=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/db/mock/executor.go
+++ b/pkg/db/mock/executor.go
@@ -1,0 +1,105 @@
+package mock
+
+import (
+	"time"
+
+	"github.com/Jguer/yay/v11/pkg/db"
+
+	"github.com/Jguer/go-alpm/v2"
+)
+
+type (
+	IPackage = alpm.IPackage
+	Depend   = alpm.Depend
+	Upgrade  = db.Upgrade
+)
+
+type DBExecutor struct{}
+
+func (t DBExecutor) AlpmArchitectures() ([]string, error) {
+	panic("implement me")
+}
+
+func (t DBExecutor) BiggestPackages() []IPackage {
+	panic("implement me")
+}
+
+func (t DBExecutor) Cleanup() {
+	panic("implement me")
+}
+
+func (t DBExecutor) IsCorrectVersionInstalled(s, s2 string) bool {
+	panic("implement me")
+}
+
+func (t DBExecutor) LastBuildTime() time.Time {
+	panic("implement me")
+}
+
+func (t DBExecutor) LocalPackage(s string) IPackage {
+	return nil
+}
+
+func (t DBExecutor) LocalPackages() []IPackage {
+	panic("implement me")
+}
+
+func (t DBExecutor) LocalSatisfierExists(s string) bool {
+	panic("implement me")
+}
+
+func (t DBExecutor) PackageConflicts(iPackage IPackage) []Depend {
+	panic("implement me")
+}
+
+func (t DBExecutor) PackageDepends(iPackage IPackage) []Depend {
+	panic("implement me")
+}
+
+func (t DBExecutor) PackageGroups(iPackage IPackage) []string {
+	return []string{}
+}
+
+func (t DBExecutor) PackageOptionalDepends(iPackage IPackage) []Depend {
+	panic("implement me")
+}
+
+func (t DBExecutor) PackageProvides(iPackage IPackage) []Depend {
+	panic("implement me")
+}
+
+func (t DBExecutor) PackagesFromGroup(s string) []IPackage {
+	panic("implement me")
+}
+
+func (t DBExecutor) RefreshHandle() error {
+	panic("implement me")
+}
+
+func (t DBExecutor) RepoUpgrades(b bool) ([]Upgrade, error) {
+	panic("implement me")
+}
+
+func (t DBExecutor) Repos() []string {
+	panic("implement me")
+}
+
+func (t DBExecutor) SatisfierFromDB(s, s2 string) IPackage {
+	panic("implement me")
+}
+
+func (t DBExecutor) SyncPackage(s string) IPackage {
+	panic("implement me")
+}
+
+func (t DBExecutor) SyncPackages(s ...string) []IPackage {
+	panic("implement me")
+}
+
+func (t DBExecutor) SyncSatisfier(s string) IPackage {
+	panic("implement me")
+}
+
+func (t DBExecutor) SyncSatisfierExists(s string) bool {
+	panic("implement me")
+}

--- a/pkg/db/mock/repo.go
+++ b/pkg/db/mock/repo.go
@@ -9,7 +9,7 @@ import (
 type Package struct {
 	PBase         string
 	PBuildDate    time.Time
-	PDB           alpm.IDB
+	PDB           *DB
 	PDescription  string
 	PISize        int64
 	PName         string
@@ -185,4 +185,17 @@ func (p *Package) SyncNewVersion(l alpm.IDBList) alpm.IPackage {
 
 func (p *Package) Type() string {
 	panic("not implemented") // TODO: Implement
+}
+
+type DB struct {
+	alpm.IDB
+	name string
+}
+
+func NewDB(name string) *DB {
+	return &DB{name: name}
+}
+
+func (d *DB) Name() string {
+	return d.name
 }

--- a/pkg/query/types.go
+++ b/pkg/query/types.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/Jguer/aur"
@@ -91,7 +92,14 @@ func getSearchBy(value string) aur.By {
 }
 
 // PrintSearch handles printing search results in a given format.
-func (q aurQuery) printSearch(start int, dbExecutor db.Executor, searchMode SearchVerbosity, sortMode int) {
+func (q aurQuery) printSearch(
+	w io.Writer,
+	start int,
+	dbExecutor db.Executor,
+	searchMode SearchVerbosity,
+	sortMode int,
+	singleLineResults bool,
+) {
 	for i := range q {
 		var toprint string
 
@@ -105,7 +113,7 @@ func (q aurQuery) printSearch(start int, dbExecutor db.Executor, searchMode Sear
 				text.Warnln(gotext.Get("invalid sort mode. Fix with yay -Y --bottomup --save"))
 			}
 		} else if searchMode == Minimal {
-			fmt.Println(q[i].Name)
+			_, _ = fmt.Fprintln(w, q[i].Name)
 			continue
 		}
 
@@ -130,13 +138,19 @@ func (q aurQuery) printSearch(start int, dbExecutor db.Executor, searchMode Sear
 			}
 		}
 
-		toprint += "\n    " + q[i].Description
-		fmt.Println(toprint)
+		if singleLineResults {
+			toprint += "\t"
+		} else {
+			toprint += "\n    "
+		}
+
+		toprint += q[i].Description
+		_, _ = fmt.Fprintln(w, toprint)
 	}
 }
 
 // PrintSearch receives a RepoSearch type and outputs pretty text.
-func (r repoQuery) printSearch(dbExecutor db.Executor, searchMode SearchVerbosity, sortMode int) {
+func (r repoQuery) printSearch(w io.Writer, dbExecutor db.Executor, searchMode SearchVerbosity, sortMode int, singleLineResults bool) {
 	for i, res := range r {
 		var toprint string
 
@@ -150,7 +164,7 @@ func (r repoQuery) printSearch(dbExecutor db.Executor, searchMode SearchVerbosit
 				text.Warnln(gotext.Get("invalid sort mode. Fix with yay -Y --bottomup --save"))
 			}
 		} else if searchMode == Minimal {
-			fmt.Println(res.Name())
+			_, _ = fmt.Fprintln(w, res.Name())
 			continue
 		}
 
@@ -172,7 +186,14 @@ func (r repoQuery) printSearch(dbExecutor db.Executor, searchMode SearchVerbosit
 			}
 		}
 
-		toprint += "\n    " + res.Description()
-		fmt.Println(toprint)
+		if singleLineResults {
+			toprint += "\t"
+		} else {
+			toprint += "\n    "
+		}
+
+		toprint += res.Description()
+
+		_, _ = fmt.Fprintln(w, toprint)
 	}
 }

--- a/pkg/query/types_test.go
+++ b/pkg/query/types_test.go
@@ -1,0 +1,251 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Jguer/yay/v11/pkg/db/mock"
+	"github.com/Jguer/yay/v11/pkg/text"
+
+	"github.com/Jguer/aur"
+)
+
+var (
+	pkgA = aur.Pkg{
+		Name:        "package-a",
+		Version:     "1.0.0",
+		Description: "Package A description",
+		Maintainer:  "Package A Maintainer",
+	}
+	pkgARepo = &mock.Package{
+		PName:        pkgA.Name,
+		PVersion:     pkgA.Version,
+		PDescription: pkgA.Description,
+		PSize:        1,
+		PISize:       1,
+		PDB:          mock.NewDB("dba"),
+	}
+
+	pkgB = aur.Pkg{
+		Name:        "package-b",
+		Version:     "1.0.0",
+		Description: "Package B description",
+		Maintainer:  "Package B Maintainer",
+	}
+	pkgBRepo = &mock.Package{
+		PName:        pkgB.Name,
+		PVersion:     pkgB.Version,
+		PDescription: pkgB.Description,
+		PSize:        1,
+		PISize:       1,
+		PDB:          mock.NewDB("dbb"),
+	}
+)
+
+func Test_aurQuery_printSearch(t *testing.T) {
+	type args struct {
+		searchMode        SearchVerbosity
+		singleLineResults bool
+	}
+	tests := []struct {
+		name     string
+		q        aurQuery
+		args     args
+		useColor bool
+		want     string
+	}{
+		{
+			name: "Minimal",
+			q:    aurQuery{pkgA, pkgB},
+			args: args{
+				searchMode: Minimal,
+			},
+			want: "package-a\npackage-b\n",
+		},
+		{
+			name: "DoubleLine, NumberMenu",
+			q:    aurQuery{pkgA, pkgB},
+			args: args{
+				searchMode:        NumberMenu,
+				singleLineResults: false,
+			},
+			want: "1 aur/package-a 1.0.0 (+0 0.00) \n    Package A description\n2 aur/package-b 1.0.0 (+0 0.00) \n    Package B description\n",
+		},
+		{
+			name: "SingleLine, NumberMenu",
+			q:    aurQuery{pkgA, pkgB},
+			args: args{
+				searchMode:        NumberMenu,
+				singleLineResults: true,
+			},
+			want: "1 aur/package-a 1.0.0 (+0 0.00) \tPackage A description\n2 aur/package-b 1.0.0 (+0 0.00) \tPackage B description\n",
+		},
+		{
+			name: "DoubleLine, Detailed",
+			q:    aurQuery{pkgA, pkgB},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: false,
+			},
+			want: "aur/package-a 1.0.0 (+0 0.00) \n    Package A description\naur/package-b 1.0.0 (+0 0.00) \n    Package B description\n",
+		},
+		{
+			name: "SingleLine, Detailed",
+			q:    aurQuery{pkgA, pkgB},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: true,
+			},
+			want: "aur/package-a 1.0.0 (+0 0.00) \tPackage A description\naur/package-b 1.0.0 (+0 0.00) \tPackage B description\n",
+		},
+		{
+			name: "DoubleLine, Detailed, With Color",
+			q:    aurQuery{pkgA, pkgB},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: false,
+			},
+			useColor: true,
+			want:     "\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\n    Package A description\n\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\n    Package B description\n",
+		},
+		{
+			name: "SingleLine, Detailed, With Color",
+			q:    aurQuery{pkgA, pkgB},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: true,
+			},
+			useColor: true,
+			want:     "\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\tPackage A description\n\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\tPackage B description\n",
+		},
+		{
+			name: "No packages",
+			q:    aurQuery{},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: true,
+			},
+			useColor: true,
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &strings.Builder{}
+			sortMode := 1
+			executor := mock.DBExecutor{}
+			text.UseColor = tt.useColor
+
+			// Fire
+			tt.q.printSearch(w, 1, executor, tt.args.searchMode, sortMode, tt.args.singleLineResults)
+
+			got := w.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_repoQuery_printSearch(t *testing.T) {
+	type args struct {
+		searchMode        SearchVerbosity
+		singleLineResults bool
+	}
+	tests := []struct {
+		name     string
+		q        repoQuery
+		args     args
+		useColor bool
+		want     string
+	}{
+		{
+			name: "Minimal",
+			q:    repoQuery{pkgARepo, pkgBRepo},
+			args: args{
+				searchMode: Minimal,
+			},
+			want: "package-a\npackage-b\n",
+		},
+		{
+			name: "DoubleLine, NumberMenu",
+			q:    repoQuery{pkgARepo, pkgBRepo},
+			args: args{
+				searchMode:        NumberMenu,
+				singleLineResults: false,
+			},
+			want: "1 dba/package-a 1.0.0 (1.0 B 1.0 B) \n    Package A description\n2 dbb/package-b 1.0.0 (1.0 B 1.0 B) \n    Package B description\n",
+		},
+		{
+			name: "SingleLine, NumberMenu",
+			q:    repoQuery{pkgARepo, pkgBRepo},
+			args: args{
+				searchMode:        NumberMenu,
+				singleLineResults: true,
+			},
+			want: "1 dba/package-a 1.0.0 (1.0 B 1.0 B) \tPackage A description\n2 dbb/package-b 1.0.0 (1.0 B 1.0 B) \tPackage B description\n",
+		},
+		{
+			name: "DoubleLine, Detailed",
+			q:    repoQuery{pkgARepo, pkgBRepo},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: false,
+			},
+			want: "dba/package-a 1.0.0 (1.0 B 1.0 B) \n    Package A description\ndbb/package-b 1.0.0 (1.0 B 1.0 B) \n    Package B description\n",
+		},
+		{
+			name: "SingleLine, Detailed",
+			q:    repoQuery{pkgARepo, pkgBRepo},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: true,
+			},
+			want: "dba/package-a 1.0.0 (1.0 B 1.0 B) \tPackage A description\ndbb/package-b 1.0.0 (1.0 B 1.0 B) \tPackage B description\n",
+		},
+		{
+			name: "DoubleLine, Detailed, With Color",
+			q:    repoQuery{pkgARepo, pkgBRepo},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: false,
+			},
+			useColor: true,
+			want:     "\x1b[1m\x1b[35mdba\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\n    Package A description\n\x1b[1m\x1b[36mdbb\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\n    Package B description\n",
+		},
+		{
+			name: "SingleLine, Detailed, With Color",
+			q:    repoQuery{pkgARepo, pkgBRepo},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: true,
+			},
+			useColor: true,
+			want:     "\x1b[1m\x1b[35mdba\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\tPackage A description\n\x1b[1m\x1b[36mdbb\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\tPackage B description\n",
+		},
+		{
+			name: "No packages",
+			q:    repoQuery{},
+			args: args{
+				searchMode:        Detailed,
+				singleLineResults: true,
+			},
+			useColor: true,
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &strings.Builder{}
+			sortMode := 1
+			executor := mock.DBExecutor{}
+			text.UseColor = tt.useColor
+
+			// Fire
+			tt.q.printSearch(w, executor, tt.args.searchMode, sortMode, tt.args.singleLineResults)
+
+			got := w.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/query/types_test.go
+++ b/pkg/query/types_test.go
@@ -57,7 +57,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "Minimal",
+			name: "AUR,Minimal,NoColor",
 			q:    aurQuery{pkgA, pkgB},
 			args: args{
 				searchMode: Minimal,
@@ -65,7 +65,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 			want: "package-a\npackage-b\n",
 		},
 		{
-			name: "DoubleLine, NumberMenu",
+			name: "AUR,DoubleLine,NumberMenu,NoColor",
 			q:    aurQuery{pkgA, pkgB},
 			args: args{
 				searchMode:        NumberMenu,
@@ -74,7 +74,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 			want: "1 aur/package-a 1.0.0 (+0 0.00) \n    Package A description\n2 aur/package-b 1.0.0 (+0 0.00) \n    Package B description\n",
 		},
 		{
-			name: "SingleLine, NumberMenu",
+			name: "AUR,SingleLine,NumberMenu,NoColor",
 			q:    aurQuery{pkgA, pkgB},
 			args: args{
 				searchMode:        NumberMenu,
@@ -83,7 +83,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 			want: "1 aur/package-a 1.0.0 (+0 0.00) \tPackage A description\n2 aur/package-b 1.0.0 (+0 0.00) \tPackage B description\n",
 		},
 		{
-			name: "DoubleLine, Detailed",
+			name: "AUR,DoubleLine,Detailed,NoColor",
 			q:    aurQuery{pkgA, pkgB},
 			args: args{
 				searchMode:        Detailed,
@@ -92,7 +92,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 			want: "aur/package-a 1.0.0 (+0 0.00) \n    Package A description\naur/package-b 1.0.0 (+0 0.00) \n    Package B description\n",
 		},
 		{
-			name: "SingleLine, Detailed",
+			name: "AUR,SingleLine,Detailed,NoColor",
 			q:    aurQuery{pkgA, pkgB},
 			args: args{
 				searchMode:        Detailed,
@@ -101,7 +101,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 			want: "aur/package-a 1.0.0 (+0 0.00) \tPackage A description\naur/package-b 1.0.0 (+0 0.00) \tPackage B description\n",
 		},
 		{
-			name: "DoubleLine, Detailed, With Color",
+			name: "AUR,DoubleLine,Detailed,Color",
 			q:    aurQuery{pkgA, pkgB},
 			args: args{
 				searchMode:        Detailed,
@@ -111,7 +111,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 			want:     "\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\n    Package A description\n\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\n    Package B description\n",
 		},
 		{
-			name: "SingleLine, Detailed, With Color",
+			name: "AUR,SingleLine,Detailed,Color",
 			q:    aurQuery{pkgA, pkgB},
 			args: args{
 				searchMode:        Detailed,
@@ -121,7 +121,7 @@ func Test_aurQuery_printSearch(t *testing.T) {
 			want:     "\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\tPackage A description\n\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (+0\x1b[0m \x1b[1m0.00) \x1b[0m\tPackage B description\n",
 		},
 		{
-			name: "No packages",
+			name: "AUR,NoPackages",
 			q:    aurQuery{},
 			args: args{
 				searchMode:        Detailed,
@@ -160,7 +160,7 @@ func Test_repoQuery_printSearch(t *testing.T) {
 		want     string
 	}{
 		{
-			name: "Minimal",
+			name: "REPO,Minimal,NoColor",
 			q:    repoQuery{pkgARepo, pkgBRepo},
 			args: args{
 				searchMode: Minimal,
@@ -168,7 +168,7 @@ func Test_repoQuery_printSearch(t *testing.T) {
 			want: "package-a\npackage-b\n",
 		},
 		{
-			name: "DoubleLine, NumberMenu",
+			name: "REPO,DoubleLine,NumberMenu,NoColor",
 			q:    repoQuery{pkgARepo, pkgBRepo},
 			args: args{
 				searchMode:        NumberMenu,
@@ -177,7 +177,7 @@ func Test_repoQuery_printSearch(t *testing.T) {
 			want: "1 dba/package-a 1.0.0 (1.0 B 1.0 B) \n    Package A description\n2 dbb/package-b 1.0.0 (1.0 B 1.0 B) \n    Package B description\n",
 		},
 		{
-			name: "SingleLine, NumberMenu",
+			name: "REPO,SingleLine,NumberMenu,NoColor",
 			q:    repoQuery{pkgARepo, pkgBRepo},
 			args: args{
 				searchMode:        NumberMenu,
@@ -186,7 +186,7 @@ func Test_repoQuery_printSearch(t *testing.T) {
 			want: "1 dba/package-a 1.0.0 (1.0 B 1.0 B) \tPackage A description\n2 dbb/package-b 1.0.0 (1.0 B 1.0 B) \tPackage B description\n",
 		},
 		{
-			name: "DoubleLine, Detailed",
+			name: "REPO,DoubleLine,Detailed,NoColor",
 			q:    repoQuery{pkgARepo, pkgBRepo},
 			args: args{
 				searchMode:        Detailed,
@@ -195,7 +195,7 @@ func Test_repoQuery_printSearch(t *testing.T) {
 			want: "dba/package-a 1.0.0 (1.0 B 1.0 B) \n    Package A description\ndbb/package-b 1.0.0 (1.0 B 1.0 B) \n    Package B description\n",
 		},
 		{
-			name: "SingleLine, Detailed",
+			name: "REPO,SingleLine,Detailed,NoColor",
 			q:    repoQuery{pkgARepo, pkgBRepo},
 			args: args{
 				searchMode:        Detailed,
@@ -204,27 +204,27 @@ func Test_repoQuery_printSearch(t *testing.T) {
 			want: "dba/package-a 1.0.0 (1.0 B 1.0 B) \tPackage A description\ndbb/package-b 1.0.0 (1.0 B 1.0 B) \tPackage B description\n",
 		},
 		{
-			name: "DoubleLine, Detailed, With Color",
+			name: "AUR,DoubleLine,Detailed,Color",
 			q:    repoQuery{pkgARepo, pkgBRepo},
 			args: args{
 				searchMode:        Detailed,
 				singleLineResults: false,
 			},
 			useColor: true,
-			want:     "\x1b[1m\x1b[35mdba\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\n    Package A description\n\x1b[1m\x1b[36mdbb\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\n    Package B description\n",
+			want:     "\x1b[1m\x1b[35mdba\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    Package A description\n\x1b[1m\x1b[36mdbb\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    Package B description\n",
 		},
 		{
-			name: "SingleLine, Detailed, With Color",
+			name: "REPO,SingleLine,Detailed,Color",
 			q:    repoQuery{pkgARepo, pkgBRepo},
 			args: args{
 				searchMode:        Detailed,
 				singleLineResults: true,
 			},
 			useColor: true,
-			want:     "\x1b[1m\x1b[35mdba\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\tPackage A description\n\x1b[1m\x1b[36mdbb\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m \x1b[1m(1.0 B\x1b[0m \x1b[1m1.0 B) \x1b[0m\tPackage B description\n",
+			want:     "\x1b[1m\x1b[35mdba\x1b[0m\x1b[0m/\x1b[1mpackage-a\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\tPackage A description\n\x1b[1m\x1b[36mdbb\x1b[0m\x1b[0m/\x1b[1mpackage-b\x1b[0m \x1b[36m1.0.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\tPackage B description\n",
 		},
 		{
-			name: "No packages",
+			name: "REPO,NoPackages",
 			q:    repoQuery{},
 			args: args{
 				searchMode:        Detailed,

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -179,6 +179,10 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.RemoveMake = "no"
 	case "askremovemake":
 		c.RemoveMake = "ask"
+	case "singlelineresults":
+		c.SingleLineResults = true
+	case "doublelineresults":
+		c.SingleLineResults = false
 	default:
 		return false
 	}

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -53,6 +53,10 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.SortMode = TopDown
 	case "bottomup":
 		c.SortMode = BottomUp
+	case "singlelineresults":
+		c.SingleLineResults = true
+	case "doublelineresults":
+		c.SingleLineResults = false
 	case "completioninterval":
 		n, err := strconv.Atoi(value)
 		if err == nil {
@@ -179,10 +183,6 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.RemoveMake = "no"
 	case "askremovemake":
 		c.RemoveMake = "ask"
-	case "singlelineresults":
-		c.SingleLineResults = true
-	case "doublelineresults":
-		c.SingleLineResults = false
 	default:
 		return false
 	}

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -75,6 +75,7 @@ type Configuration struct {
 	CombinedUpgrade    bool     `json:"combinedupgrade"`
 	UseAsk             bool     `json:"useask"`
 	BatchInstall       bool     `json:"batchinstall"`
+	SingleLineResults  bool     `json:"singlelineresults"`
 	Runtime            *Runtime `json:"-"`
 }
 

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -444,6 +444,8 @@ func isArg(arg string) bool {
 	case "news":
 	case "gendb":
 	case "currentconfig":
+	case "singlelineresults":
+	case "doublelineresults":
 	default:
 		return false
 	}

--- a/query.go
+++ b/query.go
@@ -18,7 +18,7 @@ import (
 
 // SyncSearch presents a query to the local repos and to the AUR.
 func syncSearch(ctx context.Context, pkgS []string, aurClient *aur.Client, dbExecutor db.Executor, verbose bool) error {
-	queryBuilder := query.NewSourceQueryBuilder(config.SortMode, config.SortBy, config.Runtime.Mode, config.SearchBy)
+	queryBuilder := query.NewSourceQueryBuilder(config.SortMode, config.SortBy, config.Runtime.Mode, config.SearchBy, config.SingleLineResults)
 
 	queryBuilder.Execute(ctx, dbExecutor, aurClient, pkgS)
 
@@ -27,7 +27,7 @@ func syncSearch(ctx context.Context, pkgS []string, aurClient *aur.Client, dbExe
 		searchMode = query.Detailed
 	}
 
-	return queryBuilder.Results(dbExecutor, searchMode)
+	return queryBuilder.Results(os.Stdout, dbExecutor, searchMode)
 }
 
 // SyncInfo serves as a pacman -Si for repo packages and AUR packages.


### PR DESCRIPTION
## Changes

I added two new options, `singlelineresults`, and `doublelineresults`, with `doublelineresults` being the default. If `singlelineresults` is passed, then each search result from calls to `yay -Ss cowsay` or `yay cowsay` are rendered on a single line. 

Also, I added a note to `CONTRIBUTING.md` that mentions that `make lint` can be used to check the code against `go fmt`.

## Issues

- https://github.com/Jguer/yay/issues/1515
- https://github.com/Jguer/yay/issues/1587

## Broken unit tests

These unit tests were failing on `next` and are still failing after my change:

- `github.com/Jguer/yay/v11/pkg/news`
  - `TestPrintNewsFeed/all-verbose`
  - `TestPrintNewsFeed/all-quiet`
  - `TestPrintNewsFeed/latest-quiet`
  - `TestPrintNewsFeed/latest-quiet-topdown`

## Side note

Just for reference, this Stack Exchange post (in addition to Issue #1515) details the path I was taking to install a workaround:

https://unix.stackexchange.com/questions/675344/piping-the-output-of-an-interactive-shell-script

Also, if you wanted to go totally crazy with this, you could pretty easily align the columns, but I figured a tab would suffice.