### PR TITLE
Fixed end of php use on AUR API

### DIFF
--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -27,7 +27,7 @@ func (c *Configuration) extractYayOptions(a *parser.Arguments) {
 		}
 	}
 
-	c.Runtime.AURClient.BaseURL = strings.TrimRight(c.AURURL, "/") + "/rpc.php?"
+	c.Runtime.AURClient.BaseURL = strings.TrimRight(c.AURURL, "/") + "/rpc?"
 	c.AURURL = strings.TrimRight(c.AURURL, "/")
 }
 

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -27,7 +27,7 @@ func (c *Configuration) extractYayOptions(a *parser.Arguments) {
 		}
 	}
 
-	c.Runtime.AURClient.BaseURL = strings.TrimRight(c.AURURL, "/") + "/rpc/?"
+	c.Runtime.AURClient.BaseURL = strings.TrimRight(c.AURURL, "/") + "/rpc?"
 	c.AURURL = strings.TrimRight(c.AURURL, "/")
 }
 

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -27,7 +27,7 @@ func (c *Configuration) extractYayOptions(a *parser.Arguments) {
 		}
 	}
 
-	c.Runtime.AURClient.BaseURL = strings.TrimRight(c.AURURL, "/") + "/rpc?"
+	c.Runtime.AURClient.BaseURL = strings.TrimRight(c.AURURL, "/") + "/rpc/?"
 	c.AURURL = strings.TrimRight(c.AURURL, "/")
 }
 


### PR DESCRIPTION
This PR is related to #1682, #1684 and others. Fixing the changed AUR API endpoint who no longer use PHP and thus breaking yay -S.