### PR TITLE
feat(pkgbuild): use gitlab git repo for retrieving PKGBUILDs

### DIFF
--- a/pkg/download/abs.go
+++ b/pkg/download/abs.go
@@ -14,55 +14,30 @@ import (
 
 const (
 	MaxConcurrentFetch = 20
-	_urlPackagePath    = "%s/raw/packages/%s/trunk/PKGBUILD"
+	_urlPackagePath    = "https://gitlab.archlinux.org/archlinux/packaging/packages/0ad/-/raw/main/PKGBUILD"
+	absPackageURL      = "https://gitlab.archlinux.org/archlinux/packaging/packages"
 )
 
 var (
 	ErrInvalidRepository  = errors.New(gotext.Get("invalid repository"))
 	ErrABSPackageNotFound = errors.New(gotext.Get("package not found in repos"))
-	ABSPackageURL         = "https://github.com/archlinux/svntogit-packages"
-	ABSCommunityURL       = "https://github.com/archlinux/svntogit-community"
 )
 
-func getRepoURL(db string) (string, error) {
-	switch db {
-	case "core", "extra", "testing":
-		return ABSPackageURL, nil
-	case "community", "multilib", "community-testing", "multilib-testing":
-		return ABSCommunityURL, nil
-	}
-
-	return "", ErrInvalidRepository
-}
-
 // Return format for pkgbuild
-// https://github.com/archlinux/svntogit-community/raw/packages/neovim/trunk/PKGBUILD
-func getPackageURL(db, pkgName string) (string, error) {
-	repoURL, err := getRepoURL(db)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf(_urlPackagePath, repoURL, pkgName), err
+// https://gitlab.archlinux.org/archlinux/packaging/packages/0ad/-/raw/main/PKGBUILD
+func getPackagePKGBUILDURL(pkgName string) string {
+	return fmt.Sprintf("%s/%s/-/raw/main/PKGBUILD", absPackageURL, pkgName)
 }
 
 // Return format for pkgbuild repo
-// https://github.com/archlinux/svntogit-community.git
-func getPackageRepoURL(db string) (string, error) {
-	repoURL, err := getRepoURL(db)
-	if err != nil {
-		return "", err
-	}
-
-	return repoURL + ".git", err
+// https://gitlab.archlinux.org/archlinux/packaging/packages/0ad.git
+func getPackageRepoURL(pkgName string) string {
+	return fmt.Sprintf("%s/%s.git", absPackageURL, pkgName)
 }
 
 // ABSPKGBUILD retrieves the PKGBUILD file to a dest directory.
 func ABSPKGBUILD(httpClient httpRequestDoer, dbName, pkgName string) ([]byte, error) {
-	packageURL, err := getPackageURL(dbName, pkgName)
-	if err != nil {
-		return nil, err
-	}
+	packageURL := getPackagePKGBUILDURL(pkgName)
 
 	resp, err := httpClient.Get(packageURL)
 	if err != nil {
@@ -87,11 +62,8 @@ func ABSPKGBUILD(httpClient httpRequestDoer, dbName, pkgName string) ([]byte, er
 func ABSPKGBUILDRepo(ctx context.Context, cmdBuilder exe.GitCmdBuilder,
 	dbName, pkgName, dest string, force bool,
 ) (bool, error) {
-	pkgURL, err := getPackageRepoURL(dbName)
-	if err != nil {
-		return false, err
-	}
+	pkgURL := getPackageRepoURL(pkgName)
 
 	return downloadGitRepo(ctx, cmdBuilder, pkgURL,
-		pkgName, dest, force, "--single-branch", "-b", "packages/"+pkgName)
+		pkgName, dest, force, "--single-branch")
 }

--- a/pkg/download/unified_test.go
+++ b/pkg/download/unified_test.go
@@ -211,8 +211,8 @@ func TestPKGBUILDFull(t *testing.T) {
 		Reply(200).
 		BodyString("example_yay-bin")
 
-	gock.New("https://github.com/").
-		Get("/archlinux/svntogit-packages/raw/packages/yay/trunk/PKGBUILD").
+	gock.New("https://gitlab.archlinux.org/").
+		Get("archlinux/packaging/packages/yay/-/raw/main/PKGBUILD").
 		Reply(200).
 		BodyString("example_yay")
 


### PR DESCRIPTION
Use `https://gitlab.archlinux.org/archlinux/packaging/packages` for retrieving ABS PKGBUILDs

Fixes https://github.com/Jguer/yay/issues/2176

Nice side effect, no trunk folder moving anymore necessary