### PR TITLE
fix(aur_install): fix debug packages being added to deps even if not found

### DIFF
--- a/aur_install.go
+++ b/aur_install.go
@@ -348,6 +348,8 @@ func (installer *Installer) getNewTargets(pkgdests map[string]string, name strin
 	if ok {
 		if _, errStat := os.Stat(pkgdestDebug); errStat == nil {
 			pkgArchives = append(pkgArchives, pkgdestDebug)
+		} else {
+			ok = false
 		}
 	}
 


### PR DESCRIPTION
This PR fixes another edge case with debug packages:

If debug packages are enabled (option `debug strip`), `makepkg --packagelist` will always list a -debug package as one of the built packages. However, `makepkg` will not always build one. If the package does not contain any files from which debug information can be extracted, there will not be a debug package. `yay` was correctly checking for this with the `stat` check in `getNewTargets`, but didn't update the `ok` variable when it wasn't found, leading to errors finding the packages when setting the install reason later (because they do not exist, but were added to the list anyway).

This PR fixes this by just setting the bool correctly.
