### PR TITLE
feat(yay): add boolean flags

### DIFF
--- a/doc/yay.8
+++ b/doc/yay.8
@@ -293,6 +293,9 @@ Unset the answer for the upgrade menu.
 Show the clean menu. This menu gives you the chance to fully delete the
 downloaded build files from Yay's cache before redownloading a fresh copy.
 
+If 'cleanmenu' is enabled in the configuration file, you can temporarily disable it by
+using '--cleanmenu=false' on the command line
+
 .TP
 .B \-\-diffmenu
 Show the diff menu. This menu gives you the option to view diffs from
@@ -311,15 +314,15 @@ before building.
 recommended to edit pkgbuild variables unless you know what you are doing.
 
 .TP
-.B \-\-nocleanmenu
+.B \-\-nocleanmenu *Deprecated*
 Do not show the clean menu.
 
 .TP
-.B \-\-nodiffmenu
+.B \-\-nodiffmenu *Deprecated*
 Do not show the diff menu.
 
 .TP
-.B \-\-noeditmenu
+.B \-\-noeditmenu *Deprecated*
 Do not show the edit menu.
 
 .TP
@@ -368,8 +371,11 @@ checked almost instantly and not require the original pkgbuild to be downloaded.
 The slower pacaur-like devel checks can be implemented manually by piping
 a list of packages into yay (see \fBexamples\fR).
 
+If 'devel' is enabled in the configuration file, you can temporarily disable it by
+using '--devel=false' on the command line
+
 .TP
-.B \-\-nodevel
+.B \-\-nodevel *Deprecated*
 Do not check for development packages updates during sysupgrade.
 
 .TP
@@ -381,7 +387,7 @@ This allows VCS packages to easily pull an update
 instead of having to reclone the entire repo.
 
 .TP
-.B \-\-nocleanafter
+.B \-\-nocleanafter *Deprecated*
 Do not remove package sources after successful Install.
 
 .TP
@@ -394,7 +400,7 @@ During sysupgrade also compare the build time of installed packages against
 the last modification time of each package's AUR page.
 
 .TP
-.B \-\-notimeupdate
+.B \-\-notimeupdate *Deprecated*
 Do not consider build times during sysupgrade.
 
 .TP
@@ -402,7 +408,7 @@ Do not consider build times during sysupgrade.
 Separate query results by source, AUR and sync
 
 .TP
-.B \-\-noseparatesources
+.B \-\-noseparatesources *Deprecated*
 Do not separate query results by source for searching
 
 .TP
@@ -426,7 +432,7 @@ providers are found a menu will appear prompting you to pick one. This
 increases dependency resolve time although this should not be noticeable.
 
 .TP
-.B \-\-noprovides
+.B \-\-noprovides *Deprecated*
 Do not look for matching providers when searching for AUR packages.
 Yay will never show its provider menu but Pacman will still show its
 provider menu for repo packages.
@@ -437,7 +443,7 @@ Prompt to import unknown PGP keys from the \fBvalidpgpkeys\fR field of each
 PKGBUILD.
 
 .TP
-.B \-\-nopgpfetch
+.B \-\-nopgpfetch *Deprecated*
 Do not prompt to import unknown PGP keys. This is likely to cause a build
 failure unless using options such as \fB\-\-skippgpcheck\fR or a customized
 gpg config\%.
@@ -450,7 +456,7 @@ a conflict, causing a package to be removed without the user's confirmation.
 However, this is very unlikely.
 
 .TP
-.B \-\-nouseask
+.B \-\-nouseask *Deprecated*
 Manually resolve package conflicts during the install. Packages which do not
 conflict will not need to be confined manually.
 
@@ -466,7 +472,7 @@ the user's responsibility to either resolve the reason Yay exited or run
 a sysupgrade through pacman directly.
 
 .TP
-.B \-\-nocombinedupgrade
+.B \-\-nocombinedupgrade *Deprecated*
 During sysupgrade, Pacman \-Syu will be called, then the AUR upgrade will
 start. This means the upgrade menu and pkgbuild review will be performed
 after the sysupgrade has finished.
@@ -479,7 +485,7 @@ are built or a package in the build queue is needed as a dependency to build
 another package, install all the packages in the install queue.
 
 .TP
-.B \-\-nobatchinstall
+.B \-\-nobatchinstall *Deprecated*
 Always install AUR packages immediately after building them.
 
 .TP
@@ -536,7 +542,7 @@ Loop sudo calls in the background to prevent sudo from timing out during long
 builds.
 
 .TP
-.B \-\-nosudoloop
+.B \-\-nosudoloop *Deprecated*
 Do not loop sudo calls in the background.
 
 .SH EXAMPLES

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	cmdArgs := parser.MakeArguments()
 
 	// Parse command line
-	if err = cfg.ParseCommandLine(cmdArgs); err != nil {
+	if err = cfg.ParseCommandLine(cmdArgs, fallbackLog); err != nil {
 		if str := err.Error(); str != "" {
 			fallbackLog.Errorln(str)
 		}

--- a/pkg/cmd/graph/main.go
+++ b/pkg/cmd/graph/main.go
@@ -25,7 +25,7 @@ func handleCmd(logger *text.Logger) error {
 	}
 
 	cmdArgs := parser.MakeArguments()
-	if errP := cfg.ParseCommandLine(cmdArgs); errP != nil {
+	if errP := cfg.ParseCommandLine(cmdArgs, logger); errP != nil {
 		return errP
 	}
 

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -42,30 +42,35 @@ func (c *Configuration) extractYayOptions(a *parser.Arguments) {
 }
 
 func (c *Configuration) handleOption(option, value string) bool {
+	boolValue, err := strconv.ParseBool(value)
+	if err != nil {
+		boolValue = true
+	}
+
 	switch option {
 	case "aururl":
 		c.AURURL = value
 	case "aurrpcurl":
 		c.AURRPCURL = value
 	case "save":
-		c.SaveConfig = true
+		c.SaveConfig = boolValue
 	case "afterclean", "cleanafter":
-		c.CleanAfter = true
-	case "noafterclean", "nocleanafter":
-		c.CleanAfter = false
+		c.CleanAfter = boolValue
+	case "noafterclean", "nocleanafter": // DEPRECATED
+		c.CleanAfter = !boolValue
 	case "keepsrc":
-		c.KeepSrc = true
+		c.KeepSrc = boolValue
 	case "debug":
-		c.Debug = true
-		return false
+		c.Debug = boolValue
+		return !boolValue
 	case "devel":
-		c.Devel = true
-	case "nodevel":
-		c.Devel = false
+		c.Devel = boolValue
+	case "nodevel": // DEPRECATED
+		c.Devel = !boolValue
 	case "timeupdate":
-		c.TimeUpdate = true
-	case "notimeupdate":
-		c.TimeUpdate = false
+		c.TimeUpdate = boolValue
+	case "notimeupdate": // DEPRECATED
+		c.TimeUpdate = !boolValue
 	case "topdown":
 		c.BottomUp = false
 	case "bottomup":
@@ -84,7 +89,7 @@ func (c *Configuration) handleOption(option, value string) bool {
 	case "searchby":
 		c.SearchBy = value
 	case "noconfirm":
-		NoConfirm = true
+		NoConfirm = boolValue
 	case "config":
 		c.PacmanConf = value
 	case "redownload":
@@ -102,9 +107,9 @@ func (c *Configuration) handleOption(option, value string) bool {
 	case "norebuild":
 		c.ReBuild = parser.RebuildModeNo
 	case "batchinstall":
-		c.BatchInstall = true
-	case "nobatchinstall":
-		c.BatchInstall = false
+		c.BatchInstall = boolValue
+	case "nobatchinstall": // DEPRECATED
+		c.BatchInstall = !boolValue
 	case "answerclean":
 		c.AnswerClean = value
 	case "noanswerclean":
@@ -155,37 +160,37 @@ func (c *Configuration) handleOption(option, value string) bool {
 			c.RequestSplitN = n
 		}
 	case "sudoloop":
-		c.SudoLoop = true
-	case "nosudoloop":
-		c.SudoLoop = false
+		c.SudoLoop = boolValue
+	case "nosudoloop": // DEPRECATED
+		c.SudoLoop = !boolValue
 	case "provides":
-		c.Provides = true
-	case "noprovides":
-		c.Provides = false
+		c.Provides = boolValue
+	case "noprovides": // DEPRECATED
+		c.Provides = !boolValue
 	case "pgpfetch":
-		c.PGPFetch = true
-	case "nopgpfetch":
-		c.PGPFetch = false
+		c.PGPFetch = boolValue
+	case "nopgpfetch": // DEPRECATED
+		c.PGPFetch = !boolValue
 	case "cleanmenu":
-		c.CleanMenu = true
-	case "nocleanmenu":
-		c.CleanMenu = false
+		c.CleanMenu = boolValue
+	case "nocleanmenu": // DEPRECATED
+		c.CleanMenu = !boolValue
 	case "diffmenu":
-		c.DiffMenu = true
-	case "nodiffmenu":
-		c.DiffMenu = false
+		c.DiffMenu = boolValue
+	case "nodiffmenu": // DEPRECATED
+		c.DiffMenu = !boolValue
 	case "editmenu":
-		c.EditMenu = true
-	case "noeditmenu":
-		c.EditMenu = false
+		c.EditMenu = boolValue
+	case "noeditmenu": // DEPRECATED
+		c.EditMenu = !boolValue
 	case "useask":
-		c.UseAsk = true
-	case "nouseask":
-		c.UseAsk = false
+		c.UseAsk = boolValue
+	case "nouseask": // DEPRECATED
+		c.UseAsk = !boolValue
 	case "combinedupgrade":
-		c.CombinedUpgrade = true
-	case "nocombinedupgrade":
-		c.CombinedUpgrade = false
+		c.CombinedUpgrade = boolValue
+	case "nocombinedupgrade": // DEPRECATED
+		c.CombinedUpgrade = !boolValue
 	case "a", "aur":
 		c.Mode = parser.ModeAUR
 	case "repo":
@@ -199,9 +204,9 @@ func (c *Configuration) handleOption(option, value string) bool {
 	case "askyesremovemake":
 		c.RemoveMake = "askyes"
 	case "separatesources":
-		c.SeparateSources = true
-	case "noseparatesources":
-		c.SeparateSources = false
+		c.SeparateSources = boolValue
+	case "noseparatesources": // DEPRECATED
+		c.SeparateSources = !boolValue
 	default:
 		return false
 	}

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -5,21 +5,24 @@ import (
 	"strings"
 
 	"github.com/Jguer/yay/v12/pkg/settings/parser"
+	"github.com/Jguer/yay/v12/pkg/text"
+
+	"github.com/leonelquinteros/gotext"
 )
 
-func (c *Configuration) ParseCommandLine(a *parser.Arguments) error {
+func (c *Configuration) ParseCommandLine(a *parser.Arguments, logger *text.Logger) error {
 	if err := a.Parse(); err != nil {
 		return err
 	}
 
-	c.extractYayOptions(a)
+	c.extractYayOptions(a, logger)
 
 	return nil
 }
 
-func (c *Configuration) extractYayOptions(a *parser.Arguments) {
+func (c *Configuration) extractYayOptions(a *parser.Arguments, logger *text.Logger) {
 	for option, value := range a.Options {
-		if c.handleOption(option, value.First()) {
+		if c.handleOption(option, value.First(), logger) {
 			a.DelArg(option)
 		}
 	}
@@ -41,7 +44,7 @@ func (c *Configuration) extractYayOptions(a *parser.Arguments) {
 	}
 }
 
-func (c *Configuration) handleOption(option, value string) bool {
+func (c *Configuration) handleOption(option, value string, logger *text.Logger) bool {
 	boolValue, err := strconv.ParseBool(value)
 	if err != nil {
 		boolValue = true
@@ -56,7 +59,8 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.SaveConfig = boolValue
 	case "afterclean", "cleanafter":
 		c.CleanAfter = boolValue
-	case "noafterclean", "nocleanafter": // DEPRECATED
+	case "noafterclean", "nocleanafter":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--cleanafter=false' instead", option))
 		c.CleanAfter = !boolValue
 	case "keepsrc":
 		c.KeepSrc = boolValue
@@ -65,11 +69,13 @@ func (c *Configuration) handleOption(option, value string) bool {
 		return !boolValue
 	case "devel":
 		c.Devel = boolValue
-	case "nodevel": // DEPRECATED
+	case "nodevel":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--devel=false' instead", option))
 		c.Devel = !boolValue
 	case "timeupdate":
 		c.TimeUpdate = boolValue
-	case "notimeupdate": // DEPRECATED
+	case "notimeupdate":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--timeupdate=false' instead", option))
 		c.TimeUpdate = !boolValue
 	case "topdown":
 		c.BottomUp = false
@@ -108,7 +114,8 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.ReBuild = parser.RebuildModeNo
 	case "batchinstall":
 		c.BatchInstall = boolValue
-	case "nobatchinstall": // DEPRECATED
+	case "nobatchinstall":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--batchinstall=false' instead", option))
 		c.BatchInstall = !boolValue
 	case "answerclean":
 		c.AnswerClean = value
@@ -161,35 +168,43 @@ func (c *Configuration) handleOption(option, value string) bool {
 		}
 	case "sudoloop":
 		c.SudoLoop = boolValue
-	case "nosudoloop": // DEPRECATED
+	case "nosudoloop":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--sudoloop=false' instead", option))
 		c.SudoLoop = !boolValue
 	case "provides":
 		c.Provides = boolValue
-	case "noprovides": // DEPRECATED
+	case "noprovides":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--provides=false' instead", option))
 		c.Provides = !boolValue
 	case "pgpfetch":
 		c.PGPFetch = boolValue
-	case "nopgpfetch": // DEPRECATED
+	case "nopgpfetch":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--pgpfetch=false' instead", option))
 		c.PGPFetch = !boolValue
 	case "cleanmenu":
 		c.CleanMenu = boolValue
-	case "nocleanmenu": // DEPRECATED
+	case "nocleanmenu":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--cleanmenu=false' instead", option))
 		c.CleanMenu = !boolValue
 	case "diffmenu":
 		c.DiffMenu = boolValue
-	case "nodiffmenu": // DEPRECATED
+	case "nodiffmenu":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--diffmenu=false' instead", option))
 		c.DiffMenu = !boolValue
 	case "editmenu":
 		c.EditMenu = boolValue
-	case "noeditmenu": // DEPRECATED
+	case "noeditmenu":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--editmenu=false' instead", option))
 		c.EditMenu = !boolValue
 	case "useask":
 		c.UseAsk = boolValue
-	case "nouseask": // DEPRECATED
+	case "nouseask":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--useask=false' instead", option))
 		c.UseAsk = !boolValue
 	case "combinedupgrade":
 		c.CombinedUpgrade = boolValue
-	case "nocombinedupgrade": // DEPRECATED
+	case "nocombinedupgrade":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--combinedupgrade=false' instead", option))
 		c.CombinedUpgrade = !boolValue
 	case "a", "aur":
 		c.Mode = parser.ModeAUR
@@ -205,7 +220,8 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.RemoveMake = "askyes"
 	case "separatesources":
 		c.SeparateSources = boolValue
-	case "noseparatesources": // DEPRECATED
+	case "noseparatesources":
+		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--separatesources=false' instead", option))
 		c.SeparateSources = !boolValue
 	default:
 		return false


### PR DESCRIPTION
This feature allows users to specify `--option=bool` instead of using `--option` and `--nooption`. Specifying nothing (or a `bool` value that isn't falsy) results in the boolean value being true.

A few notes on this PR:
1. I didn't add documentation in the manpage yet because I wasn't sure how to present it to users. Suggestions would be helpful
2. I marked the deprecated features with a `DEPRECATED` comment, but I can use a more robust deprecation system (such as a warning), if desired.
3. These options do not work for pacman/makepkg options (except for `debug` and `noconfirm`). I can add this but it may make more sense for users to only use these boolean flags for yay options.
4. The boolean flags only work with an equal sign unlike other flags that have values. I can switch it to allow `--option <bool>` too.