### PR TITLE
fix(vcs): improve timeout handling for vcs upgrade check

### DIFF
--- a/pkg/upgrade/sources.go
+++ b/pkg/upgrade/sources.go
@@ -2,7 +2,6 @@ package upgrade
 
 import (
 	"context"
-	"time"
 
 	"github.com/leonelquinteros/gotext"
 
@@ -22,10 +21,8 @@ func UpDevel(
 	toRemove := make([]string, 0)
 	toUpgrade := UpSlice{Up: make([]Upgrade, 0), Repos: []string{"devel"}}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
 	for pkgName, pkg := range remote {
-		if localCache.ToUpgrade(ctxTimeout, pkgName) {
+		if localCache.ToUpgrade(ctx, pkgName) {
 			if _, ok := aurdata[pkgName]; !ok {
 				log.Warnln(gotext.Get("ignoring package devel upgrade (no AUR info found):"), pkgName)
 				continue

--- a/pkg/vcs/vcs.go
+++ b/pkg/vcs/vcs.go
@@ -19,6 +19,8 @@ import (
 	"github.com/Jguer/yay/v12/pkg/text"
 )
 
+const defaultTimeout = 15 * time.Second
+
 type Store interface {
 	// ToUpgrade returns true if the package needs to be updated.
 	ToUpgrade(ctx context.Context, pkgName string) bool
@@ -82,7 +84,7 @@ func (v *InfoStore) getCommit(ctx context.Context, url, branch string, protocols
 	if len(protocols) > 0 {
 		protocol := protocols[len(protocols)-1]
 
-		ctxTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ctxTimeout, cancel := context.WithTimeout(ctx, defaultTimeout)
 		defer cancel()
 
 		cmd := v.CmdBuilder.BuildGitCmd(ctxTimeout, "", "ls-remote", protocol+"://"+url, branch)


### PR DESCRIPTION
- Remove 20s timeout for full devel update check
- Increase timeout of individual devel package check from 10s to 15s

Fixes #2117 