### PR TITLE
fix(build): fix issue where shell conditional output is passed to go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ MOFILES := $(POFILES:.po=.mo)
 FLAGS ?= -trimpath -mod=readonly -modcacherw
 EXTRA_FLAGS ?= -buildmode=pie
 LDFLAGS := -X "main.yayVersion=${VERSION}" -X "main.localePath=${SYSTEMLOCALEPATH}" -linkmode=external
-FLAGS += $(shell pacman -T 'pacman-git' && echo "-tags next")
+FLAGS += $(shell pacman -T 'pacman-git' >/dev/null 2>&1 && echo "-tags next")
 
 RELEASE_DIR := ${PKGNAME}_${VERSION}_${ARCH}
 PACKAGE := $(RELEASE_DIR).tar.gz


### PR DESCRIPTION
(cherry picked from commit 6744fa721f4737f695b40eac0571e3b4b1504b65)

Related to #1886 