### PR TITLE
Don't upgrade repo packages when --aur is specified

### DIFF
--- a/aur_install.go
+++ b/aur_install.go
@@ -420,6 +420,12 @@ func (installer *Installer) installSyncPackages(ctx context.Context, cmdArgs *pa
 	arguments.Op = "S"
 	arguments.ClearTargets()
 	arguments.AddTarget(repoTargets...)
+
+	// Don't upgrade all repo packages if only AUR upgrades are specified
+	if installer.targetMode == parser.ModeAUR {
+		arguments.DelArg("u", "upgrades")
+	}
+
 	if len(excluded) > 0 {
 		arguments.CreateOrAppendOption("ignore", excluded...)
 	}


### PR DESCRIPTION
Fixes #2149.

If the target mode is AUR (i.e. `--aur` or `-a` were passed as arguments), the `-u` and `--upgrades` flags will be removed to ensure that Pacman doesn't run upgrades when installing dependencies.

Additionally, I added a few tests to ensure this functionality works correctly.