### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/download/abs_test.go
+++ b/pkg/download/abs_test.go
@@ -229,8 +229,7 @@ func TestABSPKGBUILDRepo(t *testing.T) {
 // THEN a pull command should be formed
 func TestABSPKGBUILDRepoExistsPerms(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(dir, "linux", ".git"), 0o777)
 

--- a/pkg/download/aur_test.go
+++ b/pkg/download/aur_test.go
@@ -108,8 +108,7 @@ func TestAURPKGBUILDRepo(t *testing.T) {
 // THEN a pull command should be formed
 func TestAURPKGBUILDRepoExistsPerms(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(dir, "yay-bin", ".git"), 0o777)
 
@@ -140,8 +139,7 @@ func TestAURPKGBUILDRepoExistsPerms(t *testing.T) {
 
 func TestAURPKGBUILDRepos(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(dir, "yay-bin", ".git"), 0o777)
 

--- a/pkg/download/unified_test.go
+++ b/pkg/download/unified_test.go
@@ -20,8 +20,7 @@ import (
 // THEN all should be found and cloned, except the repo one
 func TestPKGBUILDReposDefinedDBPull(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(dir, "yay", ".git"), 0o777)
 
@@ -52,8 +51,7 @@ func TestPKGBUILDReposDefinedDBPull(t *testing.T) {
 // THEN all should be found and cloned
 func TestPKGBUILDReposDefinedDBClone(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	targets := []string{"core/yay", "yay-bin", "yay-git"}
 	cmdRunner := &testRunner{}
@@ -82,8 +80,7 @@ func TestPKGBUILDReposDefinedDBClone(t *testing.T) {
 // THEN all should be found and cloned
 func TestPKGBUILDReposClone(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	targets := []string{"yay", "yay-bin", "yay-git"}
 	cmdRunner := &testRunner{}
@@ -112,8 +109,7 @@ func TestPKGBUILDReposClone(t *testing.T) {
 // THEN all aur be found and cloned
 func TestPKGBUILDReposNotFound(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	targets := []string{"extra/yay", "yay-bin", "yay-git"}
 	cmdRunner := &testRunner{}
@@ -142,8 +138,7 @@ func TestPKGBUILDReposNotFound(t *testing.T) {
 // THEN only repo should be cloned
 func TestPKGBUILDReposRepoMode(t *testing.T) {
 	t.Parallel()
-	dir, _ := os.MkdirTemp("/tmp/", "yay-test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	targets := []string{"yay", "yay-bin", "yay-git"}
 	cmdRunner := &testRunner{}

--- a/pkg/pgp/keys_test.go
+++ b/pkg/pgp/keys_test.go
@@ -71,11 +71,7 @@ func startPgpKeyServer() *http.Server {
 }
 
 func TestImportKeys(t *testing.T) {
-	keyringDir, err := os.MkdirTemp("/tmp", "yay-test-keyring")
-	if err != nil {
-		t.Fatalf("Unable to init test keyring %q: %v\n", keyringDir, err)
-	}
-	defer os.RemoveAll(keyringDir)
+	keyringDir := t.TempDir()
 
 	server := startPgpKeyServer()
 	defer func() {
@@ -150,11 +146,7 @@ func makeSrcinfo(pkgbase string, pgpkeys ...string) *gosrc.Srcinfo {
 }
 
 func TestCheckPgpKeys(t *testing.T) {
-	keyringDir, err := os.MkdirTemp("/tmp", "yay-test-keyring")
-	if err != nil {
-		t.Fatalf("Unable to init test keyring: %v\n", err)
-	}
-	defer os.RemoveAll(keyringDir)
+	keyringDir := t.TempDir()
 
 	server := startPgpKeyServer()
 	defer func() {

--- a/pkg/settings/config_test.go
+++ b/pkg/settings/config_test.go
@@ -14,15 +14,13 @@ import (
 // WHEN the config is loaded
 // THEN the directory should be created
 func TestNewConfig(t *testing.T) {
-	configDir, err := os.MkdirTemp(os.TempDir(), "yay-config-home")
-	assert.NoError(t, err)
-	err = os.MkdirAll(filepath.Join(configDir, "yay"), 0o755)
+	configDir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(configDir, "yay"), 0o755)
 	assert.NoError(t, err)
 
 	os.Setenv("XDG_CONFIG_HOME", configDir)
 
-	cacheDir, err := os.MkdirTemp(os.TempDir(), "yay-cache-home")
-	assert.NoError(t, err)
+	cacheDir := t.TempDir()
 
 	config := map[string]string{"BuildDir": filepath.Join(cacheDir, "test-build-dir")}
 
@@ -48,15 +46,13 @@ func TestNewConfig(t *testing.T) {
 // WHEN the config is loaded
 // THEN the directory of AURDEST should be created and selected
 func TestNewConfigAURDEST(t *testing.T) {
-	configDir, err := os.MkdirTemp(os.TempDir(), "yay-config-home")
-	assert.NoError(t, err)
-	err = os.MkdirAll(filepath.Join(configDir, "yay"), 0o755)
+	configDir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(configDir, "yay"), 0o755)
 	assert.NoError(t, err)
 
 	os.Setenv("XDG_CONFIG_HOME", configDir)
 
-	cacheDir, err := os.MkdirTemp(os.TempDir(), "yay-cache-home")
-	assert.NoError(t, err)
+	cacheDir := t.TempDir()
 
 	config := map[string]string{"BuildDir": filepath.Join(cacheDir, "test-other-dir")}
 	os.Setenv("AURDEST", filepath.Join(cacheDir, "test-build-dir"))
@@ -85,15 +81,12 @@ func TestNewConfigAURDEST(t *testing.T) {
 func TestConfiguration_setPrivilegeElevator(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 
-	path, err := os.MkdirTemp("", "yay-test")
-	assert.NoError(t, err)
+	path := t.TempDir()
 
 	doas := filepath.Join(path, "sudo")
-	_, err = os.Create(doas)
+	_, err := os.Create(doas)
 	os.Chmod(doas, 0o755)
 	assert.NoError(t, err)
-
-	defer os.RemoveAll(path)
 
 	config := DefaultConfig()
 	config.SudoLoop = true
@@ -116,15 +109,12 @@ func TestConfiguration_setPrivilegeElevator(t *testing.T) {
 func TestConfiguration_setPrivilegeElevator_su(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 
-	path, err := os.MkdirTemp("", "yay-test")
-	assert.NoError(t, err)
+	path := t.TempDir()
 
 	doas := filepath.Join(path, "su")
-	_, err = os.Create(doas)
+	_, err := os.Create(doas)
 	os.Chmod(doas, 0o755)
 	assert.NoError(t, err)
-
-	defer os.RemoveAll(path)
 
 	config := DefaultConfig()
 	config.SudoLoop = true
@@ -168,15 +158,12 @@ func TestConfiguration_setPrivilegeElevator_no_path(t *testing.T) {
 func TestConfiguration_setPrivilegeElevator_doas(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 
-	path, err := os.MkdirTemp("", "yay-test")
-	assert.NoError(t, err)
+	path := t.TempDir()
 
 	doas := filepath.Join(path, "doas")
-	_, err = os.Create(doas)
+	_, err := os.Create(doas)
 	os.Chmod(doas, 0o755)
 	assert.NoError(t, err)
-
-	defer os.RemoveAll(path)
 
 	config := DefaultConfig()
 	config.SudoLoop = true
@@ -198,15 +185,12 @@ func TestConfiguration_setPrivilegeElevator_doas(t *testing.T) {
 func TestConfiguration_setPrivilegeElevator_custom_script(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 
-	path, err := os.MkdirTemp("", "yay-test")
-	assert.NoError(t, err)
+	path := t.TempDir()
 
 	wrapper := filepath.Join(path, "custom-wrapper")
-	_, err = os.Create(wrapper)
+	_, err := os.Create(wrapper)
 	os.Chmod(wrapper, 0o755)
 	assert.NoError(t, err)
-
-	defer os.RemoveAll(path)
 
 	config := DefaultConfig()
 	config.SudoLoop = true
@@ -230,11 +214,10 @@ func TestConfiguration_setPrivilegeElevator_custom_script(t *testing.T) {
 func TestConfiguration_setPrivilegeElevator_pacman_auth_doas(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 
-	path, err := os.MkdirTemp("", "yay-test")
-	require.NoError(t, err)
+	path := t.TempDir()
 
 	doas := filepath.Join(path, "doas")
-	_, err = os.Create(doas)
+	_, err := os.Create(doas)
 	os.Chmod(doas, 0o755)
 	require.NoError(t, err)
 
@@ -242,8 +225,6 @@ func TestConfiguration_setPrivilegeElevator_pacman_auth_doas(t *testing.T) {
 	_, err = os.Create(sudo)
 	os.Chmod(sudo, 0o755)
 	require.NoError(t, err)
-
-	defer os.RemoveAll(path)
 
 	config := DefaultConfig()
 	config.SudoBin = "sudo"
@@ -267,11 +248,10 @@ func TestConfiguration_setPrivilegeElevator_pacman_auth_doas(t *testing.T) {
 func TestConfiguration_setPrivilegeElevator_pacman_auth_sudo(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 
-	path, err := os.MkdirTemp("", "yay-test")
-	require.NoError(t, err)
+	path := t.TempDir()
 
 	doas := filepath.Join(path, "doas")
-	_, err = os.Create(doas)
+	_, err := os.Create(doas)
 	os.Chmod(doas, 0o755)
 	require.NoError(t, err)
 
@@ -279,8 +259,6 @@ func TestConfiguration_setPrivilegeElevator_pacman_auth_sudo(t *testing.T) {
 	_, err = os.Create(sudo)
 	os.Chmod(sudo, 0o755)
 	require.NoError(t, err)
-
-	defer os.RemoveAll(path)
 
 	config := DefaultConfig()
 	config.SudoBin = "doas"

--- a/pkg/settings/dirs_test.go
+++ b/pkg/settings/dirs_test.go
@@ -12,8 +12,7 @@ import (
 // WHEN cache home is selected
 // THEN the selected cache home should be in the tmp dir
 func Test_getCacheHome(t *testing.T) {
-	dir, err := os.MkdirTemp(os.TempDir(), "yay-cache-home")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	os.Unsetenv("XDG_CACHE_HOME")
 	os.Unsetenv("HOME")
 	os.Setenv("SUDO_USER", "test")


### PR DESCRIPTION
A small testing enhancement here.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir