### PR TITLE
Respect global arguments when removing make dependencies

### DIFF
--- a/install.go
+++ b/install.go
@@ -224,7 +224,7 @@ func install(ctx context.Context, cmdArgs *parser.Arguments, dbExecutor db.Execu
 		switch config.RemoveMake {
 		case "yes":
 			defer func() {
-				err = removeMake(ctx, config.Runtime.CmdBuilder, do.GetMake())
+				err = removeMake(ctx, config.Runtime.CmdBuilder, do.GetMake(), cmdArgs)
 			}()
 
 		case "no":
@@ -232,7 +232,7 @@ func install(ctx context.Context, cmdArgs *parser.Arguments, dbExecutor db.Execu
 		default:
 			if text.ContinueTask(os.Stdin, gotext.Get("Remove make dependencies after install?"), false, settings.NoConfirm) {
 				defer func() {
-					err = removeMake(ctx, config.Runtime.CmdBuilder, do.GetMake())
+					err = removeMake(ctx, config.Runtime.CmdBuilder, do.GetMake(), cmdArgs)
 				}()
 			}
 		}
@@ -383,8 +383,8 @@ func addUpgradeTargetsToArgs(ctx context.Context, dbExecutor db.Executor,
 	return requestTargets, nil
 }
 
-func removeMake(ctx context.Context, cmdBuilder exe.ICmdBuilder, makeDeps []string) error {
-	removeArguments := parser.MakeArguments()
+func removeMake(ctx context.Context, cmdBuilder exe.ICmdBuilder, makeDeps []string, cmdArgs *parser.Arguments) error {
+	removeArguments := cmdArgs.CopyGlobal()
 
 	err := removeArguments.AddArg("R", "u")
 	if err != nil {

--- a/preparer.go
+++ b/preparer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Jguer/yay/v11/pkg/menus"
 	"github.com/Jguer/yay/v11/pkg/settings"
 	"github.com/Jguer/yay/v11/pkg/settings/exe"
+	"github.com/Jguer/yay/v11/pkg/settings/parser"
 	"github.com/Jguer/yay/v11/pkg/text"
 
 	gosrc "github.com/Morganamilo/go-srcinfo"
@@ -70,7 +71,7 @@ func (preper *Preparer) ShouldCleanAURDirs(pkgBuildDirs map[string]string) PostI
 	}
 }
 
-func (preper *Preparer) ShouldCleanMakeDeps() PostInstallHookFunc {
+func (preper *Preparer) ShouldCleanMakeDeps(cmdArgs *parser.Arguments) PostInstallHookFunc {
 	if len(preper.makeDeps) == 0 {
 		return nil
 	}
@@ -89,7 +90,7 @@ func (preper *Preparer) ShouldCleanMakeDeps() PostInstallHookFunc {
 	text.Debugln("added post install hook to clean up AUR makedeps", preper.makeDeps)
 
 	return func(ctx context.Context) error {
-		return removeMake(ctx, preper.cfg.Runtime.CmdBuilder, preper.makeDeps)
+		return removeMake(ctx, preper.cfg.Runtime.CmdBuilder, preper.makeDeps, cmdArgs)
 	}
 }
 

--- a/sync.go
+++ b/sync.go
@@ -112,7 +112,7 @@ func (o *OperationService) Run(ctx context.Context,
 		return errInstall
 	}
 
-	cleanFunc := preparer.ShouldCleanMakeDeps()
+	cleanFunc := preparer.ShouldCleanMakeDeps(cmdArgs)
 	if cleanFunc != nil {
 		installer.AddPostInstallHook(cleanFunc)
 	}


### PR DESCRIPTION
Fixes #1869. 

Ensure all global arguments are used when calling `pacman` to remove make dependencies. 