### PR TITLE
fix(yay): fix panic -Si when package is missing

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -130,7 +130,7 @@ func cleanAUR(ctx context.Context, config *settings.Configuration,
 	// Querying the AUR is slow and needs internet so don't do it if we
 	// don't need to.
 	if keepCurrent {
-		info, errInfo := query.AURInfo(ctx, config.Runtime.AURClient, cachedPackages, &query.AURWarnings{}, config.RequestSplitN)
+		info, errInfo := query.AURInfo(ctx, config.Runtime.AURClient, cachedPackages, query.NewWarnings(nil), config.RequestSplitN)
 		if errInfo != nil {
 			return errInfo
 		}

--- a/pkg/query/aur_info.go
+++ b/pkg/query/aur_info.go
@@ -88,7 +88,7 @@ func AURInfo(ctx context.Context, aurClient rpc.ClientInterface, names []string,
 func AURInfoPrint(ctx context.Context, aurClient rpc.ClientInterface, names []string, splitN int) ([]Pkg, error) {
 	text.OperationInfoln(gotext.Get("Querying AUR..."))
 
-	warnings := &AURWarnings{}
+	warnings := NewWarnings(nil)
 
 	info, err := AURInfo(ctx, aurClient, names, warnings, splitN)
 	if err != nil {


### PR DESCRIPTION
Fix panic introduced in `yay -Si missing-package` by [1ee94f2](https://github.com/Jguer/yay/commit/1ee94f28d331146a6c4e5abe10a307f1877f89fa)