### PR TITLE
`go` package is not in the `base-devel` package group

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ If you are migrating from another AUR helper, you can simply install Yay with th
 The initial installation of Yay can be done by cloning the PKGBUILD and
 building with makepkg:
 
-Before you begin, make sure you have the `base-devel` package group installed.
+Before you begin, make sure you have the `base-devel` package group and the `go` package installed.
 
 ```sh
-pacman -S --needed git base-devel
+pacman -S --needed git base-devel go
 git clone https://aur.archlinux.org/yay.git
 cd yay
 makepkg -si

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ building with makepkg:
 Before you begin, make sure you have the `base-devel` package group and the `go` package installed.
 
 ```sh
-pacman -S --needed git base-devel go
+pacman -S --needed --asdeps git base-devel go
 git clone https://aur.archlinux.org/yay.git
 cd yay
 makepkg -si


### PR DESCRIPTION
A minor README update.
I tried to build `yay` on a fresh system from source using this README information and got this:
```
==> Missing dependencies:
  -> go>=1.17
```