### PR TITLE
feat(search): add new bys and misc fixes

### DIFF
--- a/doc/yay.8
+++ b/doc/yay.8
@@ -239,7 +239,7 @@ cache to never be refreshed.
 Sort AUR results by a specific field during search.
 
 .TP
-.B \-\-searchby <name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends>
+.B \-\-searchby <name|name-desc|maintainer|depends|checkdepends|makedepends|optdepends|provides|conflicts|replaces|groups|keywords|comaintainers>
 Search for AUR packages by querying the specified field.
 
 .TP

--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -379,6 +379,7 @@ func (g *Grapher) addNodes(
 			if len(aurPkgs) > 1 {
 				chosen := provideMenu(g.w, depName, aurPkgs, g.noConfirm)
 				g.providerCache[depName] = chosen
+				pkg = *chosen
 			}
 
 			if err := graph.DependOn(pkg.Name, parentPkgName); err != nil {

--- a/pkg/query/types.go
+++ b/pkg/query/types.go
@@ -77,6 +77,8 @@ func getSearchBy(value string) aur.By {
 		return aur.Name
 	case "maintainer":
 		return aur.Maintainer
+	case "submitter":
+		return aur.Submitter
 	case "depends":
 		return aur.Depends
 	case "makedepends":
@@ -85,6 +87,18 @@ func getSearchBy(value string) aur.By {
 		return aur.OptDepends
 	case "checkdepends":
 		return aur.CheckDepends
+	case "provides":
+		return aur.Provides
+	case "conflicts":
+		return aur.Conflicts
+	case "replaces":
+		return aur.Replaces
+	case "groups":
+		return aur.Groups
+	case "keywords":
+		return aur.Keywords
+	case "comaintainers":
+		return aur.CoMaintainers
 	default:
 		return aur.NameDesc
 	}

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -350,6 +350,8 @@ func (c *Configuration) CmdBuilder(runner exe.Runner) exe.ICmdBuilder {
 	return &exe.CmdBuilder{
 		GitBin:           c.GitBin,
 		GitFlags:         strings.Fields(c.GitFlags),
+		GPGBin:           c.GpgBin,
+		GPGFlags:         strings.Fields(c.GpgFlags),
 		MakepkgFlags:     strings.Fields(c.MFlags),
 		MakepkgConfPath:  c.MakepkgConf,
 		MakepkgBin:       c.MakepkgBin,


### PR DESCRIPTION
Add support for the following searchby options:

`provides|conflicts|replaces|groups|keywords|comaintainers`

Fix 2 bugs related to recent changes:
- take gpg bin config from configuration
- fix the displayed provides option

