### PR TITLE
Add config option to disable package installation

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -318,6 +318,12 @@ func handleYogurt(ctx context.Context, cmdArgs *parser.Arguments, dbExecutor db.
 func handleSync(ctx context.Context, cmdArgs *parser.Arguments, dbExecutor db.Executor) error {
 	targets := cmdArgs.Targets
 
+	if config.DisableInstall {
+		if !cmdArgs.ExistsArg("s", "search") {
+			return fmt.Errorf(gotext.Get("installing packages is disabled"))
+		}
+	}
+
 	switch {
 	case cmdArgs.ExistsArg("s", "search"):
 		return syncSearch(ctx, targets, config.Runtime.AURClient, dbExecutor, !cmdArgs.ExistsArg("q", "quiet"))

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -68,6 +68,7 @@ type Configuration struct {
 	EditMenu           bool     `json:"editmenu"`
 	CombinedUpgrade    bool     `json:"combinedupgrade"`
 	UseAsk             bool     `json:"useask"`
+	DisableInstall     bool     `json:"disableinstall"`
 	BatchInstall       bool     `json:"batchinstall"`
 	SingleLineResults  bool     `json:"singlelineresults"`
 	Runtime            *Runtime `json:"-"`
@@ -192,6 +193,7 @@ func DefaultConfig() *Configuration {
 		RequestSplitN:      150,
 		ReDownload:         "no",
 		ReBuild:            "no",
+		DisableInstall:     false,
 		BatchInstall:       false,
 		AnswerClean:        "",
 		AnswerDiff:         "",

--- a/po/de.po
+++ b/po/de.po
@@ -31,7 +31,7 @@ msgstr "(Ziel"
 msgid " (Wanted by: "
 msgstr "(Angefordert von:"
 
-#: install.go:81
+#: cmd.go:323
 msgid "installing packages is disabled"
 msgstr "Das Installieren von Paketen ist deaktiviert"
 

--- a/po/de.po
+++ b/po/de.po
@@ -31,6 +31,10 @@ msgstr "(Ziel"
 msgid " (Wanted by: "
 msgstr "(Angefordert von:"
 
+#: install.go:81
+msgid "installing packages is disabled"
+msgstr "Das Installieren von Paketen ist deaktiviert"
+
 #: cmd.go:424
 msgid " [Installed]"
 msgstr "[Installiert]"

--- a/po/en.po
+++ b/po/en.po
@@ -23,6 +23,10 @@ msgstr ""
 msgid " (Wanted by: "
 msgstr ""
 
+#: cmd.go:323
+msgid "installing packages is disabled"
+msgstr ""
+
 #: cmd.go:424
 msgid " [Installed]"
 msgstr ""


### PR DESCRIPTION
I was surprised this didn't already exist, so I decided to add it myself. I never actually looked into the yay source and haven't written a single like of Go ever, so forgive me if I have no clue what I'm doing.

The only sync flag that's allowed is `-s`, because I still like to use it for searching instead of visiting the AUR website. 