### PR TITLE
Fix install reason preservation when package is reinstalled

### DIFF
--- a/local_install_test.go
+++ b/local_install_test.go
@@ -138,6 +138,7 @@ func TestIntegrationLocalInstall(t *testing.T) {
 
 			return nil
 		},
+		LocalPackageFn: func(s string) mock.IPackage { return nil },
 	}
 
 	config := &settings.Configuration{
@@ -258,6 +259,7 @@ func TestIntegrationLocalInstallMissingDep(t *testing.T) {
 
 			return nil
 		},
+		LocalPackageFn: func(string) mock.IPackage { return nil },
 	}
 
 	config := &settings.Configuration{
@@ -557,6 +559,7 @@ func TestIntegrationLocalInstallGenerateSRCINFO(t *testing.T) {
 
 			return true
 		},
+		LocalPackageFn: func(string) mock.IPackage { return nil },
 		SyncSatisfierFn: func(s string) mock.IPackage {
 			switch s {
 			case "dotnet-runtime>=6", "dotnet-runtime<7":
@@ -838,6 +841,7 @@ func TestIntegrationLocalInstallWithDepsProvides(t *testing.T) {
 		SyncSatisfierFn: func(s string) mock.IPackage {
 			return nil
 		},
+		LocalPackageFn: func(s string) mock.IPackage { return nil },
 	}
 
 	config := &settings.Configuration{
@@ -976,6 +980,7 @@ func TestIntegrationLocalInstallTwoSrcInfosWithDeps(t *testing.T) {
 		SyncSatisfierFn: func(s string) mock.IPackage {
 			return nil
 		},
+		LocalPackageFn: func(s string) mock.IPackage { return nil },
 	}
 
 	config := &settings.Configuration{


### PR DESCRIPTION
First approach. Maybe a little messy and bloated in `GraphFromTargets` method. There is one side-effect: when installing packages, that previously were installed as dependencies, they are being showed as dependency at the preview section(where packages counts are). Is it okay?
 
Fixes #2164.