### PR TITLE
Fix yay -Sc wiping ~/.cache/yay on 3rd question.

### DIFF
--- a/pkg/db/ialpm/alpm.go
+++ b/pkg/db/ialpm/alpm.go
@@ -38,7 +38,7 @@ func NewExecutor(pacmanConf *pacmanconf.Config, logger *text.Logger) (*AlpmExecu
 		conf:                    pacmanConf,
 		log:                     logger,
 		installedRemotePkgNames: nil,
-		installedRemotePkgMap:   map[string]alpm.IPackage{},
+		installedRemotePkgMap:   nil,
 		installedSyncPkgNames:   nil,
 	}
 

--- a/pkg/db/ialpm/high_level.go
+++ b/pkg/db/ialpm/high_level.go
@@ -8,6 +8,9 @@ import (
 
 // GetPackageNamesBySource returns package names with and without correspondence in SyncDBS respectively.
 func (ae *AlpmExecutor) getPackageNamesBySource() {
+	if ae.installedRemotePkgMap == nil {
+		ae.installedRemotePkgMap = map[string]alpm.IPackage{}
+	}
 	for _, localpkg := range ae.LocalPackages() {
 		pkgName := localpkg.Name()
 		if ae.SyncPackage(pkgName) != nil {


### PR DESCRIPTION
If you answer yes to

>    :: Do you want to remove all other AUR packages from cache? [Y/n]

then we run `cleanAUR()`, intending to remove subdirectories of `~/.cache/yay` that do not share a name with installed packages not found in the sync repositories.

Where this was going wrong was `cleanAUR`'s invocation was getting an empty map from `dbExecutor.InstalledRemotePackages()`—because `InstalledRemotePackages` only recomputed its result if `installedRemotePkgMap` was `nil` whereas `NewExecutor` initialized it to an empty map. The symptom was it emptied my `~/.cache/yay`.

We do want a non-nil, empty `installedRemotePkgMap` to block recomputing (that is, to indicate the user really has no remote packages), so now `NewExecutor` initializes it to nil, and `getPackageNamesBySource` is responsible for making sure it's non-nil before writing to it.

Fixes #2152, which seems to have been introduced in 4626a0409c4d34bcffe0d5ed499ebff893115c69.