### PR TITLE
refactor: remove redundant `len` check

### DIFF
--- a/get.go
+++ b/get.go
@@ -26,10 +26,8 @@ func printPkgbuilds(dbExecutor download.DBSearcher, aurClient aur.QueryClient,
 		logger.Errorln(err)
 	}
 
-	if len(pkgbuilds) != 0 {
-		for target, pkgbuild := range pkgbuilds {
-			logger.Printf("\n\n# %s\n\n%s", target, string(pkgbuild))
-		}
+	for target, pkgbuild := range pkgbuilds {
+		logger.Printf("\n\n# %s\n\n%s", target, string(pkgbuild))
 	}
 
 	if len(pkgbuilds) != len(targets) {

--- a/query.go
+++ b/query.go
@@ -80,10 +80,8 @@ func syncInfo(ctx context.Context, run *runtime.Runtime,
 		missing = true
 	}
 
-	if len(info) != 0 {
-		for i := range info {
-			printInfo(run.Logger, run.Cfg, &info[i], cmdArgs.ExistsDouble("i"))
-		}
+	for i := range info {
+		printInfo(run.Logger, run.Cfg, &info[i], cmdArgs.ExistsDouble("i"))
 	}
 
 	if missing {


### PR DESCRIPTION
`len` returns 0 if the slice or map is nil. From the Go specification [^1]:

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

Therefore, an additional `len(v) != 0` check for before the loop is unnecessary.

[^1]: https://go.dev/ref/spec#For_range