### PR TITLE
Switch the TZ to UTC temporarily for running the News tests

### DIFF
--- a/pkg/news/news_test.go
+++ b/pkg/news/news_test.go
@@ -121,6 +121,9 @@ func TestPrintNewsFeed(t *testing.T) {
 		{name: "latest-quiet", args: args{bottomUp: true, cutOffDate: lastNewsTime, all: false, quiet: true}, wantErr: false},
 		{name: "latest-quiet-topdown", args: args{bottomUp: false, cutOffDate: lastNewsTime, all: false, quiet: true}, wantErr: false},
 	}
+	currentTZ := os.Getenv("TZ")
+	defer os.Setenv("TZ", currentTZ)
+	os.Setenv("TZ", "UTC")
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/news/news_test.go
+++ b/pkg/news/news_test.go
@@ -121,8 +121,6 @@ func TestPrintNewsFeed(t *testing.T) {
 		{name: "latest-quiet", args: args{bottomUp: true, cutOffDate: lastNewsTime, all: false, quiet: true}, wantErr: false},
 		{name: "latest-quiet-topdown", args: args{bottomUp: false, cutOffDate: lastNewsTime, all: false, quiet: true}, wantErr: false},
 	}
-	currentTZ := os.Getenv("TZ")
-	defer os.Setenv("TZ", currentTZ)
 	os.Setenv("TZ", "UTC")
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/news/news_test.go
+++ b/pkg/news/news_test.go
@@ -121,7 +121,7 @@ func TestPrintNewsFeed(t *testing.T) {
 		{name: "latest-quiet", args: args{bottomUp: true, cutOffDate: lastNewsTime, all: false, quiet: true}, wantErr: false},
 		{name: "latest-quiet-topdown", args: args{bottomUp: false, cutOffDate: lastNewsTime, all: false, quiet: true}, wantErr: false},
 	}
-	os.Setenv("TZ", "UTC")
+	t.Setenv("TZ", "UTC")
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Hi,
I was beginning work on another issue, when I discovered that `make test` was failing on my system.

```
--- FAIL: TestPrintNewsFeed (0.03s)
    --- FAIL: TestPrintNewsFeed/all-verbose (0.01s)
        news_test.go:143: snapshot not equal:
            --- Previous
            +++ Current
            @@ -11,3 +11,3 @@
             
            -2020-01-04 Now using Zstandard instead of xz for package compression
            +2020-01-05 Now using Zstandard instead of xz for package compression
             As announced on the mailing list, on Friday, Dec 27 2019, our package compression scheme has changed from xz (.pkg.tar.xz) to zstd (.pkg.tar.zst).
            @@ -23,3 +23,3 @@
             
            -2020-01-15 rsync compatibility
            +2020-01-16 rsync compatibility
             Our rsync package was shipped with bundled zlib to provide compatibility
            @@ -36,3 +36,3 @@
             
            -2020-02-22 Planet Arch Linux migration
            +2020-02-23 Planet Arch Linux migration
             The software behind planet.archlinux.org was implemented in Python 2 and is no longer maintained upstream. This functionality has now been implemented in archlinux.org's archweb backend which is actively maintained but offers a slightly different experience.
            
    --- FAIL: TestPrintNewsFeed/all-quiet (0.01s)
        news_test.go:143: snapshot not equal:
            --- Previous
            +++ Current
            @@ -1,6 +1,6 @@
             2019-12-20 Xorg cleanup requires manual intervention
            -2020-01-04 Now using Zstandard instead of xz for package compression
            -2020-01-15 rsync compatibility
            +2020-01-05 Now using Zstandard instead of xz for package compression
            +2020-01-16 rsync compatibility
             2020-02-17 sshd needs restarting after upgrading to openssh-8.2p1
            -2020-02-22 Planet Arch Linux migration
            +2020-02-23 Planet Arch Linux migration
             2020-02-24 The Future of the Arch Linux Project Leader
            
FAIL
```

The issue is that my local TZ is IST. Thereby causing the date mismatch (off by 1) in the snapshot for items that roll-over into the next date.
This fix makes the tests pass and I *think* that the actual functioning of `yay` is not impacted by the TZ as such. But probably something for someone more experienced in the system to check.