### PR TITLE
fix(vcs): add extra context to errors and increase timeouts

### DIFF
--- a/pkg/upgrade/sources.go
+++ b/pkg/upgrade/sources.go
@@ -22,7 +22,7 @@ func UpDevel(
 	toRemove := make([]string, 0)
 	toUpgrade := UpSlice{Up: make([]Upgrade, 0), Repos: []string{"devel"}}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctxTimeout, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	for pkgName, pkg := range remote {
 		if localCache.ToUpgrade(ctxTimeout, pkgName) {

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -82,7 +82,7 @@ func (v *InfoStore) getCommit(ctx context.Context, url, branch string, protocols
 	if len(protocols) > 0 {
 		protocol := protocols[len(protocols)-1]
 
-		ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctxTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
 		cmd := v.CmdBuilder.BuildGitCmd(ctxTimeout, "", "ls-remote", protocol+"://"+url, branch)

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -87,15 +87,15 @@ func (v *InfoStore) getCommit(ctx context.Context, url, branch string, protocols
 
 		cmd := v.CmdBuilder.BuildGitCmd(ctxTimeout, "", "ls-remote", protocol+"://"+url, branch)
 
-		stdout, _, err := v.CmdBuilder.Capture(cmd)
+		stdout, stderr, err := v.CmdBuilder.Capture(cmd)
 		if err != nil {
 			exitError := &exec.ExitError{}
 			if ok := errors.As(err, &exitError); ok && exitError.ExitCode() == 128 {
-				v.logger.Warnln(gotext.Get("devel check for package failed: '%s' encountered an error", cmd.String()))
+				v.logger.Warnln(gotext.Get("devel check for package failed: '%s' encountered an error", cmd.String()), ": ", stderr)
 				return ""
 			}
 
-			v.logger.Warnln(err)
+			v.logger.Warnln(gotext.Get("devel check for package failed: '%s' encountered an error", cmd.String()), ": ", err)
 
 			return ""
 		}


### PR DESCRIPTION
Timeout for checking a single package was 5s and for the whole checking of devel upgrades was also 5s. For sure causing issues on multiple devel packages or slow devices

Changed:
single package - 10s
full devel - 20s

Add more context for errors

Fixes https://github.com/Jguer/yay/issues/2036