### PR TITLE
Re-add functionality for Installed and NotInstalled options in the menus

### DIFF
--- a/local_install_test.go
+++ b/local_install_test.go
@@ -138,7 +138,8 @@ func TestIntegrationLocalInstall(t *testing.T) {
 
 			return nil
 		},
-		LocalPackageFn: func(s string) mock.IPackage { return nil },
+		LocalPackageFn:                func(s string) mock.IPackage { return nil },
+		InstalledRemotePackageNamesFn: func() []string { return []string{} },
 	}
 
 	config := &settings.Configuration{
@@ -417,6 +418,7 @@ func TestIntegrationLocalInstallNeeded(t *testing.T) {
 
 			return nil
 		},
+		InstalledRemotePackageNamesFn: func() []string { return []string{} },
 	}
 
 	config := &settings.Configuration{
@@ -580,6 +582,7 @@ func TestIntegrationLocalInstallGenerateSRCINFO(t *testing.T) {
 
 			return nil
 		},
+		InstalledRemotePackageNamesFn: func() []string { return []string{} },
 	}
 
 	config := &settings.Configuration{
@@ -841,7 +844,8 @@ func TestIntegrationLocalInstallWithDepsProvides(t *testing.T) {
 		SyncSatisfierFn: func(s string) mock.IPackage {
 			return nil
 		},
-		LocalPackageFn: func(s string) mock.IPackage { return nil },
+		LocalPackageFn:                func(s string) mock.IPackage { return nil },
+		InstalledRemotePackageNamesFn: func() []string { return []string{} },
 	}
 
 	config := &settings.Configuration{
@@ -980,7 +984,8 @@ func TestIntegrationLocalInstallTwoSrcInfosWithDeps(t *testing.T) {
 		SyncSatisfierFn: func(s string) mock.IPackage {
 			return nil
 		},
-		LocalPackageFn: func(s string) mock.IPackage { return nil },
+		LocalPackageFn:                func(s string) mock.IPackage { return nil },
+		InstalledRemotePackageNamesFn: func() []string { return []string{} },
 	}
 
 	config := &settings.Configuration{

--- a/pkg/menus/clean_menu.go
+++ b/pkg/menus/clean_menu.go
@@ -23,7 +23,9 @@ func anyExistInCache(pkgbuildDirs map[string]string) bool {
 	return false
 }
 
-func CleanFn(ctx context.Context, config *settings.Configuration, w io.Writer, pkgbuildDirsByBase map[string]string) error {
+func CleanFn(ctx context.Context, config *settings.Configuration, w io.Writer,
+	pkgbuildDirsByBase map[string]string, installed mapset.Set[string],
+) error {
 	if len(pkgbuildDirsByBase) == 0 {
 		return nil // no work to do
 	}
@@ -47,8 +49,7 @@ func CleanFn(ctx context.Context, config *settings.Configuration, w io.Writer, p
 		bases = append(bases, pkg)
 	}
 
-	// TOFIX: empty installed slice means installed filter is disabled
-	toClean, errClean := selectionMenu(w, pkgbuildDirsByBase, bases, mapset.NewSet[string](),
+	toClean, errClean := selectionMenu(w, pkgbuildDirsByBase, bases, installed,
 		gotext.Get("Packages to cleanBuild?"),
 		settings.NoConfirm, config.AnswerClean, skipFunc)
 	if errClean != nil {

--- a/pkg/menus/diff_menu.go
+++ b/pkg/menus/diff_menu.go
@@ -90,7 +90,7 @@ func gitHasDiff(ctx context.Context, cmdBuilder exe.ICmdBuilder, dir string) (bo
 	return true, nil
 }
 
-// Return wether or not we have reviewed a diff yet. It checks for the existence of
+// Return whether or not we have reviewed a diff yet. It checks for the existence of
 // YAY_DIFF_REVIEW in the git ref-list.
 func gitHasLastSeenRef(ctx context.Context, cmdBuilder exe.ICmdBuilder, dir string) bool {
 	_, _, err := cmdBuilder.Capture(
@@ -145,7 +145,9 @@ func updatePkgbuildSeenRef(ctx context.Context, cmdBuilder exe.ICmdBuilder, pkgb
 	return errMulti.Return()
 }
 
-func DiffFn(ctx context.Context, config *settings.Configuration, w io.Writer, pkgbuildDirsByBase map[string]string) error {
+func DiffFn(ctx context.Context, config *settings.Configuration, w io.Writer,
+	pkgbuildDirsByBase map[string]string, installed mapset.Set[string],
+) error {
 	if len(pkgbuildDirsByBase) == 0 {
 		return nil // no work to do
 	}
@@ -155,7 +157,7 @@ func DiffFn(ctx context.Context, config *settings.Configuration, w io.Writer, pk
 		bases = append(bases, base)
 	}
 
-	toDiff, errMenu := selectionMenu(w, pkgbuildDirsByBase, bases, mapset.NewThreadUnsafeSet[string](), gotext.Get("Diffs to show?"),
+	toDiff, errMenu := selectionMenu(w, pkgbuildDirsByBase, bases, installed, gotext.Get("Diffs to show?"),
 		settings.NoConfirm, config.AnswerDiff, nil)
 	if errMenu != nil || len(toDiff) == 0 {
 		return errMenu

--- a/pkg/menus/edit_menu.go
+++ b/pkg/menus/edit_menu.go
@@ -114,7 +114,7 @@ func editPkgbuilds(log *text.Logger, pkgbuildDirs map[string]string, bases []str
 }
 
 func EditFn(ctx context.Context, cfg *settings.Configuration, w io.Writer,
-	pkgbuildDirsByBase map[string]string,
+	pkgbuildDirsByBase map[string]string, installed mapset.Set[string],
 ) error {
 	if len(pkgbuildDirsByBase) == 0 {
 		return nil // no work to do
@@ -125,8 +125,7 @@ func EditFn(ctx context.Context, cfg *settings.Configuration, w io.Writer,
 		bases = append(bases, pkg)
 	}
 
-	toEdit, errMenu := selectionMenu(w, pkgbuildDirsByBase, bases,
-		mapset.NewThreadUnsafeSet[string](),
+	toEdit, errMenu := selectionMenu(w, pkgbuildDirsByBase, bases, installed,
 		gotext.Get("PKGBUILDs to edit?"), settings.NoConfirm, cfg.AnswerEdit, nil)
 	if errMenu != nil || len(toEdit) == 0 {
 		return errMenu


### PR DESCRIPTION
Fixes #2209, #2134, and part of #2131

I used the same naming scheme for `remoteNames` and `remoteNamesCache` that the old functionality had but I can change that if other names for those variables are desired to fall more in line with the information they hold.

Let me know if you want to accomplish this functionality another way. This approach seemed simple enough and was already done previously, so I decided to make a PR to re-implement it.