### PR TITLE
Ensure data is piped when using '-' argument

### DIFF
--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -610,6 +610,16 @@ func (a *Arguments) parseLongOption(arg, param string) (usedNext bool, err error
 }
 
 func (a *Arguments) parseStdin() error {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Ensure data is piped
+	if (fi.Mode() & os.ModeCharDevice) != 0 {
+		return errors.New(gotext.Get("argument '-' specified without input on stdin"))
+	}
+
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Split(bufio.ScanLines)
 


### PR DESCRIPTION
Fixes #1626.

Check to see if data was actually piped to yay, otherwise it will hang forever. This error will give users better feedback of how to use the `-` argument (it is also the same exact error pacman throws for invalid piped data).

Two tests were added. However, I didn't know how to add a test for the actual part that detects whether data was piped or not (which is essentially what this commit adds).