### PR TITLE
fix(pre-commit): update URL and versions in the pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 default_stages: [commit]
 
 repos:
-  - repo: git://github.com/dnephin/pre-commit-golang
-    rev: v0.3.5
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
     hooks:
       - id: go-fmt
       - id: go-imports
@@ -12,20 +12,20 @@ repos:
       - id: go-build
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1 # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.4 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0 # Use the ref you want to point at
+    rev: v4.4.0 # Use the ref you want to point at
     hooks:
       - id: trailing-whitespace
       - id: check-json
       - id: check-yaml
       - id: check-added-large-files
 
-  - repo: https://github.com/Woile/commitizen
-    rev: v2.17.6
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.38.0
     hooks:
       - id: commitizen
         stages: [commit-msg]


### PR DESCRIPTION
There was a dead link in the `pre-commit-golang` URL, which caused `pre-commit install` to fail. Also, `Woile/commitizen` redirects to `commitizen-tools/commitizen`, so change that URL as well. Last, update all the versions using `pre-commit autoupdate`. All hooks still pass.

This will make it easier for new contributors to use the pre-commit hooks when contributing.

Last, I noticed that the `news_test.go` unit test doesn't work in some timezones (e.g. it works in `Europe/Paris` but not in `America/Denver`). This causes the pre-commit hook to fail. Wanted to mention this in case other contributors from different timezones run into this issue (or this is an actual issue within the news code).