### PR TITLE
refactor(runtime): Build runtime after cmdargs parsing

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -41,7 +41,7 @@ func cleanRemove(ctx context.Context, config *settings.Configuration, cmdArgs *p
 
 	return config.Runtime.CmdBuilder.Show(
 		config.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			arguments, config.Runtime.Mode, settings.NoConfirm))
+			arguments, config.Mode, settings.NoConfirm))
 }
 
 func syncClean(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser.Arguments, dbExecutor db.Executor) error {
@@ -58,14 +58,14 @@ func syncClean(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser
 		}
 	}
 
-	if cfg.Runtime.Mode.AtLeastRepo() {
+	if cfg.Mode.AtLeastRepo() {
 		if err := cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm)); err != nil {
+			cmdArgs, cfg.Mode, settings.NoConfirm)); err != nil {
 			return err
 		}
 	}
 
-	if !cfg.Runtime.Mode.AtLeastAUR() {
+	if !cfg.Mode.AtLeastAUR() {
 		return nil
 	}
 

--- a/cmd.go
+++ b/cmd.go
@@ -154,7 +154,7 @@ func handleCmd(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser
 		return handleHelp(ctx, cfg, cmdArgs)
 	}
 
-	if cfg.SudoLoop && cmdArgs.NeedRoot(cfg.Runtime.Mode) {
+	if cfg.SudoLoop && cmdArgs.NeedRoot(cfg.Mode) {
 		cfg.Runtime.CmdBuilder.SudoLoop()
 	}
 
@@ -165,10 +165,10 @@ func handleCmd(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser
 		return nil
 	case "D", "database":
 		return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+			cmdArgs, cfg.Mode, settings.NoConfirm))
 	case "F", "files":
 		return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+			cmdArgs, cfg.Mode, settings.NoConfirm))
 	case "Q", "query":
 		return handleQuery(ctx, cfg, cmdArgs, dbExecutor)
 	case "R", "remove":
@@ -177,7 +177,7 @@ func handleCmd(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser
 		return handleSync(ctx, cfg, cmdArgs, dbExecutor)
 	case "T", "deptest":
 		return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+			cmdArgs, cfg.Mode, settings.NoConfirm))
 	case "U", "upgrade":
 		return handleUpgrade(ctx, cfg, cmdArgs)
 	case "B", "build":
@@ -231,7 +231,7 @@ func handleQuery(ctx context.Context, cfg *settings.Configuration, cmdArgs *pars
 	}
 
 	if err := cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-		cmdArgs, cfg.Runtime.Mode, settings.NoConfirm)); err != nil {
+		cmdArgs, cfg.Mode, settings.NoConfirm)); err != nil {
 		if str := err.Error(); strings.Contains(str, "exit status") {
 			// yay -Qdt should not output anything in case of error
 			return fmt.Errorf("")
@@ -251,7 +251,7 @@ func handleHelp(ctx context.Context, cfg *settings.Configuration, cmdArgs *parse
 	}
 
 	return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-		cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+		cmdArgs, cfg.Mode, settings.NoConfirm))
 }
 
 func handleVersion() {
@@ -276,7 +276,7 @@ func handlePrint(ctx context.Context, cfg *settings.Configuration, cmdArgs *pars
 		return news.PrintNewsFeed(ctx, cfg.Runtime.HTTPClient, dbExecutor.LastBuildTime(), cfg.BottomUp, double, quiet)
 	case cmdArgs.ExistsArg("c", "complete"):
 		return completion.Show(ctx, cfg.Runtime.HTTPClient, dbExecutor,
-			cfg.AURURL, cfg.Runtime.CompletionPath, cfg.CompletionInterval, cmdArgs.ExistsDouble("c", "complete"))
+			cfg.AURURL, cfg.CompletionPath, cfg.CompletionInterval, cmdArgs.ExistsDouble("c", "complete"))
 	case cmdArgs.ExistsArg("s", "stats"):
 		return localStatistics(ctx, cfg, dbExecutor)
 	}
@@ -317,7 +317,7 @@ func handleWeb(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser
 func handleGetpkgbuild(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser.Arguments, dbExecutor download.DBSearcher) error {
 	if cmdArgs.ExistsArg("p", "print") {
 		return printPkgbuilds(dbExecutor, cfg.Runtime.AURCache,
-			cfg.Runtime.HTTPClient, cmdArgs.Targets, cfg.Runtime.Mode, cfg.AURURL)
+			cfg.Runtime.HTTPClient, cmdArgs.Targets, cfg.Mode, cfg.AURURL)
 	}
 
 	return getPkgbuilds(ctx, dbExecutor, cfg.Runtime.AURCache, cfg,
@@ -328,7 +328,7 @@ func handleUpgrade(ctx context.Context,
 	config *settings.Configuration, cmdArgs *parser.Arguments,
 ) error {
 	return config.Runtime.CmdBuilder.Show(config.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-		cmdArgs, config.Runtime.Mode, settings.NoConfirm))
+		cmdArgs, config.Mode, settings.NoConfirm))
 }
 
 // -B* options
@@ -350,14 +350,14 @@ func handleSync(ctx context.Context, cfg *settings.Configuration, cmdArgs *parse
 		return syncSearch(ctx, targets, dbExecutor, cfg.Runtime.QueryBuilder, !cmdArgs.ExistsArg("q", "quiet"))
 	case cmdArgs.ExistsArg("p", "print", "print-format"):
 		return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+			cmdArgs, cfg.Mode, settings.NoConfirm))
 	case cmdArgs.ExistsArg("c", "clean"):
 		return syncClean(ctx, cfg, cmdArgs, dbExecutor)
 	case cmdArgs.ExistsArg("l", "list"):
 		return syncList(ctx, cfg, cfg.Runtime.HTTPClient, cmdArgs, dbExecutor)
 	case cmdArgs.ExistsArg("g", "groups"):
 		return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+			cmdArgs, cfg.Mode, settings.NoConfirm))
 	case cmdArgs.ExistsArg("i", "info"):
 		return syncInfo(ctx, cfg, cmdArgs, targets, dbExecutor)
 	case cmdArgs.ExistsArg("u", "sysupgrade") || len(cmdArgs.Targets) > 0:
@@ -368,7 +368,7 @@ func handleSync(ctx context.Context, cfg *settings.Configuration, cmdArgs *parse
 		return install(ctx, cfg, cmdArgs, dbExecutor, false)
 	case cmdArgs.ExistsArg("y", "refresh"):
 		return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+			cmdArgs, cfg.Mode, settings.NoConfirm))
 	}
 
 	return nil
@@ -376,7 +376,7 @@ func handleSync(ctx context.Context, cfg *settings.Configuration, cmdArgs *parse
 
 func handleRemove(ctx context.Context, cfg *settings.Configuration, cmdArgs *parser.Arguments, localCache vcs.Store) error {
 	err := cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-		cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+		cmdArgs, cfg.Mode, settings.NoConfirm))
 	if err == nil {
 		localCache.RemovePackages(cmdArgs.Targets)
 	}
@@ -435,13 +435,13 @@ func syncList(ctx context.Context, cfg *settings.Configuration,
 	aur := false
 
 	for i := len(cmdArgs.Targets) - 1; i >= 0; i-- {
-		if cmdArgs.Targets[i] == "aur" && cfg.Runtime.Mode.AtLeastAUR() {
+		if cmdArgs.Targets[i] == "aur" && cfg.Mode.AtLeastAUR() {
 			cmdArgs.Targets = append(cmdArgs.Targets[:i], cmdArgs.Targets[i+1:]...)
 			aur = true
 		}
 	}
 
-	if cfg.Runtime.Mode.AtLeastAUR() && (len(cmdArgs.Targets) == 0 || aur) {
+	if cfg.Mode.AtLeastAUR() && (len(cmdArgs.Targets) == 0 || aur) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.AURURL+"/packages.gz", http.NoBody)
 		if err != nil {
 			return err
@@ -473,9 +473,9 @@ func syncList(ctx context.Context, cfg *settings.Configuration,
 		}
 	}
 
-	if cfg.Runtime.Mode.AtLeastRepo() && (len(cmdArgs.Targets) != 0 || !aur) {
+	if cfg.Mode.AtLeastRepo() && (len(cmdArgs.Targets) != 0 || !aur) {
 		return cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, cfg.Runtime.Mode, settings.NoConfirm))
+			cmdArgs, cfg.Mode, settings.NoConfirm))
 	}
 
 	return nil

--- a/get.go
+++ b/get.go
@@ -59,7 +59,7 @@ func getPkgbuilds(ctx context.Context, dbExecutor download.DBSearcher, aurClient
 	}
 
 	cloned, errD := download.PKGBUILDRepos(ctx, dbExecutor, aurClient,
-		config.Runtime.CmdBuilder, targets, config.Runtime.Mode, config.AURURL, wd, force)
+		config.Runtime.CmdBuilder, targets, config.Mode, config.AURURL, wd, force)
 	if errD != nil {
 		text.Errorln(errD)
 	}

--- a/pkg/cmd/graph/main.go
+++ b/pkg/cmd/graph/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 func handleCmd() error {
-	config, err := settings.NewConfig("")
+	config, err := settings.NewConfig(settings.GetConfigPath(), "")
 	if err != nil {
 		return err
 	}

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -29,19 +29,19 @@ func (c *Configuration) extractYayOptions(a *parser.Arguments) {
 	}
 
 	c.AURURL = strings.TrimRight(c.AURURL, "/")
-	c.Runtime.AURClient.BaseURL = c.AURURL + "/rpc?"
 
 	// if AurRPCURL is set, use that for /rpc calls
-	if c.AURRPCURL != "" {
-		if !strings.HasSuffix(c.AURRPCURL, "?") {
-			if strings.HasSuffix(c.AURRPCURL, "/rpc") {
-				c.AURRPCURL += "?"
-			} else {
-				c.AURRPCURL = strings.TrimRight(c.AURRPCURL, "/") + "/rpc?"
-			}
-		}
+	if c.AURRPCURL == "" {
+		c.AURRPCURL = c.AURURL + "/rpc?"
+		return
+	}
 
-		c.Runtime.AURClient.BaseURL = c.AURRPCURL
+	if !strings.HasSuffix(c.AURRPCURL, "?") {
+		if strings.HasSuffix(c.AURRPCURL, "/rpc") {
+			c.AURRPCURL += "?"
+		} else {
+			c.AURRPCURL = strings.TrimRight(c.AURRPCURL, "/") + "/rpc?"
+		}
 	}
 }
 
@@ -52,14 +52,13 @@ func (c *Configuration) handleOption(option, value string) bool {
 	case "aurrpcurl":
 		c.AURRPCURL = value
 	case "save":
-		c.Runtime.SaveConfig = true
+		c.SaveConfig = true
 	case "afterclean", "cleanafter":
 		c.CleanAfter = true
 	case "noafterclean", "nocleanafter":
 		c.CleanAfter = false
 	case "debug":
 		c.Debug = true
-		c.Runtime.Logger.Debug = true
 		text.GlobalLogger.Debug = true
 	case "devel":
 		c.Devel = true
@@ -194,9 +193,9 @@ func (c *Configuration) handleOption(option, value string) bool {
 	case "nocombinedupgrade":
 		c.CombinedUpgrade = false
 	case "a", "aur":
-		c.Runtime.Mode = parser.ModeAUR
+		c.Mode = parser.ModeAUR
 	case "repo":
-		c.Runtime.Mode = parser.ModeRepo
+		c.Mode = parser.ModeRepo
 	case "removemake":
 		c.RemoveMake = "yes"
 	case "noremovemake":

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -60,6 +60,7 @@ func (c *Configuration) handleOption(option, value string) bool {
 	case "debug":
 		c.Debug = true
 		text.GlobalLogger.Debug = true
+		return false
 	case "devel":
 		c.Devel = true
 	case "nodevel":

--- a/pkg/settings/config_test.go
+++ b/pkg/settings/config_test.go
@@ -33,7 +33,7 @@ func TestNewConfig(t *testing.T) {
 	_, err = f.WriteString(string(configJSON))
 	assert.NoError(t, err)
 
-	newConfig, err := NewConfig("v1.0.0")
+	newConfig, err := NewConfig(GetConfigPath(), "v1.0.0")
 	assert.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(cacheDir, "test-build-dir"), newConfig.BuildDir)
@@ -66,7 +66,7 @@ func TestNewConfigAURDEST(t *testing.T) {
 	_, err = f.WriteString(string(configJSON))
 	assert.NoError(t, err)
 
-	newConfig, err := NewConfig("v1.0.0")
+	newConfig, err := NewConfig(GetConfigPath(), "v1.0.0")
 	assert.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(cacheDir, "test-build-dir"), newConfig.BuildDir)
@@ -99,7 +99,7 @@ func TestNewConfigAURDESTTildeExpansion(t *testing.T) {
 	_, err = f.WriteString(string(configJSON))
 	assert.NoError(t, err)
 
-	newConfig, err := NewConfig("v1.0.0")
+	newConfig, err := NewConfig(GetConfigPath(), "v1.0.0")
 	assert.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(homeDir, "test-build-dir"), newConfig.BuildDir)

--- a/pkg/settings/dirs.go
+++ b/pkg/settings/dirs.go
@@ -12,7 +12,7 @@ const (
 	systemdCache       string = "/var/cache/yay" // systemd should handle cache creation
 )
 
-func getConfigPath() string {
+func GetConfigPath() string {
 	if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
 		configDir := filepath.Join(configHome, "yay")
 		if err := initDir(configDir); err == nil {

--- a/pkg/settings/migrations.go
+++ b/pkg/settings/migrations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Jguer/yay/v12/pkg/db"
+	"github.com/Jguer/yay/v12/pkg/text"
 
 	"github.com/leonelquinteros/gotext"
 )
@@ -44,13 +45,15 @@ func DefaultMigrations() []configMigration {
 	}
 }
 
-func (c *Configuration) RunMigrations(migrations []configMigration, configPath string) error {
+func (c *Configuration) RunMigrations(migrations []configMigration,
+	configPath, newVersion string,
+) error {
 	saveConfig := false
 
 	for _, migration := range migrations {
 		if db.VerCmp(migration.TargetVersion(), c.Version) > 0 {
 			if migration.Do(c) {
-				c.Runtime.Logger.Infoln("Config migration executed (",
+				text.Infoln("Config migration executed (",
 					migration.TargetVersion(), "):", migration)
 
 				saveConfig = true
@@ -59,7 +62,7 @@ func (c *Configuration) RunMigrations(migrations []configMigration, configPath s
 	}
 
 	if saveConfig {
-		return c.Save(configPath)
+		return c.Save(configPath, newVersion)
 	}
 
 	return nil

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -634,43 +634,43 @@ func (a *Arguments) Parse() error {
 	args := os.Args[1:]
 	usedNext := false
 
-	if len(args) < 1 {
-		if _, err := a.parseShortOption("-Syu", ""); err != nil {
-			return err
+	for k, arg := range args {
+		var nextArg string
+
+		if usedNext {
+			usedNext = false
+			continue
 		}
-	} else {
-		for k, arg := range args {
-			var nextArg string
 
-			if usedNext {
-				usedNext = false
-				continue
-			}
+		if k+1 < len(args) {
+			nextArg = args[k+1]
+		}
 
-			if k+1 < len(args) {
-				nextArg = args[k+1]
-			}
+		var err error
+		switch {
+		case a.ExistsArg("--"):
+			a.AddTarget(arg)
+		case strings.HasPrefix(arg, "--"):
+			usedNext, err = a.parseLongOption(arg, nextArg)
+		case strings.HasPrefix(arg, "-"):
+			usedNext, err = a.parseShortOption(arg, nextArg)
+		default:
+			a.AddTarget(arg)
+		}
 
-			var err error
-			switch {
-			case a.ExistsArg("--"):
-				a.AddTarget(arg)
-			case strings.HasPrefix(arg, "--"):
-				usedNext, err = a.parseLongOption(arg, nextArg)
-			case strings.HasPrefix(arg, "-"):
-				usedNext, err = a.parseShortOption(arg, nextArg)
-			default:
-				a.AddTarget(arg)
-			}
-
-			if err != nil {
-				return err
-			}
+		if err != nil {
+			return err
 		}
 	}
 
 	if a.Op == "" {
-		a.Op = "Y"
+		if len(a.Targets) > 0 {
+			a.Op = "Y"
+		} else {
+			if _, err := a.parseShortOption("-Syu", ""); err != nil {
+				return err
+			}
+		}
 	}
 
 	if a.ExistsArg("-") {

--- a/pkg/settings/runtime.go
+++ b/pkg/settings/runtime.go
@@ -1,7 +1,13 @@
 package settings
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/leonelquinteros/gotext"
 
 	"github.com/Jguer/yay/v12/pkg/db"
 	"github.com/Jguer/yay/v12/pkg/query"
@@ -11,25 +17,95 @@ import (
 	"github.com/Jguer/yay/v12/pkg/vcs"
 
 	"github.com/Jguer/aur"
+	"github.com/Jguer/aur/metadata"
 	"github.com/Jguer/aur/rpc"
 	"github.com/Jguer/votar/pkg/vote"
 	"github.com/Morganamilo/go-pacmanconf"
 )
 
 type Runtime struct {
-	Mode           parser.TargetMode
-	QueryBuilder   query.Builder
-	Version        string // current version of yay
-	SaveConfig     bool
-	CompletionPath string
-	ConfigPath     string
-	PacmanConf     *pacmanconf.Config
-	VCSStore       vcs.Store
-	CmdBuilder     exe.ICmdBuilder
-	HTTPClient     *http.Client
-	AURClient      *rpc.Client
-	VoteClient     *vote.Client
-	AURCache       aur.QueryClient
-	DBExecutor     db.Executor
-	Logger         *text.Logger
+	QueryBuilder query.Builder
+	PacmanConf   *pacmanconf.Config
+	VCSStore     vcs.Store
+	CmdBuilder   exe.ICmdBuilder
+	HTTPClient   *http.Client
+	AURClient    *rpc.Client
+	VoteClient   *vote.Client
+	AURCache     aur.QueryClient
+	DBExecutor   db.Executor
+	Logger       *text.Logger
+}
+
+func BuildRuntime(cfg *Configuration, cmdArgs *parser.Arguments, version string) (*Runtime, error) {
+	logger := text.NewLogger(os.Stdout, os.Stdin, cfg.Debug, "runtime")
+	cmdBuilder := cfg.CmdBuilder(nil)
+
+	httpClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	userAgent := fmt.Sprintf("Yay/%s", version)
+	voteClient, errVote := vote.NewClient(vote.WithUserAgent(userAgent),
+		vote.WithHTTPClient(httpClient))
+	if errVote != nil {
+		return nil, errVote
+	}
+
+	voteClient.SetCredentials(
+		os.Getenv("AUR_USERNAME"),
+		os.Getenv("AUR_PASSWORD"))
+
+	userAgentFn := func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("User-Agent", userAgent)
+		return nil
+	}
+
+	var aurCache aur.QueryClient
+	aurCache, errAURCache := metadata.New(
+		metadata.WithHTTPClient(httpClient),
+		metadata.WithCacheFilePath(filepath.Join(cfg.BuildDir, "aur.json")),
+		metadata.WithRequestEditorFn(userAgentFn),
+		metadata.WithBaseURL(cfg.AURURL),
+		metadata.WithDebugLogger(logger.Debugln),
+	)
+	if errAURCache != nil {
+		return nil, fmt.Errorf(gotext.Get("failed to retrieve aur Cache")+": %w", errAURCache)
+	}
+
+	aurClient, errAUR := rpc.NewClient(
+		rpc.WithHTTPClient(httpClient),
+		rpc.WithRequestEditorFn(userAgentFn),
+		rpc.WithLogFn(logger.Debugln))
+	if errAUR != nil {
+		return nil, errAUR
+	}
+
+	if cfg.UseRPC {
+		aurCache = aurClient
+	}
+
+	vcsStore := vcs.NewInfoStore(
+		cfg.VCSFilePath, cmdBuilder,
+		logger.Child("vcs"))
+
+	if err := vcsStore.Load(); err != nil {
+		return nil, err
+	}
+
+	runtime := &Runtime{
+		QueryBuilder: nil,
+		PacmanConf:   nil,
+		VCSStore:     vcsStore,
+		CmdBuilder:   cmdBuilder,
+		HTTPClient:   &http.Client{},
+		AURClient:    aurClient,
+		VoteClient:   voteClient,
+		AURCache:     aurCache,
+		DBExecutor:   nil,
+		Logger:       text.NewLogger(os.Stdout, os.Stdin, cfg.Debug, "runtime"),
+	}
+
+	return runtime, nil
 }

--- a/pkg/settings/runtime.go
+++ b/pkg/settings/runtime.go
@@ -76,6 +76,7 @@ func BuildRuntime(cfg *Configuration, cmdArgs *parser.Arguments, version string)
 
 	aurClient, errAUR := rpc.NewClient(
 		rpc.WithHTTPClient(httpClient),
+		rpc.WithBaseURL(cfg.AURRPCURL),
 		rpc.WithRequestEditorFn(userAgentFn),
 		rpc.WithLogFn(logger.Debugln))
 	if errAUR != nil {

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -61,7 +61,7 @@ func (u *UpgradeService) upGraph(ctx context.Context, graph *topo.Graph[string, 
 	remote := u.dbExecutor.InstalledRemotePackages()
 	remoteNames := u.dbExecutor.InstalledRemotePackageNames()
 
-	if u.runtime.Mode.AtLeastAUR() {
+	if u.cfg.Mode.AtLeastAUR() {
 		u.log.OperationInfoln(gotext.Get("Searching AUR for updates..."))
 
 		_aurdata, err := u.aurCache.Get(ctx, &aur.Query{Needles: remoteNames, By: aur.Name})
@@ -140,7 +140,7 @@ func (u *UpgradeService) upGraph(ctx context.Context, graph *topo.Graph[string, 
 		})
 	}
 
-	if u.cfg.Runtime.Mode.AtLeastRepo() {
+	if u.cfg.Mode.AtLeastRepo() {
 		u.log.OperationInfoln(gotext.Get("Searching databases for updates..."))
 
 		syncUpgrades, err := u.dbExecutor.SyncUpgrades(enableDowngrade)

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -24,14 +24,13 @@ type UpgradeService struct {
 	aurCache   aur.QueryClient
 	dbExecutor db.Executor
 	vcsStore   vcs.Store
-	runtime    *settings.Runtime
 	cfg        *settings.Configuration
 	log        *text.Logger
 	noConfirm  bool
 }
 
 func NewUpgradeService(grapher *dep.Grapher, aurCache aur.QueryClient,
-	dbExecutor db.Executor, vcsStore vcs.Store, runtime *settings.Runtime,
+	dbExecutor db.Executor, vcsStore vcs.Store,
 	cfg *settings.Configuration, noConfirm bool, logger *text.Logger,
 ) *UpgradeService {
 	return &UpgradeService{
@@ -39,7 +38,6 @@ func NewUpgradeService(grapher *dep.Grapher, aurCache aur.QueryClient,
 		aurCache:   aurCache,
 		dbExecutor: dbExecutor,
 		vcsStore:   vcsStore,
-		runtime:    runtime,
 		cfg:        cfg,
 		noConfirm:  noConfirm,
 		log:        logger,

--- a/pkg/upgrade/service_test.go
+++ b/pkg/upgrade/service_test.go
@@ -262,8 +262,7 @@ func TestUpgradeService_GraphUpgrades(t *testing.T) {
 					tt.fields.input, true, "test"))
 
 			cfg := &settings.Configuration{
-				Runtime: &settings.Runtime{},
-				Devel:   tt.fields.devel, Mode: parser.ModeAny,
+				Devel: tt.fields.devel, Mode: parser.ModeAny,
 			}
 
 			u := &UpgradeService{
@@ -273,7 +272,6 @@ func TestUpgradeService_GraphUpgrades(t *testing.T) {
 				aurCache:   mockAUR,
 				dbExecutor: dbExe,
 				vcsStore:   vcsStore,
-				runtime:    cfg.Runtime,
 				cfg:        cfg,
 				noConfirm:  tt.fields.noConfirm,
 			}
@@ -383,9 +381,8 @@ func TestUpgradeService_GraphUpgradesNoUpdates(t *testing.T) {
 					tt.fields.input, true, "test"))
 
 			cfg := &settings.Configuration{
-				Runtime: &settings.Runtime{},
-				Devel:   tt.fields.devel,
-				Mode:    parser.ModeAny,
+				Devel: tt.fields.devel,
+				Mode:  parser.ModeAny,
 			}
 
 			u := &UpgradeService{
@@ -395,7 +392,6 @@ func TestUpgradeService_GraphUpgradesNoUpdates(t *testing.T) {
 				aurCache:   mockAUR,
 				dbExecutor: dbExe,
 				vcsStore:   vcsStore,
-				runtime:    cfg.Runtime,
 				cfg:        cfg,
 				noConfirm:  tt.fields.noConfirm,
 			}

--- a/pkg/upgrade/service_test.go
+++ b/pkg/upgrade/service_test.go
@@ -262,8 +262,8 @@ func TestUpgradeService_GraphUpgrades(t *testing.T) {
 					tt.fields.input, true, "test"))
 
 			cfg := &settings.Configuration{
-				Runtime: &settings.Runtime{Mode: parser.ModeAny},
-				Devel:   tt.fields.devel,
+				Runtime: &settings.Runtime{},
+				Devel:   tt.fields.devel, Mode: parser.ModeAny,
 			}
 
 			u := &UpgradeService{
@@ -383,8 +383,9 @@ func TestUpgradeService_GraphUpgradesNoUpdates(t *testing.T) {
 					tt.fields.input, true, "test"))
 
 			cfg := &settings.Configuration{
-				Runtime: &settings.Runtime{Mode: parser.ModeAny},
+				Runtime: &settings.Runtime{},
 				Devel:   tt.fields.devel,
+				Mode:    parser.ModeAny,
 			}
 
 			u := &UpgradeService{

--- a/print.go
+++ b/print.go
@@ -114,7 +114,7 @@ func printUpdateList(ctx context.Context, cfg *settings.Configuration, cmdArgs *
 
 	upService := upgrade.NewUpgradeService(
 		grapher, cfg.Runtime.AURCache, dbExecutor, cfg.Runtime.VCSStore,
-		cfg.Runtime, cfg, settings.NoConfirm, logger.Child("upgrade"))
+		cfg, settings.NoConfirm, logger.Child("upgrade"))
 
 	graph, errSysUp := upService.GraphUpgrades(ctx, nil,
 		enableDowngrade, filter)

--- a/query.go
+++ b/query.go
@@ -42,7 +42,7 @@ func syncInfo(ctx context.Context, cfg *settings.Configuration,
 		missing = false
 	)
 
-	pkgS = query.RemoveInvalidTargets(pkgS, cfg.Runtime.Mode)
+	pkgS = query.RemoveInvalidTargets(pkgS, cfg.Mode)
 	aurS, repoS := packageSlices(pkgS, cfg, dbExecutor)
 
 	if len(aurS) != 0 {
@@ -68,7 +68,7 @@ func syncInfo(ctx context.Context, cfg *settings.Configuration,
 		arguments.AddTarget(repoS...)
 
 		err = cfg.Runtime.CmdBuilder.Show(cfg.Runtime.CmdBuilder.BuildPacmanCmd(ctx,
-			arguments, cfg.Runtime.Mode, settings.NoConfirm))
+			arguments, cfg.Mode, settings.NoConfirm))
 		if err != nil {
 			return err
 		}
@@ -96,10 +96,10 @@ func packageSlices(toCheck []string, config *settings.Configuration, dbExecutor 
 	for _, _pkg := range toCheck {
 		dbName, name := text.SplitDBFromName(_pkg)
 
-		if dbName == "aur" || config.Runtime.Mode == parser.ModeAUR {
+		if dbName == "aur" || config.Mode == parser.ModeAUR {
 			aurNames = append(aurNames, _pkg)
 			continue
-		} else if dbName != "" || config.Runtime.Mode == parser.ModeRepo {
+		} else if dbName != "" || config.Mode == parser.ModeRepo {
 			repoNames = append(repoNames, _pkg)
 			continue
 		}

--- a/sync.go
+++ b/sync.go
@@ -32,7 +32,7 @@ func syncInstall(ctx context.Context,
 		cfg.Runtime.CmdBuilder.AddMakepkgFlag("-d")
 	}
 
-	if refreshArg && cfg.Runtime.Mode.AtLeastRepo() {
+	if refreshArg && cfg.Mode.AtLeastRepo() {
 		if errR := earlyRefresh(ctx, cfg, cfg.Runtime.CmdBuilder, cmdArgs); errR != nil {
 			return fmt.Errorf("%s - %w", gotext.Get("error refreshing databases"), errR)
 		}
@@ -112,7 +112,7 @@ func (o *OperationService) Run(ctx context.Context,
 	}
 	preparer := NewPreparer(o.dbExecutor, o.cfg.Runtime.CmdBuilder, o.cfg)
 	installer := NewInstaller(o.dbExecutor, o.cfg.Runtime.CmdBuilder,
-		o.cfg.Runtime.VCSStore, o.cfg.Runtime.Mode,
+		o.cfg.Runtime.VCSStore, o.cfg.Mode,
 		cmdArgs.ExistsArg("w", "downloadonly"), o.cfg.Runtime.Logger.Child("installer"))
 
 	pkgBuildDirs, errInstall := preparer.Run(ctx, os.Stdout, targets)
@@ -131,7 +131,7 @@ func (o *OperationService) Run(ctx context.Context,
 
 	go func() {
 		errComp := completion.Update(ctx, o.cfg.Runtime.HTTPClient, o.dbExecutor,
-			o.cfg.AURURL, o.cfg.Runtime.CompletionPath, o.cfg.CompletionInterval, false)
+			o.cfg.AURURL, o.cfg.CompletionPath, o.cfg.CompletionInterval, false)
 		if errComp != nil {
 			text.Warnln(errComp)
 		}

--- a/sync.go
+++ b/sync.go
@@ -58,7 +58,7 @@ func syncInstall(ctx context.Context,
 
 		upService := upgrade.NewUpgradeService(
 			grapher, aurCache, dbExecutor, cfg.Runtime.VCSStore,
-			cfg.Runtime, cfg, settings.NoConfirm, cfg.Runtime.Logger.Child("upgrade"))
+			cfg, settings.NoConfirm, cfg.Runtime.Logger.Child("upgrade"))
 
 		graph, errSysUp = upService.GraphUpgrades(ctx,
 			graph, cmdArgs.ExistsDouble("u", "sysupgrade"),

--- a/upgrade.go
+++ b/upgrade.go
@@ -58,7 +58,7 @@ func upList(ctx context.Context, cfg *settings.Configuration,
 		}
 	}
 
-	if cfg.Runtime.Mode.AtLeastRepo() {
+	if cfg.Mode.AtLeastRepo() {
 		text.OperationInfoln(gotext.Get("Searching databases for updates..."))
 		wg.Add(1)
 
@@ -69,7 +69,7 @@ func upList(ctx context.Context, cfg *settings.Configuration,
 		}()
 	}
 
-	if cfg.Runtime.Mode.AtLeastAUR() {
+	if cfg.Mode.AtLeastAUR() {
 		text.OperationInfoln(gotext.Get("Searching AUR for updates..."))
 
 		var _aurdata []aur.Pkg


### PR DESCRIPTION
Build runtime after args are parsed so it can more easily take into account global modifiers