### PR TITLE
fix(cmd): pass install flags into pacman in yogurt mode

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -418,19 +418,20 @@ func displayNumberMenu(ctx context.Context, pkgS []string, dbExecutor db.Executo
 		return err
 	}
 
-	arguments := cmdArgs.CopyGlobal()
-	arguments.AddTarget(targets...)
+	// modify the arguments to pass for the install
+	cmdArgs.Op = "S"
+	cmdArgs.Targets = targets
 
-	if len(arguments.Targets) == 0 {
+	if len(cmdArgs.Targets) == 0 {
 		fmt.Println(gotext.Get(" there is nothing to do"))
 		return nil
 	}
 
 	if config.NewInstallEngine {
-		return syncInstall(ctx, config, arguments, dbExecutor)
+		return syncInstall(ctx, config, cmdArgs, dbExecutor)
 	}
 
-	return install(ctx, arguments, dbExecutor, true)
+	return install(ctx, cmdArgs, dbExecutor, true)
 }
 
 func syncList(ctx context.Context, httpClient *http.Client, cmdArgs *parser.Arguments, dbExecutor db.Executor) error {


### PR DESCRIPTION
Fixes #1560

Only global flags were being passed into the install operation. Instead, pass in all flags the user specifies and set the operation to install (`-S`).

Tested with both `repo` and `aur` packages in both regular mode and `newinstallengine` mode.

Let me know if you want me to create a test for this. I did not see any tests for any other functions in `cmd.go` which is why I did not add a test for this.