### PR TITLE
fix(upgrades): don't include makedeps into -Qu/a

### DIFF
--- a/print.go
+++ b/print.go
@@ -132,6 +132,10 @@ func printUpdateList(ctx context.Context, cfg *settings.Configuration, cmdArgs *
 	nativeFilter := cmdArgs.ExistsArg("n", "native")
 
 	_ = graph.ForEach(func(pkgName string, ii *dep.InstallInfo) error {
+		if !ii.Upgrade {
+			return nil
+		}
+
 		if noTargets || targets.Contains(pkgName) {
 			if ii.Source == dep.Sync && foreignFilter {
 				return nil


### PR DESCRIPTION
As reasoned in https://github.com/Jguer/yay/issues/2076, makedeps should not be included in `-Qu/a`. 

Closes https://github.com/Jguer/yay/issues/2076