### PR TITLE
feat(upgrade): separate menu for pulled along dependencies

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	alpm "github.com/Jguer/go-alpm/v2"
@@ -403,9 +402,9 @@ func displayNumberMenu(ctx context.Context, cfg *settings.Configuration, pkgS []
 		return nil
 	}
 
-	text.Infoln(gotext.Get("Packages to install (eg: 1 2 3, 1-3 or ^4)"))
+	cfg.Runtime.Logger.Infoln(gotext.Get("Packages to install (eg: 1 2 3, 1-3 or ^4)"))
 
-	numberBuf, err := text.GetInput(os.Stdin, "", false)
+	numberBuf, err := cfg.Runtime.Logger.GetInput("", false)
 	if err != nil {
 		return err
 	}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/Jguer/aur"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v12/pkg/db/mock"
+	mockaur "github.com/Jguer/yay/v12/pkg/dep/mock"
+	"github.com/Jguer/yay/v12/pkg/query"
+	"github.com/Jguer/yay/v12/pkg/settings"
+	"github.com/Jguer/yay/v12/pkg/settings/exe"
+	"github.com/Jguer/yay/v12/pkg/settings/parser"
+	"github.com/Jguer/yay/v12/pkg/text"
+	"github.com/Jguer/yay/v12/pkg/vcs"
+)
+
+func TestYogurtMenuAURDB(t *testing.T) {
+	t.Skip("skip until Operation service is an interface")
+	t.Parallel()
+	makepkgBin := t.TempDir() + "/makepkg"
+	pacmanBin := t.TempDir() + "/pacman"
+	gitBin := t.TempDir() + "/git"
+	f, err := os.OpenFile(makepkgBin, os.O_RDONLY|os.O_CREATE, 0o755)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	f, err = os.OpenFile(pacmanBin, os.O_RDONLY|os.O_CREATE, 0o755)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	f, err = os.OpenFile(gitBin, os.O_RDONLY|os.O_CREATE, 0o755)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	captureOverride := func(cmd *exec.Cmd) (stdout string, stderr string, err error) {
+		return "", "", nil
+	}
+
+	showOverride := func(cmd *exec.Cmd) error {
+		return nil
+	}
+
+	mockRunner := &exe.MockRunner{CaptureFn: captureOverride, ShowFn: showOverride}
+	cmdBuilder := &exe.CmdBuilder{
+		MakepkgBin:       makepkgBin,
+		SudoBin:          "su",
+		PacmanBin:        pacmanBin,
+		PacmanConfigPath: "/etc/pacman.conf",
+		GitBin:           "git",
+		Runner:           mockRunner,
+		SudoLoopEnabled:  false,
+	}
+
+	cmdArgs := parser.MakeArguments()
+	cmdArgs.AddArg("Y")
+	cmdArgs.AddTarget("yay")
+
+	db := &mock.DBExecutor{
+		AlpmArchitecturesFn: func() ([]string, error) {
+			return []string{"x86_64"}, nil
+		},
+		RefreshHandleFn: func() error {
+			return nil
+		},
+		ReposFn: func() []string {
+			return []string{"aur"}
+		},
+		SyncPackagesFn: func(s ...string) []mock.IPackage {
+			return []mock.IPackage{
+				&mock.Package{
+					PName:    "yay",
+					PBase:    "yay",
+					PVersion: "10.0.0",
+					PDB:      mock.NewDB("aur"),
+				},
+			}
+		},
+		LocalPackageFn: func(s string) mock.IPackage {
+			return nil
+		},
+	}
+	aurCache := &mockaur.MockAUR{
+		GetFn: func(ctx context.Context, query *aur.Query) ([]aur.Pkg, error) {
+			return []aur.Pkg{
+				{
+					Name:        "yay",
+					PackageBase: "yay",
+					Version:     "10.0.0",
+				},
+			}, nil
+		},
+	}
+	logger := text.NewLogger(io.Discard, os.Stderr, strings.NewReader("1\n"), true, "test")
+	cfg := &settings.Configuration{
+		NewInstallEngine: true,
+		RemoveMake:       "no",
+		Runtime: &settings.Runtime{
+			Logger:     logger,
+			CmdBuilder: cmdBuilder,
+			VCSStore:   &vcs.Mock{},
+			QueryBuilder: query.NewSourceQueryBuilder(aurCache, logger, "votes", parser.ModeAny, "name",
+				true, false, true),
+			AURCache: aurCache,
+		},
+	}
+
+	err = handleCmd(context.Background(), cfg, cmdArgs, db)
+	require.NoError(t, err)
+
+	wantCapture := []string{}
+	wantShow := []string{
+		"pacman -S -y --config /etc/pacman.conf --",
+		"pacman -S -y -u --config /etc/pacman.conf --",
+	}
+
+	require.Len(t, mockRunner.ShowCalls, len(wantShow))
+	require.Len(t, mockRunner.CaptureCalls, len(wantCapture))
+
+	for i, call := range mockRunner.ShowCalls {
+		show := call.Args[0].(*exec.Cmd).String()
+		show = strings.ReplaceAll(show, makepkgBin, "makepkg")
+		show = strings.ReplaceAll(show, pacmanBin, "pacman")
+		show = strings.ReplaceAll(show, gitBin, "pacman")
+
+		// options are in a different order on different systems and on CI root user is used
+		assert.Subset(t, strings.Split(show, " "), strings.Split(wantShow[i], " "), fmt.Sprintf("%d - %s", i, show))
+	}
+}

--- a/pkg/db/mock/executor.go
+++ b/pkg/db/mock/executor.go
@@ -30,6 +30,7 @@ type DBExecutor struct {
 	RefreshHandleFn               func() error
 	ReposFn                       func() []string
 	SyncPackageFn                 func(string) IPackage
+	SyncPackagesFn                func(...string) []IPackage
 	SyncSatisfierFn               func(string) IPackage
 	SyncUpgradesFn                func(bool) (map[string]db.SyncUpgrade, error)
 }
@@ -170,6 +171,9 @@ func (t *DBExecutor) SyncPackage(s string) IPackage {
 }
 
 func (t *DBExecutor) SyncPackages(s ...string) []IPackage {
+	if t.SyncPackagesFn != nil {
+		return t.SyncPackagesFn(s...)
+	}
 	panic("implement me")
 }
 

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -211,12 +211,12 @@ func (s *SourceQueryBuilder) Results(dbExecutor db.Executor, verboseSearch Searc
 		}
 
 		pkg := s.queryMap[s.results[i].source][s.results[i].name]
-		if s.results[i].source == sourceAUR {
-			aurPkg := pkg.(aur.Pkg)
-			toPrint += aurPkgSearchString(&aurPkg, dbExecutor, s.singleLineResults)
-		} else {
-			syncPkg := pkg.(alpm.IPackage)
-			toPrint += syncPkgSearchString(syncPkg, dbExecutor, s.singleLineResults)
+
+		switch pPkg := pkg.(type) {
+		case aur.Pkg:
+			toPrint += aurPkgSearchString(&pPkg, dbExecutor, s.singleLineResults)
+		case alpm.IPackage:
+			toPrint += syncPkgSearchString(pPkg, dbExecutor, s.singleLineResults)
 		}
 
 		s.logger.Println(toPrint)

--- a/pkg/settings/runtime.go
+++ b/pkg/settings/runtime.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/leonelquinteros/gotext"
 
@@ -68,6 +69,7 @@ func BuildRuntime(cfg *Configuration, cmdArgs *parser.Arguments, version string)
 		metadata.WithCacheFilePath(filepath.Join(cfg.BuildDir, "aur.json")),
 		metadata.WithRequestEditorFn(userAgentFn),
 		metadata.WithBaseURL(cfg.AURURL),
+		metadata.WithCustomCacheValidity(100000*time.Hour),
 		metadata.WithDebugLogger(logger.Debugln),
 	)
 	if errAURCache != nil {

--- a/pkg/upgrade/service_test.go
+++ b/pkg/upgrade/service_test.go
@@ -281,7 +281,7 @@ func TestUpgradeService_GraphUpgrades(t *testing.T) {
 		{
 			name: "exclude linux",
 			fields: fields{
-				input:     strings.NewReader("4\n"),
+				input:     strings.NewReader("3\n"),
 				output:    io.Discard,
 				noConfirm: false,
 			},
@@ -301,7 +301,7 @@ func TestUpgradeService_GraphUpgrades(t *testing.T) {
 		{
 			name: "only linux",
 			fields: fields{
-				input:     strings.NewReader("^4\n"),
+				input:     strings.NewReader("^3\n"),
 				output:    io.Discard,
 				noConfirm: false,
 			},
@@ -642,7 +642,6 @@ func TestUpgradeService_GraphUpgrades_zfs_dkms(t *testing.T) {
 	}
 	type fields struct {
 		input     io.Reader
-		output    io.Writer
 		noConfirm bool
 		devel     bool
 	}
@@ -664,7 +663,6 @@ func TestUpgradeService_GraphUpgrades_zfs_dkms(t *testing.T) {
 			name: "no input",
 			fields: fields{
 				input:     strings.NewReader("\n"),
-				output:    io.Discard,
 				noConfirm: false,
 			},
 			args: args{
@@ -684,7 +682,6 @@ func TestUpgradeService_GraphUpgrades_zfs_dkms(t *testing.T) {
 			name: "no input - inverted order",
 			fields: fields{
 				input:     strings.NewReader("\n"),
-				output:    io.Discard,
 				noConfirm: false,
 			},
 			args: args{
@@ -742,16 +739,15 @@ func TestUpgradeService_GraphUpgrades_zfs_dkms(t *testing.T) {
 				ReposFn: func() []string { return []string{"core"} },
 			}
 
+			logger := text.NewLogger(io.Discard, os.Stderr,
+				tt.fields.input, true, "test")
 			grapher := dep.NewGrapher(dbExe, mockAUR,
-				false, true, false, false, false, text.NewLogger(tt.fields.output, os.Stderr,
-					tt.fields.input, true, "test"))
+				false, true, false, false, false, logger)
 
 			cfg := &settings.Configuration{
 				Devel: tt.fields.devel, Mode: parser.ModeAny,
 			}
 
-			logger := text.NewLogger(tt.fields.output, os.Stderr,
-				tt.fields.input, true, "test")
 			u := &UpgradeService{
 				log:         logger,
 				grapher:     grapher,


### PR DESCRIPTION
- fixes -Ss panic if there's a repository called aur (closes https://github.com/Jguer/yay/issues/2125)

- Adds separate menu for pulled along dependencies (closes https://github.com/Jguer/yay/pull/2114)

This should be a rarer display that only warns of pulled along (make/check/regular) dependencies.

It still allows you to fully use the number pad instead of making some number selections nops

```
:: 5 dependencies will also be pulled for this operation
   community/aspnet-runtime-6.0   -> 6.0.14.sdk114-1
   community/dotnet-runtime-6.0   -> 6.0.14.sdk114-1
   community/dotnet-sdk-6.0       -> 6.0.14.sdk114-1
   (make dependency of jellyfin, jellyfin-server, ...)
   aur/jellyfin-server            -> 10.8.9-1
   aur/jellyfin-web               -> 10.8.9-1

:: 1 package to upgrade/install.
1  aur/jellyfin   -> 10.8.9-1
```

Please submit feedback on the new menu format and on how to best display the dependencies and their dependents)