### PR TITLE
Remove redundant attempts to set install reasons

### DIFF
--- a/aur_install.go
+++ b/aur_install.go
@@ -426,6 +426,9 @@ func (installer *Installer) installSyncPackages(ctx context.Context, cmdArgs *pa
 
 	errShow := installer.exeCmd.Show(installer.exeCmd.BuildPacmanCmd(ctx,
 		arguments, installer.targetMode, noConfirm))
+	if errShow != nil {
+		return errShow
+	}
 
 	if errD := asdeps(ctx, installer.exeCmd, installer.targetMode, cmdArgs, syncDeps.ToSlice()); errD != nil {
 		return errD
@@ -435,5 +438,5 @@ func (installer *Installer) installSyncPackages(ctx context.Context, cmdArgs *pa
 		return errE
 	}
 
-	return errShow
+	return nil
 }


### PR DESCRIPTION
Redundant attempts took place when the installation by pacman was exited with error code, i.e. an real error occurred or installation was simply cancelled.

Straightforward quick fix. Maybe there is some pitfall, that I recklessly fell into.

Fixes #2167.