### PR TITLE
fix: querybuilder GetTargets start iteration at 1, when include is 0 causes a crash

### DIFF
--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -238,7 +238,7 @@ func (s *SourceQueryBuilder) GetTargets(include, exclude intrange.IntRanges,
 		lenRes    = len(s.results)
 	)
 
-	for i := 0; i <= s.Len(); i++ {
+	for i := 1; i <= s.Len(); i++ {
 		target := i - 1
 		if s.bottomUp {
 			target = lenRes - i


### PR DESCRIPTION
Fixes #2108


---

```bash

$ ./yay -s kubeconfig
4 aur/k3sup-bin 1:0.12.8-1 (+3 0.01) (Out-of-date: 2023-03-01) 
    k3sup is a light-weight utility to get from zero to KUBECONFIG with k3s on any local or remote VM.
3 aur/kubectl-konfig 0.2.6-0 (+0 0.00) 
    konfig helps to merge, split or import kubeconfig files
2 aur/kubeswitch 0.7.1-1 (+0 0.00) (Out-of-date: 2022-11-09) 
    kubeswitch (lazy: switch) is the single pane of glass for all of your kubeconfig files. Caters to operators of large scale Kubernetes installations. Designed as a drop-in replacement for kubectx.
1 aur/kubecm-git v0.15.3-1 (+0 0.00) 
    Manage your kubeconfig more easily.
==> Packages to install (eg: 1 2 3, 1-3 or ^4)
==> 0
 there is nothing to do
```

tested to make sure it didnt break 1 and up as well.