### PR TITLE
docs: remove tuna aur config for China users

### DIFF
--- a/doc/yay.8
+++ b/doc/yay.8
@@ -146,8 +146,7 @@ file.
 
 .TP
 .B \-\-aururl
-Set an alternative AUR URL. This is mostly useful for users in China who wish
-to use https://aur.tuna.tsinghua.edu.cn/.
+Set an alternative AUR URL.
 
 .TP
 .B \-\-builddir <dir>


### PR DESCRIPTION
Tuna has removed the aur proxy service since 01Mar:

- https://mirrors.tuna.tsinghua.edu.cn/news/remove-aur/
- tuna/issues#1424
