### PR TITLE
Fix version diff word detection

### DIFF
--- a/pkg/query/version_diff.go
+++ b/pkg/query/version_diff.go
@@ -18,8 +18,8 @@ func GetVersionDiff(oldVersion, newVersion string) (left, right string) {
 
 	checkWords := func(str string, index int, words ...string) bool {
 		// Make sure the word is not part of a longer word
-		ongoingWord := !(unicode.IsLetter(rune(str[index])))
-		if !ongoingWord {
+		ongoingWord := unicode.IsLetter(rune(str[index]))
+		if ongoingWord {
 			return false
 		}
 

--- a/pkg/query/version_diff.go
+++ b/pkg/query/version_diff.go
@@ -17,6 +17,12 @@ func GetVersionDiff(oldVersion, newVersion string) (left, right string) {
 	diffPosition := 0
 
 	checkWords := func(str string, index int, words ...string) bool {
+		// Make sure the word is not part of a longer word
+		ongoingWord := !(unicode.IsLetter(rune(str[index])))
+		if !ongoingWord {
+			return false
+		}
+
 		for _, word := range words {
 			wordLength := len(word)
 

--- a/pkg/query/version_diff_test.go
+++ b/pkg/query/version_diff_test.go
@@ -1,0 +1,62 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/Jguer/yay/v12/pkg/text"
+)
+
+func TestVersionDiff(t *testing.T) {
+	testCases := []struct {
+		name     string
+		a        string
+		b        string
+		wantDiff string
+	}{
+		{
+			name:     "1.0.0-1 -> 1.0.0-2",
+			a:        "1.0.0-1",
+			b:        "1.0.0-2",
+			wantDiff: "1.0.0-" + text.Red("1") + " " + "1.0.0-" + text.Green("2"),
+		},
+		{
+			name:     "1.0.0-1 -> 1.0.1-1",
+			a:        "1.0.0-1",
+			b:        "1.0.1-1",
+			wantDiff: "1.0." + text.Red("0-1") + " " + "1.0." + text.Green("1-1"),
+		},
+		{
+			name:     "3.0.0~alpha7-3 -> 3.0.0~alpha7-4",
+			a:        "3.0.0~alpha7-3",
+			b:        "3.0.0~alpha7-4",
+			wantDiff: "3.0.0~alpha7-" + text.Red("3") + " " + "3.0.0~alpha7-" + text.Green("4"),
+		},
+		{
+			name:     "3.0.0~beta7-3 -> 3.0.0~beta8-3",
+			a:        "3.0.0~beta7-3",
+			b:        "3.0.0~beta8-3",
+			wantDiff: "3.0.0~" + text.Red("beta7-3") + " " + "3.0.0~" + text.Green("beta8-3"),
+		},
+		{
+			name:     "23.04.r131.b1bfe05-1 -> 23.04.r131.b1bfe07-1",
+			a:        "23.04.r131.b1bfe05-1",
+			b:        "23.04.r131.b1bfe07-1",
+			wantDiff: "23.04.r131." + text.Red("b1bfe05-1") + " " + "23.04.r131." + text.Green("b1bfe07-1"),
+		},
+		{
+			name:     "1.0.arch0-1 -> 1.0.arch1-2",
+			a:        "1.0.arch0-1",
+			b:        "1.0.arch1-2",
+			wantDiff: "1.0." + text.Red("arch0-1") + " " + "1.0." + text.Green("arch1-2"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			left, right := GetVersionDiff(tc.a, tc.b)
+			gotDiff := left + " " + right
+			if gotDiff != tc.wantDiff {
+				t.Errorf("VersionDiff(%s, %s) = %s, want %s", tc.a, tc.b, gotDiff, tc.wantDiff)
+			}
+		})
+	}
+}

--- a/pkg/query/version_diff_test.go
+++ b/pkg/query/version_diff_test.go
@@ -52,11 +52,14 @@ func TestVersionDiff(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			originalUseColor := text.UseColor
+			text.UseColor = true
 			left, right := GetVersionDiff(tc.a, tc.b)
 			gotDiff := left + " " + right
 			if gotDiff != tc.wantDiff {
 				t.Errorf("VersionDiff(%s, %s) = %s, want %s", tc.a, tc.b, gotDiff, tc.wantDiff)
 			}
+			text.UseColor = originalUseColor
 		})
 	}
 }


### PR DESCRIPTION
Attempted Fix for https://github.com/Jguer/yay/issues/1961

The core problem is the `checkWords` function.
e.g while traversing through `arch`, it finds `rc` as well. Thereby goes off by 1.
I have added some tests and changed the `checkWords` to return true only if the current character is not a Letter (i.e not part of a bigger word).
Other tests are also passing.