### PR TITLE
Fix excluding of packages with unsatisfied deps

### DIFF
--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -652,7 +652,9 @@ func (g *Grapher) addNodes(
 	for _, depString := range targetsToFind.ToSlice() {
 		depName, mod, ver := splitDep(depString)
 		// no dep found. add as missing
-		graph.AddNode(depName)
+		if err := graph.DependOn(depName, parentPkgName); err != nil {
+			g.logger.Warnln("missing dep warn:", depString, parentPkgName, err)
+		}
 		graph.SetNodeInfo(depName, &topo.NodeInfo[*InstallInfo]{
 			Color:      colorMap[depType],
 			Background: bgColorMap[Missing],

--- a/pkg/topo/dep.go
+++ b/pkg/topo/dep.go
@@ -124,10 +124,6 @@ func (g *Graph[T, V]) DependOn(child, parent T) error {
 	g.AddNode(parent)
 	g.AddNode(child)
 
-	// Add nodes.
-	g.nodes[parent] = true
-	g.nodes[child] = true
-
 	// Add edges.
 	g.dependents.addNodeToNodeset(parent, child)
 	g.dependencies.addNodeToNodeset(child, parent)


### PR DESCRIPTION
When dependency is unsatisfied, add to the graph not only a dep node,
but relationship with parent too.

Tried to fix #2127 this way.

Does it look OK? Should I also add a test scenario for this case?