### PR TITLE
perf: smaller git clone

### DIFF
--- a/pkg/download/unified.go
+++ b/pkg/download/unified.go
@@ -44,7 +44,7 @@ func downloadGitRepo(ctx context.Context, cmdBuilder exe.GitCmdBuilder,
 		gitArgs = append(gitArgs, pkgURL, pkgName)
 
 		cloneArgs := make([]string, 0, len(gitArgs)+4)
-		cloneArgs = append(cloneArgs, "clone", "--no-progress")
+		cloneArgs = append(cloneArgs, "clone", "--no-progress", "--depth=1", "--single-branch")
 		cloneArgs = append(cloneArgs, gitArgs...)
 		cmd := cmdBuilder.BuildGitCmd(ctx, dest, cloneArgs...)
 


### PR DESCRIPTION
At the end, we don't need the commit history or others branchs to install an aur package. The git clone can be smaller and faster using some flags like:

    git clone --depth=1 --single-branch