### PR TITLE
fix(new_engine): exclude menu removing new deps

### DIFF
--- a/pkg/db/mock/repo.go
+++ b/pkg/db/mock/repo.go
@@ -6,6 +6,25 @@ import (
 	alpm "github.com/Jguer/go-alpm/v2"
 )
 
+type DependList struct {
+	Depends []Depend
+}
+
+func (d DependList) Slice() []alpm.Depend {
+	return d.Depends
+}
+
+func (d DependList) ForEach(f func(*alpm.Depend) error) error {
+	for _, dep := range d.Depends {
+		err := f(&dep)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type Package struct {
 	PBase         string
 	PBuildDate    time.Time
@@ -17,6 +36,7 @@ type Package struct {
 	PSize         int64
 	PVersion      string
 	PReason       alpm.PkgReason
+	PDepends      alpm.IDependList
 }
 
 func (p *Package) Base() string {
@@ -88,6 +108,9 @@ func (p *Package) Conflicts() alpm.IDependList {
 
 // Depends returns the package's dependency list.
 func (p *Package) Depends() alpm.IDependList {
+	if p.PDepends != nil {
+		return p.PDepends
+	}
 	return alpm.DependList{}
 }
 

--- a/pkg/db/mock/repo.go
+++ b/pkg/db/mock/repo.go
@@ -15,8 +15,9 @@ func (d DependList) Slice() []alpm.Depend {
 }
 
 func (d DependList) ForEach(f func(*alpm.Depend) error) error {
-	for _, dep := range d.Depends {
-		err := f(&dep)
+	for i := range d.Depends {
+		dep := &d.Depends[i]
+		err := f(dep)
 		if err != nil {
 			return err
 		}

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -268,9 +268,15 @@ func (u *UpgradeService) UserExcludeUpgrades(graph *topo.Graph[string, *dep.Inst
 	excluded := make([]string, 0)
 	for i := range allUp.Up {
 		up := &allUp.Up[i]
+		// choices do not apply to non-installed packages
+		if up.LocalVersion == "" {
+			continue
+		}
+
 		if isInclude && otherExclude.Get(up.Repository) {
 			u.log.Debugln("pruning", up.Name)
 			excluded = append(excluded, graph.Prune(up.Name)...)
+			continue
 		}
 
 		if isInclude && exclude.Get(allUpLen-i) {


### PR DESCRIPTION
Fixes #1952

Excluding non-installed packages will have no effect.
- Targets will not be removed when using the menu
- Upgrade new deps will only be removed if the dependent is excluded