### PR TITLE
fix(download): do not garble download output by default

### DIFF
--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -208,7 +208,7 @@ func DefaultConfig(version string) *Configuration {
 		GitFlags:               "",
 		BottomUp:               true,
 		CompletionInterval:     7,
-		MaxConcurrentDownloads: 0,
+		MaxConcurrentDownloads: 1,
 		SortBy:                 "votes",
 		SearchBy:               "name-desc",
 		SudoLoop:               false,


### PR DESCRIPTION
Not really a fix, more of a defeaturing. Limit concurrent downloads to 1 by default (thereby sequential) to not garble the output. 

Concurrent download will still be available for the time being for users who have packages with slow sources.

Fixes https://github.com/Jguer/yay/issues/1620