### PR TITLE
 fix(yay): correct operation order for preparer 

### DIFF
--- a/pkg/menus/clean_menu.go
+++ b/pkg/menus/clean_menu.go
@@ -35,6 +35,7 @@ func CleanFn(ctx context.Context, config *settings.Configuration, w io.Writer, p
 
 	skipFunc := func(pkg string) bool {
 		dir := pkgbuildDirsByBase[pkg]
+		// TOFIX: new install engine dir will always exist, check if unclean instead
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			return true
 		}

--- a/pkg/menus/clean_menu.go
+++ b/pkg/menus/clean_menu.go
@@ -59,7 +59,7 @@ func CleanFn(ctx context.Context, config *settings.Configuration, w io.Writer, p
 		dir := pkgbuildDirsByBase[base]
 		text.OperationInfoln(gotext.Get("Deleting (%d/%d): %s", i+1, len(toClean), text.Cyan(dir)))
 
-		if err := config.Runtime.CmdBuilder.Show(config.Runtime.CmdBuilder.BuildGitCmd(ctx, dir, "reset", "--hard", "HEAD")); err != nil {
+		if err := config.Runtime.CmdBuilder.Show(config.Runtime.CmdBuilder.BuildGitCmd(ctx, dir, "reset", "--hard", "origin/HEAD")); err != nil {
 			text.Warnln(gotext.Get("Unable to clean:"), dir)
 
 			return err

--- a/pkg/menus/menu.go
+++ b/pkg/menus/menu.go
@@ -26,6 +26,7 @@ func pkgbuildNumberMenu(w io.Writer, pkgbuildDirs map[string]string, bases []str
 			toPrint += text.Bold(text.Green(gotext.Get(" (Installed)")))
 		}
 
+		// TODO: remove or refactor to check if git dir is unclean
 		if _, err := os.Stat(dir); !os.IsNotExist(err) {
 			toPrint += text.Bold(text.Green(gotext.Get(" (Build Files Exist)")))
 		}

--- a/pkg/upgrade/sources_test.go
+++ b/pkg/upgrade/sources_test.go
@@ -124,7 +124,9 @@ func Test_upAUR(t *testing.T) {
 
 			got := UpAUR(text.NewLogger(io.Discard, strings.NewReader(""), false, "test"),
 				tt.args.remote, tt.args.aurdata, tt.args.timeUpdate, tt.args.enableDowngrade)
-			assert.EqualValues(t, tt.want, got)
+			assert.ElementsMatch(t, tt.want.Repos, got.Repos)
+			assert.ElementsMatch(t, tt.want.Up, got.Up)
+			assert.Equal(t, tt.want.Len(), got.Len())
 		})
 	}
 }

--- a/preparer_test.go
+++ b/preparer_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Jguer/yay/v12/pkg/settings"
+)
+
+// Test order of pre-download-sources hooks
+func TestPreDownloadSourcesHooks(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cfg      *settings.Configuration
+		wantHook []string
+	}{
+		{
+			name: "clean, diff, edit",
+			cfg: &settings.Configuration{
+				CleanMenu: true,
+				DiffMenu:  true,
+				EditMenu:  true,
+			},
+			wantHook: []string{"clean", "diff", "edit"},
+		},
+		{
+			name: "clean, edit",
+			cfg: &settings.Configuration{
+				CleanMenu: true,
+				DiffMenu:  false,
+				EditMenu:  true,
+			},
+			wantHook: []string{"clean", "edit"},
+		},
+		{
+			name: "clean, diff",
+			cfg: &settings.Configuration{
+				CleanMenu: true,
+				DiffMenu:  true,
+				EditMenu:  false,
+			},
+			wantHook: []string{"clean", "diff"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			preper := NewPreparer(nil, nil, tc.cfg)
+
+			assert.Len(t, preper.hooks, len(tc.wantHook))
+
+			got := make([]string, 0, len(preper.hooks))
+
+			for _, hook := range preper.hooks {
+				got = append(got, hook.Name)
+			}
+
+			assert.Equal(t, tc.wantHook, got)
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/Jguer/yay/issues/2066

Preparer was verifying the source (just downloading pkg sources) before edit. 

Although it works to still edit it after, no makepkg action should be done until the user has either used diff/edit on the repo. 

- [fix(yay): reset to origin/HEAD for clean_menu](https://github.com/Jguer/yay/commit/677cc0707da9d44da79b384c54d637b9d90d1948)

- [fix(yay): correct operation order for preparer](https://github.com/Jguer/yay/commit/b6e9a3ffea99b469973db437f6ed0e86101a6f3a)