### PR TITLE
Mutualize local sync install

### DIFF
--- a/pkg/menus/clean_menu.go
+++ b/pkg/menus/clean_menu.go
@@ -59,7 +59,7 @@ func CleanFn(ctx context.Context, config *settings.Configuration, w io.Writer, p
 		dir := pkgbuildDirsByBase[base]
 		text.OperationInfoln(gotext.Get("Deleting (%d/%d): %s", i+1, len(toClean), text.Cyan(dir)))
 
-		if err := config.Runtime.CmdBuilder.Show(config.Runtime.CmdBuilder.BuildGitCmd(ctx, dir, "reset", "--hard")); err != nil {
+		if err := config.Runtime.CmdBuilder.Show(config.Runtime.CmdBuilder.BuildGitCmd(ctx, dir, "reset", "--hard", "HEAD")); err != nil {
 			text.Warnln(gotext.Get("Unable to clean:"), dir)
 
 			return err

--- a/preparer.go
+++ b/preparer.go
@@ -58,7 +58,7 @@ func NewPreparer(dbExecutor db.Executor, cmdBuilder exe.ICmdBuilder, config *set
 }
 
 func (preper *Preparer) ShouldCleanAURDirs(pkgBuildDirs map[string]string) PostInstallHookFunc {
-	if !preper.config.CleanAfter {
+	if !preper.config.CleanAfter || len(pkgBuildDirs) == 0 {
 		return nil
 	}
 

--- a/sync.go
+++ b/sync.go
@@ -56,10 +56,9 @@ func syncInstall(ctx context.Context,
 }
 
 type OperationService struct {
-	ctx               context.Context
-	config            *settings.Configuration
-	dbExecutor        db.Executor
-	updateCompletions bool
+	ctx        context.Context
+	config     *settings.Configuration
+	dbExecutor db.Executor
 }
 
 func NewOperationService(ctx context.Context, config *settings.Configuration, dbExecutor db.Executor) *OperationService {


### PR DESCRIPTION
Gather Targets -> Operation [Prepare workspace, Install] 

Operation is common to both sync/AUR installs and local pkgbuild installs.

Avoid content added to one of the services not being called by one of the flows 