### PR TITLE
chore(upgrade): add makedep explain to the upgrade menu

### DIFF
--- a/pkg/db/executor.go
+++ b/pkg/db/executor.go
@@ -26,6 +26,7 @@ type Upgrade struct {
 	LocalVersion  string
 	RemoteVersion string
 	Reason        alpm.PkgReason
+	Extra         string // Extra information to be displayed
 }
 
 type SyncUpgrade struct {

--- a/pkg/topo/dep.go
+++ b/pkg/topo/dep.go
@@ -12,6 +12,16 @@ type (
 	DepMap[T comparable]  map[T]NodeSet[T]
 )
 
+func (n NodeSet[T]) Slice() []T {
+	var slice []T
+
+	for node := range n {
+		slice = append(slice, node)
+	}
+
+	return slice
+}
+
 type NodeInfo[V any] struct {
 	Color      string
 	Background string
@@ -253,10 +263,10 @@ func (g *Graph[T, V]) remove(node T) {
 }
 
 func (g *Graph[T, V]) Dependencies(child T) NodeSet[T] {
-	return g.buildTransitive(child, g.immediateDependencies)
+	return g.buildTransitive(child, g.ImmediateDependencies)
 }
 
-func (g *Graph[T, V]) immediateDependencies(node T) NodeSet[T] {
+func (g *Graph[T, V]) ImmediateDependencies(node T) NodeSet[T] {
 	return g.dependencies[node]
 }
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"fmt"
+	"strings"
 	"unicode"
 
 	"github.com/Jguer/yay/v12/pkg/db"
@@ -112,18 +113,23 @@ func (u UpSlice) Print(logger *text.Logger) {
 		longestVersion = intrange.Max(packVersionLen, longestVersion)
 	}
 
+	lenUp := len(u.Up)
+	longestNumber := len(fmt.Sprintf("%v", lenUp))
 	namePadding := fmt.Sprintf("%%-%ds  ", longestName)
 	versionPadding := fmt.Sprintf("%%-%ds", longestVersion)
-	numberPadding := fmt.Sprintf("%%%dd  ", len(fmt.Sprintf("%v", len(u.Up))))
+	numberPadding := fmt.Sprintf("%%%dd  ", longestNumber)
 
 	for k := range u.Up {
 		upgrade := &u.Up[k]
 		left, right := GetVersionDiff(upgrade.LocalVersion, upgrade.RemoteVersion)
 
-		logger.Printf(text.Magenta(fmt.Sprintf(numberPadding, len(u.Up)-k)))
+		logger.Printf(text.Magenta(fmt.Sprintf(numberPadding, lenUp-k)))
 
 		logger.Printf(namePadding, StylizedNameWithRepository(upgrade))
 
 		logger.Printf("%s -> %s\n", fmt.Sprintf(versionPadding, left), right)
+		if upgrade.Extra != "" {
+			logger.Println(strings.Repeat(" ", longestNumber), upgrade.Extra)
+		}
 	}
 }


### PR DESCRIPTION
Add explanation for why a make dep is included in the upgrade menu.

Only for makedeps and no other type of deps to avoid cluttering

![image](https://user-images.githubusercontent.com/8071073/231229931-a8a59e49-7202-4f1f-9fa6-51041f00bddc.png)
