### PR TITLE
fix(new_engine): add missing warnings to AUR updates

### DIFF
--- a/install.go
+++ b/install.go
@@ -96,7 +96,7 @@ func install(ctx context.Context, cfg *settings.Configuration,
 		assumeInstalled = cmdArgs.GetArgs("assume-installed")
 		sysupgradeArg   = cmdArgs.ExistsArg("u", "sysupgrade")
 		refreshArg      = cmdArgs.ExistsArg("y", "refresh")
-		warnings        = query.NewWarnings()
+		warnings        = query.NewWarnings(cfg.Runtime.Logger)
 	)
 
 	if noDeps {

--- a/pkg/query/aur_warnings.go
+++ b/pkg/query/aur_warnings.go
@@ -30,7 +30,10 @@ func NewWarnings(logger *text.Logger) *AURWarnings {
 
 func (warnings *AURWarnings) AddToWarnings(remote map[string]alpm.IPackage, aurPkg *aur.Pkg) {
 	name := aurPkg.Name
-	pkg := remote[name]
+	pkg, ok := remote[name]
+	if !ok {
+		return
+	}
 
 	if aurPkg.Maintainer == "" && !pkg.ShouldIgnore() {
 		warnings.Orphans = append(warnings.Orphans, name)

--- a/sync.go
+++ b/sync.go
@@ -66,6 +66,9 @@ func syncInstall(ctx context.Context,
 		if errSysUp != nil {
 			return errSysUp
 		}
+
+		upService.AURWarnings.Print()
+
 		excluded, errSysUp = upService.UserExcludeUpgrades(graph)
 		if errSysUp != nil {
 			return errSysUp

--- a/sync_test.go
+++ b/sync_test.go
@@ -632,6 +632,7 @@ func TestSyncUpgrade_NoCombinedUpgrade(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			makepkgBin := t.TempDir() + "/makepkg"

--- a/upgrade.go
+++ b/upgrade.go
@@ -262,7 +262,7 @@ func upgradePkgsMenu(cfg *settings.Configuration, aurUp, repoUp upgrade.UpSlice)
 func sysupgradeTargets(ctx context.Context, cfg *settings.Configuration, dbExecutor db.Executor,
 	enableDowngrade bool,
 ) (stringset.StringSet, []string, error) {
-	warnings := query.NewWarnings()
+	warnings := query.NewWarnings(cfg.Runtime.Logger)
 
 	aurUp, repoUp, err := upList(ctx, cfg, warnings, dbExecutor, enableDowngrade,
 		func(*upgrade.Upgrade) bool { return true })


### PR DESCRIPTION
Add missing warnings to AUR updates while ensuring it doesn't disturb `yay -Qu/a` without stdout discard hacks