### PR TITLE
add --quiet to systemd-run

### DIFF
--- a/pkg/download/abs_test.go
+++ b/pkg/download/abs_test.go
@@ -206,7 +206,7 @@ func TestABSPKGBUILDRepo(t *testing.T) {
 		if path, _ := exec.LookPath(ld); path != "" {
 			ld = path
 		}
-		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C /tmp/doesnt-exist clone --no-progress --single-branch -b packages/linux https://github.com/archlinux/svntogit-packages.git linux", ld)
+		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty --quiet -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C /tmp/doesnt-exist clone --no-progress --single-branch -b packages/linux https://github.com/archlinux/svntogit-packages.git linux", ld)
 	}
 
 	cmdBuilder := &testGitBuilder{
@@ -240,7 +240,7 @@ func TestABSPKGBUILDRepoExistsPerms(t *testing.T) {
 		if path, _ := exec.LookPath(ld); path != "" {
 			ld = path
 		}
-		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C %s/linux pull --rebase --autostash", ld, dir)
+		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty --quiet -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C %s/linux pull --rebase --autostash", ld, dir)
 	}
 
 	cmdRunner := &testRunner{}

--- a/pkg/download/aur_test.go
+++ b/pkg/download/aur_test.go
@@ -84,7 +84,7 @@ func TestAURPKGBUILDRepo(t *testing.T) {
 		if path, _ := exec.LookPath(ld); path != "" {
 			ld = path
 		}
-		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C /tmp/doesnt-exist clone --no-progress https://aur.archlinux.org/yay-bin.git yay-bin", ld)
+		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty --quiet -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C /tmp/doesnt-exist clone --no-progress https://aur.archlinux.org/yay-bin.git yay-bin", ld)
 	}
 
 	cmdRunner := &testRunner{}
@@ -119,7 +119,7 @@ func TestAURPKGBUILDRepoExistsPerms(t *testing.T) {
 		if path, _ := exec.LookPath(ld); path != "" {
 			ld = path
 		}
-		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C %s/yay-bin pull --rebase --autostash", ld, dir)
+		want = fmt.Sprintf("%s --service-type=oneshot --pipe --wait --pty --quiet -p DynamicUser=yes -p CacheDirectory=yay -E HOME=/tmp  --no-replace-objects -C %s/yay-bin pull --rebase --autostash", ld, dir)
 	}
 
 	cmdRunner := &testRunner{}

--- a/pkg/settings/exe/cmd_builder.go
+++ b/pkg/settings/exe/cmd_builder.go
@@ -123,7 +123,7 @@ func (c *CmdBuilder) deElevateCommand(ctx context.Context, cmd *exec.Cmd) *exec.
 
 	cmdArgs := []string{
 		"--service-type=oneshot",
-		"--pipe", "--wait", "--pty",
+		"--pipe", "--wait", "--pty", "--quiet",
 		"-p", "DynamicUser=yes",
 		"-p", "CacheDirectory=yay",
 		"-E", "HOME=/tmp",


### PR DESCRIPTION
this will avoid the `Press ^] three times within 1s to disconnect TTY.` message.

it's mentioned in the systemd-run man page too:
```
--quiet, -q
    Suppresses additional informational output while running. This is particularly useful in combination with --pty when it will suppress the
    initial message explaining how to terminate the TTY connection.
```