### PR TITLE
Fix formatting of error message that occurs on AUR errors

### DIFF
--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -373,7 +373,7 @@ func (g *Grapher) GraphFromAUR(ctx context.Context,
 			var errA error
 			aurPkgs, errA = g.aurClient.Get(ctx, &aurc.Query{By: aurc.Provides, Needles: []string{target}, Contains: true})
 			if errA != nil {
-				g.logger.Errorln(gotext.Get("Failed to find AUR package for"), target, ":", errA)
+				g.logger.Errorln(gotext.Get("Failed to find AUR package for"), " ", target, ":", errA)
 			}
 		}
 


### PR DESCRIPTION
If there's an error while querying the AUR for a package, the following error message is shown:

```
 -> Failed to find AUR package forautotiling-git:1 error occurred:
    * AUR is unavailable at this moment
```

It's missing a space before the package name. This PR fixes that.