### PR TITLE
Fix legacy engine install issues

### DIFF
--- a/install.go
+++ b/install.go
@@ -199,9 +199,7 @@ func install(ctx context.Context, cmdArgs *parser.Arguments, dbExecutor db.Execu
 
 	for _, base := range do.Aur {
 		dir := filepath.Join(config.BuildDir, base.Pkgbase())
-		if isGitRepository(dir) {
-			pkgbuildDirs[base.Pkgbase()] = dir
-		}
+		pkgbuildDirs[base.Pkgbase()] = dir
 	}
 
 	if config.CleanAfter {

--- a/install.go
+++ b/install.go
@@ -784,8 +784,14 @@ func buildInstallPkgbuilds(
 		)
 
 		for _, pkg := range base {
+			if srcinfo == nil {
+				text.Errorln(gotext.Get("could not find srcinfo for: %s", pkg.Name))
+				break
+			}
+
 			wg.Add(1)
 
+			text.Debugln("checking vcs store for:", pkg.Name)
 			go config.Runtime.VCSStore.Update(ctx, pkg.Name, srcinfo.Source, &mux, &wg)
 		}
 


### PR DESCRIPTION
Fix #1838 

- Treat pkgdirs as the expected destination but don't test if it's already a git repository ( repo might not be downloaded yet)

Fix #1840 

- if the debug pkgarchive does not exist do not clear the slice of archives to install

Thanks @Matir for taking the time to debug these issues 