### PR TITLE
fix(aur_install): fix debug pacakges not being found

### DIFF
--- a/aur_install.go
+++ b/aur_install.go
@@ -342,12 +342,12 @@ func (installer *Installer) getNewTargets(pkgdests map[string]string, name strin
 
 	pkgArchives = append(pkgArchives, pkgdest)
 
-	debugName := pkgdest + "-debug"
+	debugName := name + "-debug"
 
 	pkgdestDebug, ok := pkgdests[debugName]
 	if ok {
 		if _, errStat := os.Stat(pkgdestDebug); errStat == nil {
-			pkgArchives = append(pkgArchives, debugName)
+			pkgArchives = append(pkgArchives, pkgdestDebug)
 		}
 	}
 


### PR DESCRIPTION
This PR fixes debug packages no longer being installed correctly.

The bug was a simple accidental swapping of package path and package name.