### PR TITLE
fix(pkgbuild): convert package name for gitlab URLs

### DIFF
--- a/pkg/download/abs.go
+++ b/pkg/download/abs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 
 	"github.com/leonelquinteros/gotext"
 
@@ -22,16 +23,39 @@ var (
 	ErrABSPackageNotFound = errors.New(gotext.Get("package not found in repos"))
 )
 
+type regexReplace struct {
+	repl  string
+	match *regexp.Regexp
+}
+
+// regex replacements for Gitlab URLs
+// info: https://gitlab.archlinux.org/archlinux/devtools/-/blob/6ce666a1669235749c17d5c44d8a24dea4a135da/src/lib/api/gitlab.sh#L84
+var gitlabRepl = []regexReplace{
+	{repl: `$1-$2`, match: regexp.MustCompile(`([a-zA-Z0-9]+)\+([a-zA-Z]+)`)},
+	{repl: `plus`, match: regexp.MustCompile(`\+`)},
+	{repl: `-`, match: regexp.MustCompile(`[^a-zA-Z0-9_\-.]`)},
+	{repl: `-`, match: regexp.MustCompile(`[_\-]{2,}`)},
+	{repl: `unix-tree`, match: regexp.MustCompile(`^tree$`)},
+}
+
 // Return format for pkgbuild
 // https://gitlab.archlinux.org/archlinux/packaging/packages/0ad/-/raw/main/PKGBUILD
 func getPackagePKGBUILDURL(pkgName string) string {
-	return fmt.Sprintf("%s/%s/-/raw/main/PKGBUILD", absPackageURL, pkgName)
+	return fmt.Sprintf("%s/%s/-/raw/main/PKGBUILD", absPackageURL, convertPkgNameForURL(pkgName))
 }
 
 // Return format for pkgbuild repo
 // https://gitlab.archlinux.org/archlinux/packaging/packages/0ad.git
 func getPackageRepoURL(pkgName string) string {
-	return fmt.Sprintf("%s/%s.git", absPackageURL, pkgName)
+	return fmt.Sprintf("%s/%s.git", absPackageURL, convertPkgNameForURL(pkgName))
+}
+
+// convert pkgName for Gitlab URL path (repo name)
+func convertPkgNameForURL(pkgName string) string {
+	for _, regex := range gitlabRepl {
+		pkgName = regex.match.ReplaceAllString(pkgName, regex.repl)
+	}
+	return pkgName
 }
 
 // ABSPKGBUILD retrieves the PKGBUILD file to a dest directory.

--- a/pkg/download/abs_test.go
+++ b/pkg/download/abs_test.go
@@ -76,6 +76,51 @@ func Test_getPackageURL(t *testing.T) {
 			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/zabix/-/raw/main/PKGBUILD",
 			wantErr: false,
 		},
+		{
+			name: "special name +",
+			args: args{
+				db:      "core",
+				pkgName: "my+package",
+			},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/my-package/-/raw/main/PKGBUILD",
+			wantErr: false,
+		},
+		{
+			name: "special name %",
+			args: args{
+				db:      "core",
+				pkgName: "my%package",
+			},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/my-package/-/raw/main/PKGBUILD",
+			wantErr: false,
+		},
+		{
+			name: "special name _-",
+			args: args{
+				db:      "core",
+				pkgName: "my_-package",
+			},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/my-package/-/raw/main/PKGBUILD",
+			wantErr: false,
+		},
+		{
+			name: "special name ++",
+			args: args{
+				db:      "core",
+				pkgName: "my++package",
+			},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/mypluspluspackage/-/raw/main/PKGBUILD",
+			wantErr: false,
+		},
+		{
+			name: "special name tree",
+			args: args{
+				db:      "sweswe",
+				pkgName: "tree",
+			},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/unix-tree/-/raw/main/PKGBUILD",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -178,6 +223,36 @@ func Test_getPackageRepoURL(t *testing.T) {
 			name:    "personal repo package",
 			args:    args{pkgName: "sweswe"},
 			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/sweswe.git",
+			wantErr: false,
+		},
+		{
+			name:    "special name +",
+			args:    args{pkgName: "my+package"},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/my-package.git",
+			wantErr: false,
+		},
+		{
+			name:    "special name %",
+			args:    args{pkgName: "my%package"},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/my-package.git",
+			wantErr: false,
+		},
+		{
+			name:    "special name _-",
+			args:    args{pkgName: "my_-package"},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/my-package.git",
+			wantErr: false,
+		},
+		{
+			name:    "special name ++",
+			args:    args{pkgName: "my++package"},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/mypluspluspackage.git",
+			wantErr: false,
+		},
+		{
+			name:    "special name tree",
+			args:    args{pkgName: "tree"},
+			want:    "https://gitlab.archlinux.org/archlinux/packaging/packages/unix-tree.git",
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
Some package(base) names contain characters that are not allowed in gitlab repository names.
Arch converted them according to the following rules:

https://gitlab.archlinux.org/archlinux/devtools/-/blob/6ce666a1669235749c17d5c44d8a24dea4a135da/src/lib/api/gitlab.sh#L84

