### PR TITLE
fix(yay): fix missing placeholders in translations

### DIFF
--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Oliver Conzen, 2021
@@ -9,7 +9,7 @@
 # Mélanie Chauvel <perso@hack-libre.org>, 2023
 # Maxime Demolin, 2023
 # Mathias Brugger, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Mathias Brugger, 2023\n"
@@ -247,7 +247,7 @@ msgstr "Paquets AUR marqués comme obsolètes :"
 
 #: print.go:84
 msgid "Foreign installed packages: %s"
-msgstr "Paquets étrangers installés :"
+msgstr "Paquets étrangers installés : %s"
 
 #: pkg/vcs/vcs.go:144
 msgid "Found git repo: %s"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -1,10 +1,10 @@
-# 
+#
 # Translators:
 # J G, 2021
 # makvasm, 2021
 # antsif.a, 2022
 # Demir Yerli, 2022
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Demir Yerli, 2022\n"
@@ -373,11 +373,11 @@ msgstr "Показываются только пакеты из репозито
 
 #: print.go:89
 msgid "Size of pacman cache %s: %s"
-msgstr "Размер кэша \"pacman\""
+msgstr "Размер кэша \"pacman\" %s: %s"
 
 #: print.go:92
 msgid "Size of yay cache %s: %s"
-msgstr "Размер кэша \"yay\""
+msgstr "Размер кэша \"yay\" %s: %s"
 
 #: print.go:53
 msgid "Snapshot URL"


### PR DESCRIPTION
Fixes #2267.

This PR fixes the missing placeholders in the French and Russian translations (both of which were reported in the issue). I'm not sure if this is the correct way to update translations (I don't know either language, but it fixed the issue), so let me know if I should do it another way (such as on Transifex).