### PR TITLE
fix(clean): notify RemoveAll error when cleaning AUR

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -154,9 +154,10 @@ func cleanAUR(ctx context.Context, keepInstalled, keepCurrent, removeAll bool, d
 			}
 		}
 
-		err = os.RemoveAll(filepath.Join(config.BuildDir, file.Name()))
+		dir := filepath.Join(config.BuildDir, file.Name())
+		err = os.RemoveAll(dir)
 		if err != nil {
-			return nil
+			text.Warnln(gotext.Get("Unable to remove %s: %s", dir, err))
 		}
 	}
 


### PR DESCRIPTION
Otherwise if any hard-to-delete file lands in the AUR cache folder, running `yay -Scc` will appear to succeed to the user, but actually abort midway.

*Practical relevance*: Aside from the obvious ways to create a file you can't delete inside `.cache/yay`, if you build a Go package without passing the `-modcacherw` flag to `go build`, it creates files inside `.cache/yay` that can't be deleted with just a `os.RemoveAll()` call (or just using the `rm` shell command).  (See also the Go package guidelines: https://wiki.archlinux.org/title/Go_package_guidelines#Flags_and_build_options)

With this change, at least yay tells you that it can't delete the those files instead of failing without notice. For example:

```shell
$ # Let's create a hard-to-delete folder like Go
$ mkdir -p .cache/yay/annoying_folder/inner
$ chmod 555 .cache/yay/annoying_folder -R
$ rm -rf .cache/yay/annoying_folder
rm: cannot remove '.cache/yay/annoying_folder/inner': Permission denied
$ rm -rf .cache/yay/annoying_folder/inner/
rm: cannot remove '.cache/yay/annoying_folder/inner/': Permission denied
$ # -------------------------------
$ # Let's try to delete it with yay
$ yay -Scc --noconfirm

Cache directory: /var/cache/pacman/pkg/
:: Do you want to remove ALL files from cache? [y/N] 

Database directory: /var/lib/pacman/
:: Do you want to remove unused repositories? [Y/n] 
removing unused sync repositories...

Build directory: /home/sol/.cache/yay
removing AUR packages from cache...
 -> Unable to remove /home/sol/.cache/yay/annoying_folder: unlinkat /home/sol/.cache/yay/annoying_folder/inner: permission denied
$ # !!! Before this PR, the line above didn't appear and yay appeared to silently succeed!
```

Possibly related to #1758.