### PR TITLE
Refactor AURPKGBUILDRepos and Fix Localization Command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ $(PACKAGE): $(BIN) $(RELEASE_DIR) ${MOFILES}
 locale:
 	xgotext -in . -out po
 	for lang in ${LANGS}; do \
-		test -f po/$$lang.po || msginit -l po/$$lang.po -i po/${POTFILE} -o po/$$lang.po \
+		test -f po/$$lang.po || msginit --no-translator -l po/$$lang.po -i po/${POTFILE} -o po/$$lang.po; \
 		msgmerge -U po/$$lang.po po/${POTFILE}; \
 		touch po/$$lang.po; \
 	done

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,63 +1,63 @@
-# 
+#
 # Translators:
 # Davidmp <medipas@gmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Davidmp <medipas@gmail.com>, 2023\n"
 "Language-Team: Catalan (https://app.transifex.com/yay-1/teams/123732/ca/)\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr "(Els fitxers de compilació ja existeixen)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr "(Instal·lat)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr "[Instal·lat]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "No hi ha res per fer."
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr "%s [T]ot [Av]orta [I]nstal·lat [No] instal·lat o (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s ja fet: se n'omet la construcció."
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s no està establert."
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s és present."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s està al dia: s'omet."
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s per actualitzar / instal·lar."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "%s també s'instal·larà per a aquesta operació."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, requerit per %s"
 
@@ -77,27 +77,83 @@ msgstr "%s: no es pot usar l'objectiu amb l'opció --repo, s'omet."
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: s'ignora l'actualització del paquet (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: el paquet local (%s) és més nou que el de l'AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "%s: establiu les variables d'entorn AUR_NOMDUSUARI i AUR_CONTRASENYA per "
 "votar."
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD baixat de l'ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD baixat: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD baixat: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) S'analitza SRCINFO: %s"
 
@@ -117,7 +173,7 @@ msgstr "(Orfes)"
 msgid "(Out-of-date: %s)"
 msgstr "(Obsolet: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL de l'AUR"
 
@@ -125,7 +181,7 @@ msgstr "URL de l'AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Afegiu %s o %s a les variables d'entorn."
 
@@ -137,7 +193,7 @@ msgstr "Eviteu executar el yay com a root / sudo."
 msgid "Check Dependency"
 msgstr "Comprova'n la dependència"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Comprova les dependències"
 
@@ -145,15 +201,15 @@ msgstr "Comprova les dependències"
 msgid "Checking development packages..."
 msgstr "Es comproven els paquets de desenvolupament..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Es neteja (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Té conflicte amb"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Se suprimeix (%d/%d): %s"
 
@@ -161,15 +217,15 @@ msgstr "Se suprimeix (%d/%d): %s"
 msgid "Dependency"
 msgstr "Dependència"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Depèn de"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Descripció"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Diferències per mostrar?"
 
@@ -177,19 +233,19 @@ msgstr "Diferències per mostrar?"
 msgid "Disable 'provides' setting by default"
 msgstr "Desactiva la configuració de \"proporciona\" per defecte."
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Voleu suprimir TOTS els paquets de l'AUR de la memòria cau?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Voleu suprimir TOTS els fitxers de l'AUR sense seguiment?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Voleu suprimir tots els altres paquets de l'AUR de la memòria cau?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Amb què voleu editar el PKGBUILD?"
 
@@ -197,7 +253,7 @@ msgstr "Amb què voleu editar el PKGBUILD?"
 msgid "Error during AUR search: %s\n"
 msgstr "Error durant la cerca a l'AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "L'exclusió de paquets pot provocar actualitzacions parcials i trencar els "
@@ -207,32 +263,32 @@ msgstr ""
 msgid "Explicit"
 msgstr "Explícit"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Paquets instal·lats explícitament: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "No s'ha pogut trobar el paquet de l'AUR per a"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Ha fallat instal·lar la capa. Es passa a la següent."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "Ha fallat instal·lar els paquets següents. Cal intervenció manual:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Enviat primer"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Paquets de l'AUR obsolets marcats:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Paquets forans instal·lats: %s"
 
@@ -240,31 +296,31 @@ msgstr "Paquets forans instal·lats: %s"
 msgid "Found git repo: %s"
 msgstr "S'ha trobat el repositori git: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB ha acabat. No s'ha instal·lat cap paquet."
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Grups"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Ho importo?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "S'importen claus amb gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Paraules clau"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Darrera modificació"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Llicències"
 
@@ -272,7 +328,7 @@ msgstr "Llicències"
 msgid "Local"
 msgstr "Local"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Mantenidor"
 
@@ -280,11 +336,11 @@ msgstr "Mantenidor"
 msgid "Make Dependency"
 msgstr "Dependència de construcció"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Dependències de construcció"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Manquen paquets de depuració de l'AUR:"
 
@@ -292,35 +348,40 @@ msgstr "Manquen paquets de depuració de l'AUR:"
 msgid "Missing"
 msgstr "Manca"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Nom"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "No s'ha trobat cap paquet d'AUR per a"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "No s'ha trobat cap paquet d'AUR per a"
+
+#: print.go:225
 msgid "None"
 msgstr "Cap"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Dependències opcionals"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Paquets d'AUR orfes (no mantinguts):"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Obsolet"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Cal importar claus PGP:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD actualitzat, s'omet la baixada: %s"
 
@@ -328,56 +389,61 @@ msgstr "PKGBUILD actualitzat, s'omet la baixada: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "PKGBUILDs per editar?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID de la base de paquets"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Base de paquets"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Paquets no a l'AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Paquets per a la neteja de la construcció?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Paquets per excloure"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Paquets per excloure: (p. ex.: \"1 2 3\", \"1-3\", \"^4\" o nom del repositori)"
+msgstr ""
+"Paquets per excloure: (p. ex.: \"1 2 3\", \"1-3\", \"^4\" o nom del "
+"repositori)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Paquets per instal·lar (p. ex.: 1 2 3, 1-3 o ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularitat"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Voleu continuar la instal·lació?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Proporciona"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
-msgstr ""
-"Suprimeixo les dependències de construcció després de la instal·lació?"
+msgstr "Suprimeixo les dependències de construcció després de la instal·lació?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repositori de l'AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repositori"
 
@@ -397,15 +463,15 @@ msgstr "Se cerquen actualitzacions a les bases de dades..."
 msgid "Showing repo packages only"
 msgstr "Es mostren només paquets dels repositoris."
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Mida de la memòria cau del pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Mida de la memòria cau del yay %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL de la instantània"
 
@@ -413,72 +479,72 @@ msgstr "URL de la instantània"
 msgid "Sync"
 msgstr "Sincronització"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Els deu paquets més grossos:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Els paquets següents no són compatibles amb la vostra arquitectura:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Hi ha %d proveïdors disponibles per a %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr ""
 "Pot ser que hi hagi una altra instància del Pacman en execució. S'espera..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Mida total ocupada pels paquets: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Total de paquets instal·lats: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Intento construir-los tanmateix?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "No es pot netejar:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "No s'han pogut trobar els paquets següents:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "No es pot gestionar el vot del paquet per a %s. Error: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "No es pot suprimir %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Versió"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Vots"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Versió del yay: v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "Ca[p]"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -486,7 +552,7 @@ msgstr ""
 "\n"
 "Directori de construcció:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -498,19 +564,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "s'avorta a causa de l'usuari"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "argument '-' especificat sense entrada a stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "no es pot trobar PKGBUILD i SRCINFO al directori"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "no es pot trobar el nom del paquet: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "no s'ha pogut trobar PKGDEST per a %s"
 
@@ -518,11 +584,11 @@ msgstr "no s'ha pogut trobar PKGDEST per a %s"
 msgid "could not find all required packages"
 msgstr "no s'han pogut trobar tots els paquets necessaris"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "no s'ha pogut trobar cap arxiu de paquets llistat a %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "dependència"
 
@@ -530,11 +596,11 @@ msgstr "dependència"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "la comprovació del paquet ha fallat: %s ha trobat un error"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "l'editor no ha sortit correctament, s'avorta: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "error en baixar les fonts: %s"
 
@@ -542,19 +608,19 @@ msgstr "error en baixar les fonts: %s"
 msgid "error fetching %s: %s"
 msgstr "error en obtenir %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "error en instal·lar paquets dels repositoris"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "error d'instal·lació:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "error de construcció: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "error en combinar %s: %s"
 
@@ -562,19 +628,19 @@ msgstr "error en combinar %s: %s"
 msgid "error reading %s"
 msgstr "error en llegir %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "error en actualitzar les bases de dades"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "error en restablir %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "error en actualitzar el motiu d'instal·lació del paquet a %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "explícit"
 
@@ -582,27 +648,27 @@ msgstr "explícit"
 msgid "failed to create directory '%s': %s"
 msgstr "ha fallat crear el directori %s: %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "ha fallat obrir el fitxer de configuració %s: %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "ha fallat analitzar %s, s'omet: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "no s'ha pogut analitzar %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "ha fallat analitzar .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "ha fallat llegir el fitxer de configuració %s: %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "ha fallat obtenir la cau de l'AUR"
 
@@ -616,7 +682,7 @@ msgstr ""
 msgid "input too long"
 msgstr "entrada massa llarga"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "número no vàlid: %s"
 
@@ -624,7 +690,7 @@ msgstr "número no vàlid: %s"
 msgid "invalid option '%s'"
 msgstr "opció no vàlida: %s"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr "opció no vàlida: \"--deps\" i \"--explicit\" no es poden usar juntes"
 
@@ -632,11 +698,11 @@ msgstr "opció no vàlida: \"--deps\" i \"--explicit\" no es poden usar juntes"
 msgid "invalid repository"
 msgstr "repositori no vàlid"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "valor no vàlid: %d no és entre %d i %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "sense claus per importar"
 
@@ -644,15 +710,15 @@ msgstr "sense claus per importar"
 msgid "no query was executed"
 msgstr "no s'ha executat cap consulta"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "no s'han especificat directoris de destinació"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "no"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "no hi ha res per instal·lar per %s"
 
@@ -660,7 +726,11 @@ msgstr "no hi ha res per instal·lar per %s"
 msgid "only one operation may be used at a time"
 msgstr "només es pot usar una operació alhora"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "no s'ha trobat el paquet %s"
 
@@ -672,30 +742,30 @@ msgstr "paquet no trobat a l'AUR"
 msgid "package not found in repos"
 msgstr "paquet no trobat als repositoris"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "paquet"
 msgstr[1] "paquets"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "problema d'importació de claus"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "se suprimeixen paquets de l'AUR de la memòria cau..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr ""
 "se suprimeixen els fitxers de l'AUR sense seguiment de la memòria cau..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "el PKGDEST per a %s està llistat per makepkg però no existeix:%s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "No hi ha res per fer."
 
@@ -703,14 +773,14 @@ msgstr "No hi ha res per fer."
 msgid "unable to CreateHandle: %s"
 msgstr "no se'n pot crear el maneig: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "operació no manejada"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "versió desconeguda"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "sí"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,72 +1,70 @@
-# 
+#
 # Translators:
 # Fjuro Fjuro, 2022
 # walken, 2023
 # Matej Borsky, 2023
 # Matyáš Černý, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Matyáš Černý, 2023\n"
 "Language-Team: Czech (https://app.transifex.com/yay-1/teams/123732/cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr "(Soubory sestavení existují)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr "(Nainstalováno)"
 
-#: pkg/dep/depCheck.go:310
-msgid " (Target"
-msgstr "(Cíl"
-
-#: pkg/dep/depCheck.go:312
-msgid " (Wanted by: "
-msgstr "(Požaduje:"
-
-#: cmd.go:472
+#: cmd.go:463
 msgid " [Installed]"
 msgstr "[Nainstalováno]"
 
-#: cmd.go:425 install.go:172 install.go:206 vote.go:34
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "není co dělat"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]Vše [Ab]Zrušit [I]Nainstalováno [No]Nenainstalováno nebo (1 2 3, 1-3, "
 "^4)"
 
-#: aur_install.go:274 install.go:741
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%sjiž existuje -- přeskakuji sestavení"
 
-#: pkg/menus/edit_menu.go:58
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s není nastaven"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s je přítomný"
 
-#: pkg/dep/dep_graph.go:385 aur_install.go:271 install.go:727
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s je aktualizován -- přeskakuji"
 
-#: install.go:642
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s není uspokojen, vymazávání fronty instalací"
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
+msgstr "Balíčky k aktualizaci/instalaci."
 
-#: pkg/pgp/keys.go:127
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
+
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, vyžadován balíčkem %s"
 
@@ -82,58 +80,114 @@ msgstr "%s: nelze použít cíl s možností --aur -- přeskakuji"
 msgid "%s: can't use target with option --repo -- skipping"
 msgstr "%s: nelze použít cíl s možností --repo -- přeskakuji"
 
-#: pkg/upgrade/sources.go:60
+#: pkg/upgrade/sources.go:57
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: ignoruji aktualizaci balíčku (%s => %s)"
 
-#: upgrade.go:165
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: místní (%s) je novější než AUR (%s) "
 
-#: vote.go:49
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "prosím nastavte proměnné prostředí AUR_USERNAME a AUR_PASSWORD pro hodnocení"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) Stažen PKGBUILD z ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) Stažen PKGBUILD: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) Stažen PKGBUILD: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Parsování SRCINFO: %s"
 
-#: pkg/query/types.go:70 pkg/query/types.go:101
+#: pkg/query/types.go:72 pkg/query/types.go:103
 msgid "(Installed)"
 msgstr "(Nainstalováno)"
 
-#: pkg/query/types.go:68 pkg/query/types.go:99
+#: pkg/query/types.go:70 pkg/query/types.go:101
 msgid "(Installed: %s)"
 msgstr "(Nainstalováno: %s)"
 
-#: pkg/query/types.go:59
+#: pkg/query/types.go:61
 msgid "(Orphaned)"
 msgstr "(Osamocené)"
 
-#: pkg/query/types.go:63
+#: pkg/query/types.go:65
 msgid "(Out-of-date: %s)"
 msgstr "(Zastaralé: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL AUR"
 
-#: pkg/dep/dep_graph.go:74
+#: pkg/dep/dep_graph.go:75
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:59
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Přidejte %s nebo %s do svých proměnných prostředí "
 
@@ -141,55 +195,43 @@ msgstr "Přidejte %s nebo %s do svých proměnných prostředí "
 msgid "Avoid running yay as root/sudo."
 msgstr "Vyhněte se spuštění yay jako root/sudo."
 
-#: pkg/dep/dep_graph.go:62
+#: pkg/dep/dep_graph.go:63
 msgid "Check Dependency"
 msgstr "Zkontrolovat závislost"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Zkontrolovat závislosti"
 
-#: pkg/upgrade/service.go:78 upgrade.go:95
+#: pkg/upgrade/service.go:90
 msgid "Checking development packages..."
 msgstr "Kontrola vývojových balíčků..."
 
-#: pkg/dep/depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "Kontrola konfliktů..."
-
-#: pkg/dep/depCheck.go:145
-msgid "Checking for inner conflicts..."
-msgstr "Kontrola vnitřních konfliktů..."
-
-#: clean.go:214
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Čištění (%d/%d): %s"
 
-#: pkg/dep/depCheck.go:200
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr "Konfliktní balíčky budou muset být ručně potvrzeny"
-
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Konflikt s"
 
-#: pkg/menus/clean_menu.go:61 pkg/menus/clean_menu.go:108
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Mazání (%d/%d): %s"
 
-#: pkg/dep/dep_graph.go:60
+#: pkg/dep/dep_graph.go:61
 msgid "Dependency"
 msgstr "Závislost"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Závisí na"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Popis"
 
-#: pkg/menus/diff_menu.go:161 pkg/menus/diff_menu.go:194
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Zobrazit rozdíly?"
 
@@ -197,19 +239,19 @@ msgstr "Zobrazit rozdíly?"
 msgid "Disable 'provides' setting by default"
 msgstr "Zákaz nastavení 'provides' jako výchozí"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Chcete odstranit VŠECHNY balíčky AUR z mezipaměti?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Chcete odstranit VŠECHNY nesledované soubory AUR?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Chcete odstranit všechny ostatní balíčky AUR z mezipaměti?"
 
-#: pkg/menus/edit_menu.go:62
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Upravit PKGBUILD pomocí?"
 
@@ -217,314 +259,296 @@ msgstr "Upravit PKGBUILD pomocí?"
 msgid "Error during AUR search: %s\n"
 msgstr "Chyby při hledání v AUR: %s\n"
 
-#: pkg/upgrade/service.go:256
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Vyjímání balíčků může způsobovat částečné aktualizace a rozbíjet systémy."
 
-#: pkg/dep/dep_graph.go:59
+#: pkg/dep/dep_graph.go:60
 msgid "Explicit"
 msgstr "Explicitní"
 
-#: print.go:84
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Explicitně nainstalované balíčky: %s"
 
-#: pkg/dep/dep_graph.go:365 pkg/dep/dep_graph.go:454
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Chyba hledání balíčku AUR:"
 
-#: aur_install.go:104
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Chyba instalace vrstvy, zabaluji k další vrstvě."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "Selhala instalace těchto balíčků. Ruční zásah je vyžadován."
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "První odeslané"
 
-#: pkg/query/aur_warnings.go:43
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Označené zastaralé balíčky AUR:"
 
-#: print.go:83
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Neznámé nainstalované balíčky: %s"
 
-#: pkg/vcs/vcs.go:142
+#: pkg/vcs/vcs.go:144
 msgid "Found git repo: %s"
 msgstr "Nalezen repozitář git: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB dokončena. Nebyly nainstalovány žádné balíčky"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Skupiny"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Importovat?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Importování klíčů pomocí gpg..."
 
-#: pkg/dep/depCheck.go:155
-msgid "Inner conflicts found:"
-msgstr "Nalezeny vnitřní konflikty:"
-
-#: pkg/dep/depCheck.go:173
-msgid "Installing %s will remove:"
-msgstr "Instalací %s odstraníte:"
-
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Klíčová slova"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Naposledy upraveno"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Licence"
 
-#: pkg/dep/dep_graph.go:76
+#: pkg/dep/dep_graph.go:77
 msgid "Local"
 msgstr "Místní"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Správce"
 
-#: pkg/dep/dep_graph.go:61
+#: pkg/dep/dep_graph.go:62
 msgid "Make Dependency"
 msgstr "Závislosti pro sestavení"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Vytvořit závislosti"
 
-#: pkg/query/aur_warnings.go:33
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Chybějící ladicí balíčky AUR:"
 
-#: pkg/dep/dep_graph.go:78
+#: pkg/dep/dep_graph.go:79
 msgid "Missing"
 msgstr "Chybějící"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Název"
 
-#: pkg/dep/dep_graph.go:370 pkg/dep/dep_graph.go:467
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "AUR balíček nenalezen pro"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "AUR balíček nenalezen pro"
+
+#: print.go:225
 msgid "None"
 msgstr "Žádné"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Volitelné závislosti"
 
-#: pkg/query/aur_warnings.go:38
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Osamocené (neudržované) balíčky AUR:"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Zastaralé"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Je třeba importovat klíče PGP:"
 
-#: install.go:265 vcs.go:46
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
-msgstr "PKGBUILD je aktuální, přeskakuji (%d/%d): %s"
-
-#: preparer.go:226
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD je aktuální, přeskakuji: %s"
 
-#: pkg/menus/edit_menu.go:132 pkg/menus/edit_menu.go:164
+#: pkg/menus/edit_menu.go:130
 msgid "PKGBUILDs to edit?"
 msgstr "PKGBUILDy k upravení?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "Základní ID aplikace"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Základ aplikace"
 
-#: pkg/dep/depCheck.go:170
-msgid "Package conflicts found:"
-msgstr "Nalezeny konflikty balíčků:"
-
-#: pkg/query/aur_warnings.go:28
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Balíčky mimo AUR:"
 
-#: pkg/menus/clean_menu.go:53 pkg/menus/clean_menu.go:100
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Balíčky ke cleanBuild?"
 
-#: pkg/dep/dep_graph.go:215 upgrade.go:213
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Balíčky k vyjmutí."
 
-#: pkg/upgrade/service.go:255
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Balíčky k vyloučení: (např.: \"1 2 3\", \"1-3\", \"^4\" nebo název repozitáře)"
+msgstr ""
+"Balíčky k vyloučení: (např.: \"1 2 3\", \"1-3\", \"^4\" nebo název "
+"repozitáře)"
 
-#: cmd.go:406
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Balíčky k instalaci (např.: 1 2 3, 1-3 nebo ^4)"
 
-#: upgrade.go:210
-msgid "Packages to upgrade."
-msgstr "Balíčky k aktualizaci"
-
-#: pkg/upgrade/service.go:252
-msgid "Packages to upgrade/install."
-msgstr "Balíčky k aktualizaci/instalaci."
-
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularita"
 
-#: pkg/menus/diff_menu.go:173 pkg/menus/diff_menu.go:206
-#: pkg/menus/edit_menu.go:143 pkg/menus/edit_menu.go:177
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Pokračovat v instalaci?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Poskytuje"
 
-#: pkg/query/aur_info.go:89
-msgid "Querying AUR..."
-msgstr "Prohledávání AUR..."
-
-#: install.go:236 preparer.go:108
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Odstranit vytvořené závislosti po instalaci?"
 
-#: pkg/dep/depPool.go:503 pkg/dep/dep_graph.go:631
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repozitář AUR"
 
-#: pkg/db/ialpm/alpm.go:191 print.go:25
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repozitář"
 
-#: pkg/dep/dep_graph.go:77
+#: pkg/dep/dep_graph.go:78
 msgid "SRCINFO"
 msgstr "SRCINFO"
 
-#: pkg/upgrade/service.go:63 upgrade.go:73
+#: pkg/upgrade/service.go:72
 msgid "Searching AUR for updates..."
 msgstr "Prohledávání AUR pro aktualizace..."
 
-#: pkg/upgrade/service.go:142 upgrade.go:62
+#: pkg/upgrade/service.go:160
 msgid "Searching databases for updates..."
 msgstr "Prohledávání databází k aktualizaci..."
 
-#: pkg/query/query_builder.go:191
+#: pkg/query/query_builder.go:214
 msgid "Showing repo packages only"
 msgstr "Zobrazování pouze balíčků repozitáře"
 
-#: print.go:88
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Velikost mezipaměti pacman %s: %s"
 
-#: print.go:91
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Velikost mezipaměti yay %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL snapshotu"
 
-#: pkg/dep/dep_graph.go:75
+#: pkg/dep/dep_graph.go:76
 msgid "Sync"
 msgstr "Synchronizace"
 
-#: print.go:93
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Deset největších balíčků"
 
-#: install.go:495 sync.go:183
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Následující balíčky nejsou kompatibilní s vaší architekturou:"
 
-#: pkg/db/ialpm/alpm.go:179 pkg/dep/depPool.go:499 pkg/dep/dep_graph.go:627
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Pro %s je dostupných %d poskytovatelů:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Možná běží další instance Pacman. Čekání..."
 
-#: print.go:85
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Celková velikost zabraná balíčky: %s"
 
-#: print.go:82
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Celkem nainstalovaných balíčků: %s"
 
-#: install.go:503 sync.go:191
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Pokusit se je přesto sestavit?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:192 pkg/menus/clean_menu.go:64 pkg/menus/clean_menu.go:70
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Nepodařilo se vyčistit:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Nepodařilo se nalézt následující balíčky:"
 
-#: vote.go:21
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Nelze hlasovat pro balíček: %s. chyba: %s"
 
-#: clean.go:169
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Nelze odebrat %s:%s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Verze"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Hlasy"
 
-#: print.go:80
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Verze yay v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]Žádné"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -532,7 +556,7 @@ msgstr ""
 "\n"
 "Adresář sestavení:"
 
-#: pkg/db/ialpm/alpm.go:201 pkg/dep/depPool.go:513 pkg/dep/dep_graph.go:641
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -548,15 +572,15 @@ msgstr "rušení kvůli uživateli"
 msgid "argument '-' specified without input on stdin"
 msgstr "argument '-' použit bez vstupu na stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "PKGBUILD a .SRCINFO nebyly nalezeny ve složce"
 
-#: install.go:532
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "nepodařilo se nalézt název balíčku: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "nepodařilo se nalézt PKGDEST pro: %s"
 
@@ -564,31 +588,23 @@ msgstr "nepodařilo se nalézt PKGDEST pro: %s"
 msgid "could not find all required packages"
 msgstr "Nepodařilo se nalézt všechny požadované balíčky"
 
-#: pkg/dep/depCheck.go:303
-msgid "could not find all required packages:"
-msgstr "Nepodařilo se nalézt všechny požadované balíčky:"
-
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "nenalezeny žádné archivy balíčků v %s"
 
-#: install.go:788
-msgid "could not find srcinfo for: %s"
-msgstr "nepodařilo se nalézt srcinfo pro: %s"
-
-#: errors.go:26
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "závislost"
 
-#: pkg/vcs/vcs.go:94 pkg/vcs/vcs.go:98
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "kontrola devel balíčku selhala: '%s' narazil na chybu"
 
-#: pkg/menus/edit_menu.go:111
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "editor nebyl úspěšně ukončen, rušení: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "chyba při stahování zdrojů: %s"
 
@@ -596,20 +612,19 @@ msgstr "chyba při stahování zdrojů: %s"
 msgid "error fetching %s: %s"
 msgstr "chyba při načítání %s: %s"
 
-#: install.go:321 install.go:455 local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "chyba při instalaci balíčků repozitáře"
 
-#: aur_install.go:236 aur_install.go:240
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "chyba při instalaci:"
 
-#: aur_install.go:204 aur_install.go:208 install.go:683 install.go:724
-#: install.go:738 install.go:752
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "chyba při vytváření: %s"
 
-#: install.go:588
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "chyba při slučování %s: %s"
 
@@ -617,19 +632,19 @@ msgstr "chyba při slučování %s: %s"
 msgid "error reading %s"
 msgstr "chyba při čtení %s"
 
-#: install.go:110 sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "chyba při obnovování databází"
 
-#: clean.go:220 install.go:581
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "chyba při resetování %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "chyba při aktualizaci důvodu instalace balíčku na"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "explicitní"
 
@@ -637,31 +652,31 @@ msgstr "explicitní"
 msgid "failed to create directory '%s': %s"
 msgstr "nepodařilo se vytvořit adresář '%s': %s"
 
-#: pkg/settings/config.go:286
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "nepodařilo se otevřít konfigurační soubor '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "nepodařilo se parsovat %s -- přeskakuji: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "nepodařilo se parsovat %s: %s"
 
-#: local_install.go:82
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "nepodařilo se parsovat .SRCINFO"
 
-#: pkg/settings/config.go:296
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "nepodařilo se přečíst konfigurační soubor '%s': %s"
 
-#: pkg/settings/runtime.go:74
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "nepodařilo se získat aur Cache"
 
-#: pkg/upgrade/sources.go:30
+#: pkg/upgrade/sources.go:27
 msgid "ignoring package devel upgrade (no AUR info found):"
 msgstr "ignoruji vývojovou aktualizaci balíčku (AUR informace nenalezeny)"
 
@@ -669,7 +684,7 @@ msgstr "ignoruji vývojovou aktualizaci balíčku (AUR informace nenalezeny)"
 msgid "input too long"
 msgstr "vstup příliš dlouhý"
 
-#: pkg/db/ialpm/alpm.go:222 pkg/dep/depPool.go:533 pkg/dep/dep_graph.go:662
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "neplatné číslo: %s"
 
@@ -677,20 +692,19 @@ msgstr "neplatné číslo: %s"
 msgid "invalid option '%s'"
 msgstr "neplatná možnost '%s'"
 
-#: cmd.go:208
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
-msgstr ""
-"neplatná možnost: '--deps' a '--explicit' nemohou být použity současně"
+msgstr "neplatná možnost: '--deps' a '--explicit' nemohou být použity současně"
 
-#: pkg/download/abs.go:21
+#: pkg/download/abs.go:22
 msgid "invalid repository"
 msgstr "neplatný repozitář"
 
-#: pkg/db/ialpm/alpm.go:227 pkg/dep/depPool.go:538 pkg/dep/dep_graph.go:668
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "neplatná hodnota: %d není mezi %d a %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "žádné klíče k importování"
 
@@ -698,15 +712,15 @@ msgstr "žádné klíče k importování"
 msgid "no query was executed"
 msgstr "nebyl vykonán žádný dotaz"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "nebyly specifikovány cílové adresáře"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "ne"
 
-#: aur_install.go:213
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "nic k nainstalování pro %s"
 
@@ -714,39 +728,48 @@ msgstr "nic k nainstalování pro %s"
 msgid "only one operation may be used at a time"
 msgstr "naráz může být použita pouze jedna operace"
 
-#: print.go:158
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "balíček '%s' nebyl nalezen"
-
-#: pkg/dep/depCheck.go:197
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr "konflikty balíčků nelze vyřešit pomocí noconfirm, ruším"
 
 #: pkg/download/errors.go:15
 msgid "package not found in AUR"
 msgstr "balíček nenalezen v AUR"
 
-#: pkg/download/abs.go:22
+#: pkg/download/abs.go:23
 msgid "package not found in repos"
 msgstr "balíček nenalezen v repozitářích"
 
-#: pkg/pgp/keys.go:103
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "Základ aplikace"
+msgstr[1] "Základ aplikace"
+msgstr[2] "Základ aplikace"
+msgstr[3] "Základ aplikace"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "problém při importování klíčů"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "odstraňování balíčků AUR z mezipaměti..."
 
-#: clean.go:177 clean.go:210
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "odstraňování nesledovaných souborů AUR z mezipaměti..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "PKGDEST pro %s je v seznamu makepkg ale neexistuje: %s"
 
-#: sync.go:110
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "není co dělat"
 
@@ -754,14 +777,59 @@ msgstr "není co dělat"
 msgid "unable to CreateHandle: %s"
 msgstr "nepodařilo se CreateHandle: %s"
 
-#: cmd.go:197
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "neznámá operace"
 
-#: cmd.go:469
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "neznámá-verze"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "ano"
+
+#~ msgid " (Target"
+#~ msgstr "(Cíl"
+
+#~ msgid " (Wanted by: "
+#~ msgstr "(Požaduje:"
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s není uspokojen, vymazávání fronty instalací"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "Kontrola konfliktů..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "Kontrola vnitřních konfliktů..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr "Konfliktní balíčky budou muset být ručně potvrzeny"
+
+#~ msgid "Inner conflicts found:"
+#~ msgstr "Nalezeny vnitřní konflikty:"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "Instalací %s odstraníte:"
+
+#~ msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
+#~ msgstr "PKGBUILD je aktuální, přeskakuji (%d/%d): %s"
+
+#~ msgid "Package conflicts found:"
+#~ msgstr "Nalezeny konflikty balíčků:"
+
+#~ msgid "Packages to upgrade."
+#~ msgstr "Balíčky k aktualizaci"
+
+#~ msgid "Querying AUR..."
+#~ msgstr "Prohledávání AUR..."
+
+#~ msgid "could not find all required packages:"
+#~ msgstr "Nepodařilo se nalézt všechny požadované balíčky:"
+
+#~ msgid "could not find srcinfo for: %s"
+#~ msgstr "nepodařilo se nalézt srcinfo pro: %s"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr "konflikty balíčků nelze vyřešit pomocí noconfirm, ruším"

--- a/po/de.po
+++ b/po/de.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # Julian Neupert <julian.neupert@gmail.com>, 2021
 # Chris Boesch, 2021
@@ -13,65 +13,65 @@
 # Philip H., 2023
 # Lukas Esc, 2023
 # Severin Hamader <severin.hamader@yahoo.de>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Severin Hamader <severin.hamader@yahoo.de>, 2023\n"
 "Language-Team: German (https://app.transifex.com/yay-1/teams/123732/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (Build-Dateien sind vorhanden)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Installiert)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr "[Installiert]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " es gibt nichts zu tun"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]lle [Ab]brechen [I]nstalliert [No]nicht installiert oder (1 2 3, 1-3, "
 "^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s Bereits erledigt -- Build wird übersprungen"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s ist nicht definiert"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s ist vorhanden."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s ist bereits aktuell -- wird übersprungen"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s zu upgraden/installieren."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "%s wird für diesen Vorgang ebenfalls installiert."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, benötigt von: %s"
 
@@ -91,26 +91,82 @@ msgstr "%s: Argument --repo nicht möglich -- wird übersprungen"
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: Ignoriere Paketaktualisierung (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: lokales (%s) ist neuer als das AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "Bitte AUR_USERNAME und AUR_PASSWORD Umgebungsvariablen setzen um abzustimmen"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD von ABS heruntergeladen: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD heruntergeladen: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD heruntergeladen: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) SRCINFO geparst: %s"
 
@@ -130,7 +186,7 @@ msgstr "(Verwaist)"
 msgid "(Out-of-date: %s)"
 msgstr "(Veraltet: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR-URL"
 
@@ -138,7 +194,7 @@ msgstr "AUR-URL"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "%s oder %s zu den Umgebungsvariablen hinzufügen"
 
@@ -150,7 +206,7 @@ msgstr "Vermeide es yay als root/sudo zu nutzen!"
 msgid "Check Dependency"
 msgstr "Überprüfe Abhängigkeiten"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Prüfe Abhängigkeiten"
 
@@ -158,15 +214,15 @@ msgstr "Prüfe Abhängigkeiten"
 msgid "Checking development packages..."
 msgstr "Prüfe Entwicklungspakete..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Säubere (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Ist in Konflikt mit"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Lösche (%d/%d): %s"
 
@@ -174,15 +230,15 @@ msgstr "Lösche (%d/%d): %s"
 msgid "Dependency"
 msgstr "Abhängigkeit"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Ist abhängig von"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Beschreibung"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Unterschiede zeigen?"
 
@@ -190,19 +246,19 @@ msgstr "Unterschiede zeigen?"
 msgid "Disable 'provides' setting by default"
 msgstr "'provides' Einstellung automatisch abschalten"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Wollen Sie ALLE AUR-Pakete aus dem Cache entfernen?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Wollen Sie ALLE nicht überwachten AUR-Dateien entfernen?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Wollen Sie alle anderen AUR-Pakete aus dem Cache entfernen?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "PKGBUILD editieren mit?"
 
@@ -210,7 +266,7 @@ msgstr "PKGBUILD editieren mit?"
 msgid "Error during AUR search: %s\n"
 msgstr "Fehler während AUR-Suche: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Das Ausschließen von Paketen kann zu teilweisen Aktualisierungen führen und "
@@ -220,36 +276,36 @@ msgstr ""
 msgid "Explicit"
 msgstr "Explizit"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Explizit installierte Pakete: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "AUR-Paket nicht gefunden für"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr ""
 "Die Installationsschicht ist fehlgeschlagen, es wird zur nächsten Schicht "
 "übergegangen."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 "Die folgenden Pakete konnten nicht installiert werden. Ein manueller "
 "Eingriff ist erforderlich:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Erstmals eingereicht"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Als nicht aktuell markierte AUR-Pakete:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Installierte Fremdpakete: %s"
 
@@ -257,31 +313,31 @@ msgstr "Installierte Fremdpakete: %s"
 msgid "Found git repo: %s"
 msgstr "Git-Repo gefunden: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB beendet. Es wurden keine Pakete installiert"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Gruppen"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Importieren?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Importiere Schlüssel mit gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Stichworte"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Zuletzt geändert"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Lizenzen"
 
@@ -289,7 +345,7 @@ msgstr "Lizenzen"
 msgid "Local"
 msgstr "Lokal"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Betreuer"
 
@@ -297,11 +353,11 @@ msgstr "Betreuer"
 msgid "Make Dependency"
 msgstr "Erstelle Abhängigkeit."
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Abhängigkeiten herstellen"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Fehlende AUR Debug-Pakete: "
 
@@ -309,35 +365,40 @@ msgstr "Fehlende AUR Debug-Pakete: "
 msgid "Missing"
 msgstr "Fehlend"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Name"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Kein AUR-Paket gefunden für"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Kein AUR-Paket gefunden für"
+
+#: print.go:225
 msgid "None"
 msgstr "Keine"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Optionale Abhängigkeiten"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Verwaiste (nicht gepflegte) AUR-Pakete:"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Veraltet"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "PGP-Schlüssel müssen importiert werden: "
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD ist auf dem neuesten Stand, überspringe Herunterladen: %s"
 
@@ -345,55 +406,60 @@ msgstr "PKGBUILD ist auf dem neuesten Stand, überspringe Herunterladen: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "Welche PKGBUILDs editieren?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "Paket-Basis-ID"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Paketbasis"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Pakete nicht im AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Pakete neu erstellen?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Auszuschließende Pakete"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Pakete zum Ausschließen: (z.B. \"1 2 3\", \"1-3\", \"^4\" oder Repo-Name)"
+msgstr ""
+"Pakete zum Ausschließen: (z.B. \"1 2 3\", \"1-3\", \"^4\" oder Repo-Name)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Zu installierende Pakete: (z.B. 1 2 3, 1-3 oder ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Beliebtheit"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Mit der Installation fortfahren?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Bietet"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Abhängigkeiten nach der Installation entfernen?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repository AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repository"
 
@@ -413,15 +479,15 @@ msgstr "Durchsuche Datenbanken nach Updates..."
 msgid "Showing repo packages only"
 msgstr "Zeige nur Repo-Pakete"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Größe des pacman-Cache %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Größe des yay-Cache %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "Snapshot-URL"
 
@@ -429,71 +495,71 @@ msgstr "Snapshot-URL"
 msgid "Sync"
 msgstr "Synchronisieren"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Die zehn größten Pakete:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Die folgenden Pakete sind mit Ihrer Architektur inkompatibel:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Es sind %d Anbieter für %s verfügbar:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Eine andere Instanz von Pacman ist aktiv. Warte..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Gesamtgröße der installierten Pakete: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Insgesamt installierte Pakete: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Build trotzdem versuchen?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Kann nicht entfernen:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Konnte die folgenden Pakete nicht finden: "
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Paketabstimmung nicht möglich für:%s. Fehler: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Kann nicht entfernt werden %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Version"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Stimmen"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay-Version v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N] Keine"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -501,7 +567,7 @@ msgstr ""
 "\n"
 "Build-Verzeichnis:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -513,19 +579,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "Abbruch durch den Benutzer"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "Argument '-' ohne Eingabe in stdin angegeben"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "kann PKGBUILD und .SRCINFO im Verzeichnis nicht finden"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "Kann Paketname nicht finden: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "Kann PKGDEST nicht finden für: %s"
 
@@ -533,11 +599,11 @@ msgstr "Kann PKGDEST nicht finden für: %s"
 msgid "could not find all required packages"
 msgstr "konnte nicht alle erforderlichen Pakete finden"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "konnte keine Paketarchive finden ist nicht aufgeführt in %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "Abhängigkeit"
 
@@ -545,11 +611,11 @@ msgstr "Abhängigkeit"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "Entwicklungstest fehlgeschlagen für Paket: '%s' Fehler gefunden."
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "Editor wurde nicht erfogreich beendet, breche ab: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "Fehler beim Herunterladen der Quellen: %s"
 
@@ -557,19 +623,19 @@ msgstr "Fehler beim Herunterladen der Quellen: %s"
 msgid "error fetching %s: %s"
 msgstr "Fehler beim Abrufen von %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "Fehler bei der Installation der Repo-Pakete"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "Fehler bei der Installation: "
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "Fehler beim Erstellen: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "Fehler beim Zusammenführen von %s: %s"
 
@@ -577,19 +643,19 @@ msgstr "Fehler beim Zusammenführen von %s: %s"
 msgid "error reading %s"
 msgstr "Fehler beim Lesen von %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "Fehler beim Aktualisieren der Datenbanken"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "Fehler beim Zurücksetzen von %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "Fehler bei der Aktualisierung der Paket-Installation aufgrund von %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "explizit"
 
@@ -597,27 +663,27 @@ msgstr "explizit"
 msgid "failed to create directory '%s': %s"
 msgstr "Fehler beim Erstellen von Verzeichnis '%s': %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "Fehler beim Öffnen der Konfigurationsdatei '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "Fehler beim Parsen von %s -- überspringe: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "Fehler beim Parsen von: %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "Fehler von Parsen von .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "Fehler beim Lesen der Konfigurationsdatei '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "Erhalten des AUR Caches ist fehlgeschlagen"
 
@@ -629,7 +695,7 @@ msgstr "ignoriere devel Paket Aktualisierung (keine AUR Info gefunden):"
 msgid "input too long"
 msgstr "Eingabe zu lang"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "Ungültige Nummer: %s"
 
@@ -637,7 +703,7 @@ msgstr "Ungültige Nummer: %s"
 msgid "invalid option '%s'"
 msgstr "Ungültige Option '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "Ungültige Option: '--deps' und '--explicit' können nicht zusammen genutzt "
@@ -647,11 +713,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "Ungültiges Repository"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "Ungültiger Wert: %d ist nicht zwischen %d und %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "Keine Schlüssel zu importieren"
 
@@ -659,15 +725,15 @@ msgstr "Keine Schlüssel zu importieren"
 msgid "no query was executed"
 msgstr "Es wurde keine Abfrage ausgeführt"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "Kein Ziel Verzeichnis angegeben"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "nein"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "nichts zu installieren für %s"
 
@@ -675,7 +741,11 @@ msgstr "nichts zu installieren für %s"
 msgid "only one operation may be used at a time"
 msgstr "Nur eine Operation kann gleichzeitig benutzt werden"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "Paket '%s' konnte nicht gefunden werden"
 
@@ -687,29 +757,29 @@ msgstr "Paket nicht im AUR gefunden"
 msgid "package not found in repos"
 msgstr "Paket nicht in den Repos gefunden"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "Paket"
 msgstr[1] "Pakete"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "Problem beim Importieren der Schlüssel"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "Entferne AUR-Pakete aus dem Cache..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "Entferne nicht überwachte AUR-Dateien aus dem Cache..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "PKGDEST für %s ist in MAKEPKG aufgeführt, existiert aber nicht: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "es gibt nichts zu tun"
 
@@ -717,14 +787,14 @@ msgstr "es gibt nichts zu tun"
 msgid "unable to CreateHandle: %s"
 msgstr "Kann CreateHandle nicht erstellen: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "Unbehandelte Operation"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "Unbekannte Version"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "ja"

--- a/po/en.po
+++ b/po/en.po
@@ -1,59 +1,57 @@
 msgid ""
 msgstr ""
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr ""
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr ""
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr ""
 
-#: cmd.go:418
-#: vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr ""
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr ""
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr ""
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr ""
 
-#: pkg/dep/dep_graph.go:431
-#: aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr ""
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr ""
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr ""
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr ""
 
@@ -73,34 +71,88 @@ msgstr ""
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr ""
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr ""
 
-#: vote.go:50
-msgid "%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
+#: vote.go:51
+msgid ""
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
+msgstr ""
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
 msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr ""
 
-#: pkg/download/aur.go:84
-#: pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr ""
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr ""
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr ""
 
-#: pkg/query/types.go:72
-#: pkg/query/types.go:103
+#: pkg/query/types.go:72 pkg/query/types.go:103
 msgid "(Installed)"
 msgstr ""
 
-#: pkg/query/types.go:70
-#: pkg/query/types.go:101
+#: pkg/query/types.go:70 pkg/query/types.go:101
 msgid "(Installed: %s)"
 msgstr ""
 
@@ -112,7 +164,7 @@ msgstr ""
 msgid "(Out-of-date: %s)"
 msgstr ""
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr ""
 
@@ -120,7 +172,7 @@ msgstr ""
 msgid "AUR"
 msgstr ""
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr ""
 
@@ -132,7 +184,7 @@ msgstr ""
 msgid "Check Dependency"
 msgstr ""
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr ""
 
@@ -140,15 +192,15 @@ msgstr ""
 msgid "Checking development packages..."
 msgstr ""
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr ""
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr ""
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr ""
 
@@ -156,15 +208,15 @@ msgstr ""
 msgid "Dependency"
 msgstr ""
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr ""
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr ""
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr ""
 
@@ -172,19 +224,19 @@ msgstr ""
 msgid "Disable 'provides' setting by default"
 msgstr ""
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr ""
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr ""
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr ""
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr ""
 
@@ -192,7 +244,7 @@ msgstr ""
 msgid "Error during AUR search: %s\n"
 msgstr ""
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 
@@ -200,32 +252,32 @@ msgstr ""
 msgid "Explicit"
 msgstr ""
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:408
-#: pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr ""
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr ""
 
-#: errors.go:55
-msgid "Failed to install the following packages. Manual intervention is required:"
+#: pkg/sync/build/errors.go:16
+msgid ""
+"Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr ""
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr ""
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr ""
 
@@ -233,31 +285,31 @@ msgstr ""
 msgid "Found git repo: %s"
 msgstr ""
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr ""
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr ""
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr ""
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr ""
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr ""
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr ""
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr ""
 
@@ -265,7 +317,7 @@ msgstr ""
 msgid "Local"
 msgstr ""
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr ""
 
@@ -273,11 +325,11 @@ msgstr ""
 msgid "Make Dependency"
 msgstr ""
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr ""
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr ""
 
@@ -285,37 +337,39 @@ msgstr ""
 msgid "Missing"
 msgstr ""
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:413
-#: pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr ""
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+msgid "No package found for"
+msgstr ""
+
+#: print.go:225
 msgid "None"
 msgstr ""
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr ""
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr ""
 
-#: print.go:47
-#: print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr ""
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr ""
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr ""
 
@@ -323,57 +377,59 @@ msgstr ""
 msgid "PKGBUILDs to edit?"
 msgstr ""
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr ""
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr ""
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr ""
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr ""
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr ""
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr ""
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr ""
 
-#: pkg/menus/diff_menu.go:170
-#: pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr ""
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr ""
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr ""
 
-#: print.go:25
-#: pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr ""
 
@@ -393,15 +449,15 @@ msgstr ""
 msgid "Showing repo packages only"
 msgstr ""
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr ""
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr ""
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr ""
 
@@ -409,100 +465,99 @@ msgstr ""
 msgid "Sync"
 msgstr ""
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr ""
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:697
-#: pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr ""
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr ""
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr ""
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr ""
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr ""
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr ""
 
-#: clean.go:195
-#: pkg/menus/clean_menu.go:63
-#: pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr ""
 
-#: get.go:44
-#: get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr ""
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr ""
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr ""
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr ""
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr ""
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr ""
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr ""
 
-#: clean.go:84
-msgid "\nBuild directory:"
+#: clean.go:83
+msgid ""
+"\n"
+"Build directory:"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:711
-#: pkg/db/ialpm/alpm.go:201
-msgid "\nEnter a number (default=1): "
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
+msgid ""
+"\n"
+"Enter a number (default=1): "
 msgstr ""
 
 #: pkg/settings/errors.go:29
 msgid "aborting due to user"
 msgstr ""
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr ""
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr ""
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr ""
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr ""
 
@@ -510,25 +565,23 @@ msgstr ""
 msgid "could not find all required packages"
 msgstr ""
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr ""
 
-#: errors.go:26
-#: pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr ""
 
-#: pkg/vcs/vcs.go:96
-#: pkg/vcs/vcs.go:100
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr ""
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr ""
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr ""
 
@@ -536,21 +589,19 @@ msgstr ""
 msgid "error fetching %s: %s"
 msgstr ""
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr ""
 
-#: aur_install.go:266
-#: aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr ""
 
-#: aur_install.go:233
-#: aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr ""
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr ""
 
@@ -558,20 +609,19 @@ msgstr ""
 msgid "error reading %s"
 msgstr ""
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr ""
 
-#: clean.go:223
-#: install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr ""
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr ""
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr ""
 
@@ -579,27 +629,27 @@ msgstr ""
 msgid "failed to create directory '%s': %s"
 msgstr ""
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr ""
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr ""
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr ""
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr ""
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr ""
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr ""
 
@@ -611,8 +661,7 @@ msgstr ""
 msgid "input too long"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:732
-#: pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr ""
 
@@ -620,7 +669,7 @@ msgstr ""
 msgid "invalid option '%s'"
 msgstr ""
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 
@@ -628,12 +677,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr ""
 
-#: pkg/dep/dep_graph.go:738
-#: pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr ""
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr ""
 
@@ -641,15 +689,15 @@ msgstr ""
 msgid "no query was executed"
 msgstr ""
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr ""
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr ""
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr ""
 
@@ -657,7 +705,11 @@ msgstr ""
 msgid "only one operation may be used at a time"
 msgstr ""
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr ""
 
@@ -669,30 +721,29 @@ msgstr ""
 msgid "package not found in repos"
 msgstr ""
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr ""
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr ""
 
-#: clean.go:179
-#: clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr ""
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr ""
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr ""
 
@@ -700,14 +751,14 @@ msgstr ""
 msgid "unable to CreateHandle: %s"
 msgstr ""
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr ""
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr ""
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Ivan Garcia, 2021
@@ -8,63 +8,64 @@
 # Antonio Alvarado-Hernández, 2023
 # brandon galvis, 2023
 # Angel López, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Angel López, 2023\n"
 "Language-Team: Spanish (https://app.transifex.com/yay-1/teams/123732/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (Archivos de compilación existen)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Instalado)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Instalado]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " no hay nada que hacer"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr "%s [A]Todos [Ab]ortar [I]nstalados [No]Instalados o (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s ya creado -- omitiendo compilación"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s no está definido"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s está presente."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s está actualizado -- ignorando"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "por actualizar/instalar"
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "también será instalado para esta operación"
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, necesario para: %s"
 
@@ -86,28 +87,84 @@ msgstr ""
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: actualización del paquete ignorada (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr ""
 "%s: paquete local (%s) es más nuevo que el paquete disponible en AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "%s: por favor, configure las variables de entorno AUR_USERNAME y "
 "AUR_PASSWORD para votar"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD descargado de ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD Descargado : %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD Descargado : %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Analizando SRCINFO: %s"
 
@@ -127,7 +184,7 @@ msgstr "(Huérfano)"
 msgid "(Out-of-date: %s)"
 msgstr "(Desactualizado: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL de AUR"
 
@@ -135,7 +192,7 @@ msgstr "URL de AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Añade %s o %s a tus variables de entorno"
 
@@ -147,7 +204,7 @@ msgstr "Evite ejecutar yay como root/sudo."
 msgid "Check Dependency"
 msgstr "Verificar dependencia"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Dependencias de verificación"
 
@@ -155,15 +212,15 @@ msgstr "Dependencias de verificación"
 msgid "Checking development packages..."
 msgstr "Verificando paquetes de desarrollo..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Limpiando (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Conflictos con"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Borrando (%d/%d): %s"
 
@@ -171,15 +228,15 @@ msgstr "Borrando (%d/%d): %s"
 msgid "Dependency"
 msgstr "Dependencia"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Depende de"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Descripción"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "¿Diffs a mostrar?"
 
@@ -187,19 +244,19 @@ msgstr "¿Diffs a mostrar?"
 msgid "Disable 'provides' setting by default"
 msgstr "Deshabilitar ajuste 'provee' por omisión "
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "¿Quieres borrar TODOS los paquetes de AUR del caché?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "¿Quieres borrar TODOS los archivos de AUR sin rastrear?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "¿Quieres borrar los otros paquetes de AUR del caché?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "¿Editar PKGBUILD con?"
 
@@ -207,7 +264,7 @@ msgstr "¿Editar PKGBUILD con?"
 msgid "Error during AUR search: %s\n"
 msgstr "Error al buscar en AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Excluir paquetes puede causar actualizaciones parciales y rupturas de "
@@ -217,34 +274,34 @@ msgstr ""
 msgid "Explicit"
 msgstr "Explícito"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Paquetes explícitamente instalados: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Ha fallado en encontrar el paquete AUR para"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Ha fallado al instalar la capa, rodando hacia la siguiente capa "
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 "Ha fallado al instalar los siguientes paquetes. Una intervención manual es "
 "requerida:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Primera vez subido"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Paquetes de AUR marcados como desactualizados:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Paquetes exteriores instalados: %s"
 
@@ -252,31 +309,31 @@ msgstr "Paquetes exteriores instalados: %s"
 msgid "Found git repo: %s"
 msgstr "Repositorio git encontrado: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB finalizó. Ningún paquete fue instalado"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Grupos"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "¿Importar?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Importando llaves con gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Palabras clave"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Última vez modificado"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Licencias"
 
@@ -284,7 +341,7 @@ msgstr "Licencias"
 msgid "Local"
 msgstr "Local"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Responsable"
 
@@ -292,11 +349,11 @@ msgstr "Responsable"
 msgid "Make Dependency"
 msgstr "Crear dependencia"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Dependencias de compilación"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Paquetes de depuración de AUR faltantes"
 
@@ -304,35 +361,40 @@ msgstr "Paquetes de depuración de AUR faltantes"
 msgid "Missing"
 msgstr "Ausente"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Nombre"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Ningún paquete AUR para"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Ningún paquete AUR para"
+
+#: print.go:225
 msgid "None"
 msgstr "Ninguno"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Dependencias opcionales"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Paquetes AUR huérfanos (no mantenidos): "
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Desactualizado"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Llaves PGP a importar:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD actualizado, omitiendo descarga: %s"
 
@@ -340,55 +402,60 @@ msgstr "PKGBUILD actualizado, omitiendo descarga: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "¿PKGBUILDs a editar?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID de paquete base"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Paquete base"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Paquetes que no están en AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "¿Paquetes a limpiar antes de compilar?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Paquetes a excluir"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Paquetes a excluir: (eg: \"1 2 3\", \"1-3\", \"^4\" o nombre del repositorio)"
+msgstr ""
+"Paquetes a excluir: (eg: \"1 2 3\", \"1-3\", \"^4\" o nombre del repositorio)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Paquetes a instalar (eg.: 1 2 3, 1-3 or ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularidad"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "¿Proceder con la instalación?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Provee"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "¿Borrar dependencias de instalación después de instalar?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repositorio AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repositorio"
 
@@ -408,15 +475,15 @@ msgstr "Buscando actualizaciones en los repositorios..."
 msgid "Showing repo packages only"
 msgstr "Mostrando solamente paquetes de los repositorios"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Tamaño del cache de pacman %s:%s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Tamaño del cache de yay %s:%s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL de snapshot"
 
@@ -424,72 +491,72 @@ msgstr "URL de snapshot"
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Diez paquetes más grandes:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Los siguientes paquetes no son compatibles con su arquitectura:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Existen %d paquetes que proveen %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr ""
 "Es posible que exista otra instancia de Pacman en ejecución. Esperando..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Tamaño total ocupado por los paquetes: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Número de paquetes instalados: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "¿Intentar compilarlos de todas formas?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "No es posible limpiar: "
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "No es posible encontrar los siguientes paquetes:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "No se ha podido gestionar el voto del paquete para: %s. errar: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "No se puede eliminar %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Versión"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Votos"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Versión de yay v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]inguno"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -497,7 +564,7 @@ msgstr ""
 "\n"
 "Carpeta de compilación:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -509,19 +576,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "abortando por el usuario"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "argumento '-' especificado sin entrada en stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "no se puede encontrar PKGBUILD y .SRCINFO en el directorio"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "no es posible encontrar el paquete: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "no fue posible encontrar PKGDEST para: %s"
 
@@ -529,11 +596,11 @@ msgstr "no fue posible encontrar PKGDEST para: %s"
 msgid "could not find all required packages"
 msgstr "no se han encontrado todos los paquetes necesarios"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "no pudo encontrar ningún archivo de paquetes listado en %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "dependencia"
 
@@ -543,11 +610,11 @@ msgstr ""
 "verificación de desarrollo para el paquete fallada: '1 %s' encontrado un "
 "error"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "el editor no terminó correctamente, abortando: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "error descargando fuentes: %s"
 
@@ -555,19 +622,19 @@ msgstr "error descargando fuentes: %s"
 msgid "error fetching %s: %s"
 msgstr "error descargando %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "error instalando paquetes del repositorio"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "error al instalar:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "error compilando: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "error fusionando %s: %s"
 
@@ -575,19 +642,19 @@ msgstr "error fusionando %s: %s"
 msgid "error reading %s"
 msgstr "error leyendo %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "error refrescando las bases de datos"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "error al hacer reset en %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "error al actualizar el paquete motivo de instalación para %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "explícito"
 
@@ -595,27 +662,27 @@ msgstr "explícito"
 msgid "failed to create directory '%s': %s"
 msgstr "fallo al crear directorio '%s': %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "fracaso al abrir archivo de configuración '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "fracaso al analizar %s -- ignorando: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "fracaso al analizar %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "fallo al analizar .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "fracaso al leer archivo de configuración '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "Error al recuperar el aur Cache"
 
@@ -629,7 +696,7 @@ msgstr ""
 msgid "input too long"
 msgstr "entrada demasiado larga"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "número no válido: %s"
 
@@ -637,7 +704,7 @@ msgstr "número no válido: %s"
 msgid "invalid option '%s'"
 msgstr "opción no válida '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr "opción invalida: '--deps' y '--explicit' no deben usarse a la vez"
 
@@ -645,11 +712,11 @@ msgstr "opción invalida: '--deps' y '--explicit' no deben usarse a la vez"
 msgid "invalid repository"
 msgstr "repositorio invalido "
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "valor no válido: %d no está entre %d y %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "ninguna llave por importar"
 
@@ -657,15 +724,15 @@ msgstr "ninguna llave por importar"
 msgid "no query was executed"
 msgstr "no se ha realizado ninguna consulta"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "no se han especificado directorios de destino"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "no"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "nada que instalar para %s"
 
@@ -673,7 +740,11 @@ msgstr "nada que instalar para %s"
 msgid "only one operation may be used at a time"
 msgstr "sólo una operación se puede usar a la vez"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "paquete '%s' no fue encontrado"
 
@@ -685,30 +756,30 @@ msgstr "paquete no encontrado en AUR"
 msgid "package not found in repos"
 msgstr "paquete no encontrado en los repositorios "
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "paquete"
 msgstr[1] "paquetes"
 msgstr[2] "paquetes"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "problema al importar llaves"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "borrando paquetes AUR del caché..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "borrando archivos AUR no rastreados del caché..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "el PKGDEST para %s está listado por makepkg pero no existe: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "no hay nada que hacer"
 
@@ -716,14 +787,14 @@ msgstr "no hay nada que hacer"
 msgid "unable to CreateHandle: %s"
 msgstr "no fue posible ejecutar CreateHandle: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "operación no implementada"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "versión-desconocida"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "sí"

--- a/po/eu.po
+++ b/po/eu.po
@@ -8,424 +8,557 @@ msgstr ""
 "PO-Revision-Date: 2021-08-13 22:55+0000\n"
 "Last-Translator: J G <transifex@jguer.space>, 2021\n"
 "Language-Team: Basque (https://www.transifex.com/yay-1/teams/123732/eu/)\n"
+"Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
-#: install.go:563
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (Konpilazio fitxategiak existitzen dira)"
 
-#: install.go:559
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Instalatuta)"
 
-#: depCheck.go:279
-msgid " (Target"
-msgstr " (Helburua"
-
-#: depCheck.go:281
-msgid " (Wanted by: "
-msgstr " (Honek behar du: "
-
-#: callbacks.go:72
-msgid " Input too long"
-msgstr " Sarrera luzeegia"
-
-#: cmd.go:446
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Instalatuta]"
 
-#: cmd.go:402 install.go:166 install.go:200
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " ez dago ezer egiteko"
 
-#: depCheck.go:170
-msgid "Installing %s will remove:"
-msgstr "%s instalatzeak ezabatuko du:"
-
-#: install.go:583 install.go:658 install.go:665
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
-"%s Guzti[A]k [Ab]ortatu [I]nstalatuak [No]Ez instalatuak edo (1 2 3, 1-3, "
-"^4)"
+"%s Guzti[A]k [Ab]ortatu [I]nstalatuak [No]Ez instalatuak edo (1 2 3, 1-3, ^4)"
 
-#: download.go:273
-msgid "%s already downloaded -- use -f to overwrite"
-msgstr "%s deskargatuta dago -- erabili -f gainidazteko"
-
-#: install.go:1086
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s eginda dago jada -- konpilazioa alde batera uzten"
 
-#: pkg/settings/runtime.go:50 pkg/settings/runtime.go:62
-msgid "%s and %s unset"
-msgstr "%s eta %s ezarri gabe"
-
-#: config.go:76
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s ezarri gabe dago"
 
-#: exec.go:71
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s presente dago."
 
-#: install.go:1075
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s eguneratuta dago - alde batera uzten"
 
-#: install.go:1008
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s ez da betetzen, instalazio ilara ezabatzen"
-
-#: install.go:752
-msgid "%s: No changes -- skipping"
-msgstr "%s: Aldaketarik ez -- alde batera uzten"
-
-#: utils.go:48
-msgid "%s: can't use target with option --aur -- skipping"
-msgstr "%s: ezin da helburua --aur aukerarekin erabili -- alde batera uzten"
-
-#: utils.go:43
-msgid "%s: can't use target with option --repo -- skipping"
-msgstr "%s: ezin da helburua --repo aukerarekin erabili -- alde batera uzten"
-
-#: upgrade.go:274
-msgid "%s: ignoring package upgrade (%s => %s)"
-msgstr "%s: paketearen eguneraketa alde batera uzten (%s => %s)"
-
-#: upgrade.go:291
-msgid "%s: local (%s) is newer than AUR (%s)"
-msgstr "%s: pakete lokala (%s) AURekoa (%s) baino berriagoa da"
-
-#: download.go:298
-msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
-msgstr "(%d/%d) PKGBUILD ABStik deskargatuta: %s"
-
-#: install.go:805
-msgid "(%d/%d) Parsing SRCINFO: %s"
-msgstr "(%d/%d) SRCINFO aztertzen: %s"
-
-#: print.go:86 print.go:127
-msgid "(Installed)"
-msgstr "(Instalatuta)"
-
-#: print.go:84 print.go:125
-msgid "(Installed: %s)"
-msgstr "(Instalatuta: %s)"
-
-#: print.go:75
-msgid "(Orphaned)"
-msgstr "(Umezurtz)"
-
-#: print.go:79
-msgid "(Out-of-date: %s)"
-msgstr "(Zaharkituta: %s)"
-
-#: print.go:275
-msgid "AUR URL"
-msgstr "AUReko URLa"
-
-#: config.go:77
-msgid "Add %s or %s to your environment variables"
-msgstr "Gehitu %s edo %s zure ingurune-aldagaietara"
-
-#: main.go:182
-msgid "Avoid running yay as root/sudo."
-msgstr "Saihestu yay root/sudo bezala exekutatzea."
-
-#: print.go:281
-msgid "Check Deps"
-msgstr "Egiaztapen menpekotasunak"
-
-#: upgrade.go:167
-msgid "Checking development packages..."
-msgstr "Garapen paketeak egiaztatzen..."
-
-#: depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "Gatazkak bilatzen..."
-
-#: depCheck.go:144
-msgid "Checking for inner conflicts..."
-msgstr "Barneko gatazkak bilatzen..."
-
-#: clean.go:224
-msgid "Cleaning (%d/%d): %s"
-msgstr "(%d/%d) garbitzen: %s"
-
-#: depCheck.go:196
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr "Pakete gatazkatsuak eskuz egiaztatu beharko dira"
-
-#: print.go:283
-msgid "Conflicts With"
-msgstr "Gatazkak hauekin"
-
-#: depCheck.go:273
-msgid "Could not find all required packages:"
-msgstr "Ez izan dira aurkitu beharrezko pakete guztiak:"
-
-#: clean.go:240
-msgid "Deleting (%d/%d): %s"
-msgstr "(%d/%d) ezabatzen: %s"
-
-#: print.go:279
-msgid "Depends On"
-msgstr "Behar du"
-
-#: print.go:273
-msgid "Description"
-msgstr "Deskribapena"
-
-#: install.go:657
-msgid "Diffs to show?"
-msgstr "Aldaketak erakutsi?"
-
-#: clean.go:91
-msgid "Do you want to remove ALL AUR packages from cache?"
-msgstr "Cachean dauden AUR pakete GUZTIAK kendu nahi dituzu?"
-
-#: clean.go:108
-msgid "Do you want to remove ALL untracked AUR files?"
-msgstr "Jarraipen gabeko AUR fitxategi GUZTIAK kendu nahi dituzu?"
-
-#: clean.go:93
-msgid "Do you want to remove all other AUR packages from cache?"
-msgstr "Cachean dauden beste AUR paketeak kendu nahi dituzu?"
-
-#: install.go:893
-msgid "Downloaded PKGBUILD (%d/%d): %s"
-msgstr "(%d/%d) PKGBUILDak deskargatuta: %s"
-
-#: config.go:80
-msgid "Edit PKGBUILD with?"
-msgstr "PKGBUILD zerekin editatu?"
-
-#: cmd.go:346
-msgid "Error during AUR search: %s\n"
-msgstr "Errorea AURen bilatzerakoan: %s\n"
-
-#: print.go:342
-msgid "Explicitly installed packages: %s"
-msgstr "Eskuz instalatutako paketeak: %s"
-
-#: print.go:287
-msgid "First Submitted"
-msgstr "Lehenengo bidalita"
-
-#: print.go:41
-msgid "Flagged Out Of Date AUR Packages:"
-msgstr "Zaharkitu gisa markatutako AUR paketeak:"
-
-#: vcs.go:147
-msgid "Found git repo: %s"
-msgstr "Git biltegia aurkitu da: %s"
-
-#: vcs.go:64
-msgid "GenDB finished. No packages were installed"
-msgstr "GenDB amaitu da. Ez da paketerik instalatu"
-
-#: print.go:276
-msgid "Groups"
-msgstr "Taldeak"
-
-#: keys.go:84
-msgid "Import?"
-msgstr "Inportatu?"
-
-#: keys.go:97
-msgid "Importing keys with gpg..."
-msgstr "Gakoak GPGrekin inportatzen..."
-
-#: print.go:271
-msgid "Keywords"
-msgstr "Gako-hitzak"
-
-#: print.go:288
-msgid "Last Modified"
-msgstr "Azken aldaketa"
-
-#: print.go:277
-msgid "Licenses"
-msgstr "Lizentziak"
-
-#: print.go:284
-msgid "Maintainer"
-msgstr "Arduraduna"
-
-#: print.go:280
-msgid "Make Deps"
-msgstr "Menpekotasunak burutzea"
-
-#: download.go:281
-msgid "Missing ABS packages:"
-msgstr "Faltan dauden ABS paketeak:"
-
-#: print.go:25
-msgid "Missing AUR Packages:"
-msgstr "Faltan dauden AUR paketeak:"
-
-#: print.go:270
-msgid "Name"
-msgstr "Izena"
-
-#: pkg/text/print.go:50
-msgid "None"
-msgstr "Deus ez"
-
-#: print.go:282
-msgid "Optional Deps"
-msgstr "Hautazko menpekotasunak"
-
-#: print.go:33
-msgid "Orphaned AUR Packages:"
-msgstr "Umezurtz geratu diren AUR paketeak:"
-
-#: print.go:291 print.go:293
-msgid "Out-of-date"
-msgstr "Zaharkituta"
-
-#: keys.go:115
-msgid "PGP keys need importing:"
-msgstr "PGP gakoek inportatu behar dute:"
-
-#: install.go:874
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
-msgstr "PKGBUILD eguneratuta, alde batera uzten (%d/%d): %s"
-
-#: install.go:664
-msgid "PKGBUILDs to edit?"
-msgstr "Editatzeko PKGBUILDak?"
-
-#: print.go:298
-msgid "Package Base ID"
-msgstr "Pakete-oinarriaren IDa"
-
-#: print.go:299
-msgid "Package Base"
-msgstr "Pakete-oinarria"
-
-#: install.go:582
-msgid "Packages to cleanBuild?"
-msgstr "Konpilatu aurretik garbitzeko paketeak?"
-
-#: upgrade.go:365
-msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Kanpoan uzteko paketeak: (adb: \"1 2 3\", \"1-3\", \"^4\" edo biltegiaren izena)"
-
-#: cmd.go:350
-msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
-msgstr "Instalatzeko paketeak (eg.: 1 2 3, 1-3 edo ^4)"
-
-#: upgrade.go:362
-msgid "Packages to upgrade."
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
 msgstr "eguneratzeko pakete."
 
-#: print.go:286
-msgid "Popularity"
-msgstr "Ospea"
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
 
-#: install.go:269 install.go:309
-msgid "Proceed with install?"
-msgstr "Instalatu?"
-
-#: print.go:278
-msgid "Provides"
-msgstr "Hornitzen du"
-
-#: query.go:509
-msgid "Querying AUR..."
-msgstr "AURen bilatzen..."
-
-#: install.go:221
-msgid "Remove make dependencies after install?"
-msgstr "Konpilatzeko menpekotasunak ezabatu instalatu ostean?"
-
-#: print.go:495
-msgid "Repository AUR"
-msgstr "AUR biltegia"
-
-#: callbacks.go:46 print.go:269
-msgid "Repository"
-msgstr "Biltegia"
-
-#: upgrade.go:150
-msgid "Searching AUR for updates..."
-msgstr "Eguneraketak AURen bilatzen..."
-
-#: upgrade.go:140
-msgid "Searching databases for updates..."
-msgstr "Datu-baseetan eguneraketak bilatzen..."
-
-#: cmd.go:347 query.go:194
-msgid "Showing repo packages only"
-msgstr "Biltegietako paketeak soilik erakusten"
-
-#: print.go:300
-msgid "Snapshot URL"
-msgstr "PKGBUILDaren argazkiaren URLa"
-
-#: print.go:345
-msgid "Ten biggest packages:"
-msgstr "Hamar pakete handienak:"
-
-#: install.go:481
-msgid "The following packages are not compatible with your architecture:"
-msgstr "Ondorengo paketeak ez dira zure arkitekturarekin bateragarriak:"
-
-#: callbacks.go:36 print.go:492
-msgid "There are %d providers available for %s:\n"
-msgstr "%d hornitzaile eskuragarri %s paketearentzat:\n"
-
-#: exec.go:72
-msgid "There may be another Pacman instance running. Waiting..."
-msgstr "Baliteke beste Pacman instantzia bat exekutzan aritzea. Zain..."
-
-#: print.go:343
-msgid "Total Size occupied by packages: %s"
-msgstr "Pakete guztiek erabilitako biltegiratzea: %s"
-
-#: print.go:341
-msgid "Total foreign installed packages: %s"
-msgstr "Kanpotik instalatu diren paketeak: %s"
-
-#: print.go:340
-msgid "Total installed packages: %s"
-msgstr "Instalatu diren paketeak: %s"
-
-#: install.go:488
-msgid "Try to build them anyway?"
-msgstr "Saiatu konpilatzen hala ere?"
-
-#: print.go:274
-msgid "URL"
-msgstr "URLa"
-
-#: print.go:272
-msgid "Version"
-msgstr "Bertsioa"
-
-#: print.go:285
-msgid "Votes"
-msgstr "Botoak"
-
-#: print.go:338
-msgid "Yay version v%s"
-msgstr "Yay bertsioa v%s"
-
-#: install.go:583 install.go:658 install.go:665
-msgid "[N]one"
-msgstr "I[N]or ez"
-
-#: keys.go:122
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, honek beharrezkoa du: %s"
 
-#: clean.go:96
+#: pkg/menus/diff_menu.go:49
+msgid "%s: No changes -- skipping"
+msgstr "%s: Aldaketarik ez -- alde batera uzten"
+
+#: pkg/query/filter.go:22
+msgid "%s: can't use target with option --aur -- skipping"
+msgstr "%s: ezin da helburua --aur aukerarekin erabili -- alde batera uzten"
+
+#: pkg/query/filter.go:17
+msgid "%s: can't use target with option --repo -- skipping"
+msgstr "%s: ezin da helburua --repo aukerarekin erabili -- alde batera uzten"
+
+#: pkg/upgrade/sources.go:57
+msgid "%s: ignoring package upgrade (%s => %s)"
+msgstr "%s: paketearen eguneraketa alde batera uzten (%s => %s)"
+
+#: pkg/query/aur_warnings.go:46
+msgid "%s: local (%s) is newer than AUR (%s)"
+msgstr "%s: pakete lokala (%s) AURekoa (%s) baino berriagoa da"
+
+#: vote.go:51
+msgid ""
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
+msgstr ""
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
+
+#: pkg/download/unified.go:192
+msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
+msgstr "(%d/%d) PKGBUILD ABStik deskargatuta: %s"
+
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
+#, fuzzy
+msgid "(%d/%d) Downloaded PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD ABStik deskargatuta: %s"
+
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD ABStik deskargatuta: %s"
+
+#: pkg/sync/srcinfo/service.go:109
+msgid "(%d/%d) Parsing SRCINFO: %s"
+msgstr "(%d/%d) SRCINFO aztertzen: %s"
+
+#: pkg/query/types.go:72 pkg/query/types.go:103
+msgid "(Installed)"
+msgstr "(Instalatuta)"
+
+#: pkg/query/types.go:70 pkg/query/types.go:101
+msgid "(Installed: %s)"
+msgstr "(Instalatuta: %s)"
+
+#: pkg/query/types.go:61
+msgid "(Orphaned)"
+msgstr "(Umezurtz)"
+
+#: pkg/query/types.go:65
+msgid "(Out-of-date: %s)"
+msgstr "(Zaharkituta: %s)"
+
+#: print.go:44
+msgid "AUR URL"
+msgstr "AUReko URLa"
+
+#: pkg/dep/dep_graph.go:75
+#, fuzzy
+msgid "AUR"
+msgstr "URLa"
+
+#: pkg/menus/edit_menu.go:58
+msgid "Add %s or %s to your environment variables"
+msgstr "Gehitu %s edo %s zure ingurune-aldagaietara"
+
+#: main.go:60
+msgid "Avoid running yay as root/sudo."
+msgstr "Saihestu yay root/sudo bezala exekutatzea."
+
+#: pkg/dep/dep_graph.go:63
+#, fuzzy
+msgid "Check Dependency"
+msgstr "Egiaztapen menpekotasunak"
+
+#: print.go:41
+msgid "Check Deps"
+msgstr "Egiaztapen menpekotasunak"
+
+#: pkg/upgrade/service.go:90
+msgid "Checking development packages..."
+msgstr "Garapen paketeak egiaztatzen..."
+
+#: pkg/sync/workdir/clean.go:45
+msgid "Cleaning (%d/%d): %s"
+msgstr "(%d/%d) garbitzen: %s"
+
+#: print.go:42
+msgid "Conflicts With"
+msgstr "Gatazkak hauekin"
+
+#: pkg/menus/clean_menu.go:62
+msgid "Deleting (%d/%d): %s"
+msgstr "(%d/%d) ezabatzen: %s"
+
+#: pkg/dep/dep_graph.go:61
+#, fuzzy
+msgid "Dependency"
+msgstr "Behar du"
+
+#: print.go:38
+msgid "Depends On"
+msgstr "Behar du"
+
+#: print.go:33
+msgid "Description"
+msgstr "Deskribapena"
+
+#: pkg/menus/diff_menu.go:160
+msgid "Diffs to show?"
+msgstr "Aldaketak erakutsi?"
+
+#: pkg/settings/migrations.go:25
+msgid "Disable 'provides' setting by default"
+msgstr ""
+
+#: clean.go:78
+msgid "Do you want to remove ALL AUR packages from cache?"
+msgstr "Cachean dauden AUR pakete GUZTIAK kendu nahi dituzu?"
+
+#: clean.go:95
+msgid "Do you want to remove ALL untracked AUR files?"
+msgstr "Jarraipen gabeko AUR fitxategi GUZTIAK kendu nahi dituzu?"
+
+#: clean.go:80
+msgid "Do you want to remove all other AUR packages from cache?"
+msgstr "Cachean dauden beste AUR paketeak kendu nahi dituzu?"
+
+#: pkg/menus/edit_menu.go:61
+msgid "Edit PKGBUILD with?"
+msgstr "PKGBUILD zerekin editatu?"
+
+#: pkg/query/errors.go:13
+msgid "Error during AUR search: %s\n"
+msgstr "Errorea AURen bilatzerakoan: %s\n"
+
+#: pkg/upgrade/service.go:296
+msgid "Excluding packages may cause partial upgrades and break systems"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:60
+msgid "Explicit"
+msgstr ""
+
+#: print.go:91
+msgid "Explicitly installed packages: %s"
+msgstr "Eskuz instalatutako paketeak: %s"
+
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
+#, fuzzy
+msgid "Failed to find AUR package for"
+msgstr "Zaharkitu gisa markatutako AUR paketeak:"
+
+#: pkg/sync/build/installer.go:120
+msgid "Failed to install layer, rolling up to next layer."
+msgstr ""
+
+#: pkg/sync/build/errors.go:16
+msgid ""
+"Failed to install the following packages. Manual intervention is required:"
+msgstr ""
+
+#: print.go:45
+msgid "First Submitted"
+msgstr "Lehenengo bidalita"
+
+#: pkg/query/aur_warnings.go:79
+msgid "Flagged Out Of Date AUR Packages:"
+msgstr "Zaharkitu gisa markatutako AUR paketeak:"
+
+#: print.go:90
+#, fuzzy
+msgid "Foreign installed packages: %s"
+msgstr "Kanpotik instalatu diren paketeak: %s"
+
+#: pkg/vcs/vcs.go:144
+msgid "Found git repo: %s"
+msgstr "Git biltegia aurkitu da: %s"
+
+#: vcs.go:72
+msgid "GenDB finished. No packages were installed"
+msgstr "GenDB amaitu da. Ez da paketerik instalatu"
+
+#: print.go:36
+msgid "Groups"
+msgstr "Taldeak"
+
+#: pkg/sync/srcinfo/pgp/keys.go:88
+msgid "Import?"
+msgstr "Inportatu?"
+
+#: pkg/sync/srcinfo/pgp/keys.go:97
+msgid "Importing keys with gpg..."
+msgstr "Gakoak GPGrekin inportatzen..."
+
+#: print.go:46
+msgid "Keywords"
+msgstr "Gako-hitzak"
+
+#: print.go:47
+msgid "Last Modified"
+msgstr "Azken aldaketa"
+
+#: print.go:35
+msgid "Licenses"
+msgstr "Lizentziak"
+
+#: pkg/dep/dep_graph.go:77
+msgid "Local"
+msgstr ""
+
+#: print.go:48
+msgid "Maintainer"
+msgstr "Arduraduna"
+
+#: pkg/dep/dep_graph.go:62
+#, fuzzy
+msgid "Make Dependency"
+msgstr "Menpekotasunak burutzea"
+
+#: print.go:40
+msgid "Make Deps"
+msgstr "Menpekotasunak burutzea"
+
+#: pkg/query/aur_warnings.go:71
+#, fuzzy
+msgid "Missing AUR Debug Packages:"
+msgstr "Faltan dauden AUR paketeak:"
+
+#: pkg/dep/dep_graph.go:79
+msgid "Missing"
+msgstr ""
+
+#: print.go:31
+msgid "Name"
+msgstr "Izena"
+
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
+msgid "No AUR package found for"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:182
+msgid "No package found for"
+msgstr ""
+
+#: print.go:225
+msgid "None"
+msgstr "Deus ez"
+
+#: print.go:39
+msgid "Optional Deps"
+msgstr "Hautazko menpekotasunak"
+
+#: pkg/query/aur_warnings.go:75
+#, fuzzy
+msgid "Orphan (unmaintained) AUR Packages:"
+msgstr "Umezurtz geratu diren AUR paketeak:"
+
+#: print.go:53 print.go:55
+msgid "Out-of-date"
+msgstr "Zaharkituta"
+
+#: pkg/sync/srcinfo/pgp/keys.go:115
+msgid "PGP keys need importing:"
+msgstr "PGP gakoek inportatu behar dute:"
+
+#: pkg/sync/workdir/preparer.go:252
+#, fuzzy
+msgid "PKGBUILD up to date, skipping download: %s"
+msgstr "PKGBUILD eguneratuta, alde batera uzten (%d/%d): %s"
+
+#: pkg/menus/edit_menu.go:130
+msgid "PKGBUILDs to edit?"
+msgstr "Editatzeko PKGBUILDak?"
+
+#: print.go:60
+msgid "Package Base ID"
+msgstr "Pakete-oinarriaren IDa"
+
+#: print.go:61
+msgid "Package Base"
+msgstr "Pakete-oinarria"
+
+#: pkg/query/aur_warnings.go:67
+msgid "Packages not in AUR:"
+msgstr ""
+
+#: pkg/menus/clean_menu.go:54
+msgid "Packages to cleanBuild?"
+msgstr "Konpilatu aurretik garbitzeko paketeak?"
+
+#: pkg/dep/dep_graph.go:202
+#, fuzzy
+msgid "Packages to exclude"
+msgstr "eguneratzeko pakete."
+
+#: pkg/upgrade/service.go:295
+msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
+msgstr ""
+"Kanpoan uzteko paketeak: (adb: \"1 2 3\", \"1-3\", \"^4\" edo biltegiaren "
+"izena)"
+
+#: cmd.go:402
+msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
+msgstr "Instalatzeko paketeak (eg.: 1 2 3, 1-3 edo ^4)"
+
+#: print.go:49
+msgid "Popularity"
+msgstr "Ospea"
+
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
+msgid "Proceed with install?"
+msgstr "Instalatu?"
+
+#: print.go:37
+msgid "Provides"
+msgstr "Hornitzen du"
+
+#: pkg/sync/workdir/preparer.go:125
+msgid "Remove make dependencies after install?"
+msgstr "Konpilatzeko menpekotasunak ezabatu instalatu ostean?"
+
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
+msgid "Repository AUR"
+msgstr "AUR biltegia"
+
+#: print.go:30 pkg/db/ialpm/alpm.go:191
+msgid "Repository"
+msgstr "Biltegia"
+
+#: pkg/dep/dep_graph.go:78
+msgid "SRCINFO"
+msgstr ""
+
+#: pkg/upgrade/service.go:72
+msgid "Searching AUR for updates..."
+msgstr "Eguneraketak AURen bilatzen..."
+
+#: pkg/upgrade/service.go:160
+msgid "Searching databases for updates..."
+msgstr "Datu-baseetan eguneraketak bilatzen..."
+
+#: pkg/query/query_builder.go:214
+msgid "Showing repo packages only"
+msgstr "Biltegietako paketeak soilik erakusten"
+
+#: print.go:95
+#, fuzzy
+msgid "Size of pacman cache %s: %s"
+msgstr "%s analizatzeak huts egin du: %s"
+
+#: print.go:98
+#, fuzzy
+msgid "Size of yay cache %s: %s"
+msgstr "%s analizatzeak huts egin du: %s"
+
+#: print.go:62
+msgid "Snapshot URL"
+msgstr "PKGBUILDaren argazkiaren URLa"
+
+#: pkg/dep/dep_graph.go:76
+msgid "Sync"
+msgstr ""
+
+#: print.go:100
+msgid "Ten biggest packages:"
+msgstr "Hamar pakete handienak:"
+
+#: pkg/sync/sync.go:124
+msgid "The following packages are not compatible with your architecture:"
+msgstr "Ondorengo paketeak ez dira zure arkitekturarekin bateragarriak:"
+
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
+#, fuzzy
+msgid "There are %d providers available for %s:"
+msgstr "%d hornitzaile eskuragarri %s paketearentzat:\n"
+
+#: pkg/settings/exe/cmd_builder.go:258
+msgid "There may be another Pacman instance running. Waiting..."
+msgstr "Baliteke beste Pacman instantzia bat exekutzan aritzea. Zain..."
+
+#: print.go:92
+msgid "Total Size occupied by packages: %s"
+msgstr "Pakete guztiek erabilitako biltegiratzea: %s"
+
+#: print.go:89
+msgid "Total installed packages: %s"
+msgstr "Instalatu diren paketeak: %s"
+
+#: pkg/sync/sync.go:132
+msgid "Try to build them anyway?"
+msgstr "Saiatu konpilatzen hala ere?"
+
+#: print.go:34
+msgid "URL"
+msgstr "URLa"
+
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
+#, fuzzy
+msgid "Unable to clean:"
+msgstr "ezin da CreateHandle burutu: %s"
+
+#: get.go:42 get.go:74
+msgid "Unable to find the following packages:"
+msgstr ""
+
+#: vote.go:20
+msgid "Unable to handle package vote for: %s. err: %s"
+msgstr ""
+
+#: clean.go:170
+#, fuzzy
+msgid "Unable to remove %s: %s"
+msgstr "%s analizatzeak huts egin du: %s"
+
+#: print.go:32
+msgid "Version"
+msgstr "Bertsioa"
+
+#: print.go:50
+msgid "Votes"
+msgstr "Botoak"
+
+#: print.go:87
+msgid "Yay version v%s"
+msgstr "Yay bertsioa v%s"
+
+#: pkg/menus/menu.go:49
+msgid "[N]one"
+msgstr "I[N]or ez"
+
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -433,7 +566,7 @@ msgstr ""
 "\n"
 "Konpilazio direktorioa:"
 
-#: callbacks.go:56 print.go:505
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -441,201 +574,329 @@ msgstr ""
 "\n"
 "Idatzi zenbaki bat (lehenetsia=1): "
 
-#: depCheck.go:153
-msgid ""
-"\n"
-"Inner conflicts found:"
-msgstr ""
-"\n"
-"Barne gatazkak aurkitu dira:"
-
-#: depCheck.go:167
-msgid ""
-"\n"
-"Package conflicts found:"
-msgstr ""
-"\n"
-"Pakete arteko gaztakak aurkitu dira:"
-
-#: install.go:270 install.go:310 install.go:489 install.go:593 install.go:676
+#: pkg/settings/errors.go:29
 msgid "aborting due to user"
 msgstr "erabiltzailearengatik bertan behera uzten"
 
-#: install.go:515
+#: pkg/settings/parser/parser.go:620
+msgid "argument '-' specified without input on stdin"
+msgstr ""
+
+#: local_install.go:26
+msgid "cannot find PKGBUILD and .SRCINFO in directory"
+msgstr ""
+
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "ezin da paketearen izena aurkitu: %v"
 
-#: install.go:1048 install.go:1120
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "ezin izan da aurkitu PKGDEST %s paketearentzat"
 
-#: install.go:792
+#: errors.go:9
+#, fuzzy
+msgid "could not find all required packages"
+msgstr "Ez izan dira aurkitu beharrezko pakete guztiak:"
+
+#: pkg/sync/build/errors.go:61
+msgid "could not find any package archives listed in %s"
+msgstr ""
+
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
+#, fuzzy
+msgid "dependency"
+msgstr "Behar du"
+
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
+msgid "devel check for package failed: '%s' encountered an error"
+msgstr ""
+
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "editorea ez da behar bezala irten, bertan behera uzten: %s"
 
-#: download.go:84 download.go:109
-msgid "error cloning %s: %s"
-msgstr "errorea %s klonatzerakoan: %s"
-
-#: install.go:924
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "errorea iturriak deskargatzerakoan: %s"
 
-#: query.go:193
-msgid "error during AUR search: %s"
-msgstr "errorea AURen bilatzerakoan: %s"
-
-#: download.go:96 download.go:121
+#: pkg/download/errors.go:25
 msgid "error fetching %s: %s"
 msgstr "errorea %s lortzerakoan: %s"
 
-#: install.go:333 install.go:442
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "errorea biltegitako paketeak instalatzerakoan"
 
-#: install.go:1032 install.go:1072 install.go:1083 install.go:1095
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
+#, fuzzy
+msgid "error installing:"
+msgstr "errorea biltegitako paketeak instalatzerakoan"
+
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "konpilazio akatsa: %s"
 
-#: download.go:135
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "errorea %s bateratzerakoan: %s"
 
-#: download.go:89 download.go:114
+#: pkg/download/unified.go:59
 msgid "error reading %s"
 msgstr "errorea %s irakurtzerakoan"
 
-#: install.go:75
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "errorea datu-baseak freskatzerakoan"
 
-#: clean.go:228 download.go:130
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "errorea %s berrezartzerakoan: %s"
 
-#: main.go:68
-msgid "failed to create BuildDir directory '%s': %s"
-msgstr "'%s' BuildDir direktorioa sortzeak huts egin du: %s"
+#: pkg/sync/build/errors.go:53
+msgid "error updating package install reason to %s"
+msgstr ""
 
-#: pkg/settings/runtime.go:79
+#: pkg/sync/build/errors.go:48
+msgid "explicit"
+msgstr ""
+
+#: pkg/settings/errors.go:23
 msgid "failed to create directory '%s': %s"
 msgstr "'%s' konfigurazio direktorioa sortzeak huts egin du: %s"
 
-#: download.go:288
-msgid "failed to get pkgbuild: %s: %s"
-msgstr "PKGBUILD lortzeak huts egin du: %s: %s"
-
-#: download.go:296
-msgid "failed to link %s: %s"
-msgstr "%s estekatzeak huts egin du: %s"
-
-#: main.go:29
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "'%s' konfigurazio fitxategia irekitzeak huts egin du: %s"
 
-#: main.go:51
-msgid "failed to open vcs file '%s': %s"
-msgstr "'%s' VCS fitxategia irekitzeak huts egin du: %s"
-
-#: install.go:810
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "%s analizatzeak huts egin du -- alde batera uzten: %s"
 
-#: install.go:813
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "%s analizatzeak huts egin du: %s"
 
-#: main.go:36
+#: local_install.go:77
+#, fuzzy
+msgid "failed to parse .SRCINFO"
+msgstr "%s analizatzeak huts egin du: %s"
+
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "'%s' konfigurazio fitxategia irakurtzeak huts egin du: %s"
 
-#: main.go:58
-msgid "failed to read vcs file '%s': %s"
-msgstr "'%s' VCS fitxategia irakurtzeak huts egin du: %s"
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
+msgid "failed to retrieve aur Cache"
+msgstr ""
 
-#: cmd.go:360 config.go:147 print.go:521
+#: pkg/upgrade/sources.go:27
+#, fuzzy
+msgid "ignoring package devel upgrade (no AUR info found):"
+msgstr "%s: paketearen eguneraketa alde batera uzten (%s => %s)"
+
+#: pkg/text/errors.go:8
 msgid "input too long"
 msgstr "sarrera luzeegia"
 
-#: callbacks.go:82 print.go:531
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "zenbaki baliogabea: %s"
 
-#: pkg/settings/parser.go:144
+#: pkg/settings/parser/parser.go:174
 msgid "invalid option '%s'"
 msgstr "'%s' aukera baliogabea"
 
-#: cmd.go:342 cmd.go:376 cmd.go:393 print.go:62 print.go:105 query.go:189
-msgid "invalid sort mode. Fix with yay -Y --bottomup --save"
+#: cmd.go:207
+msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
-"ordenatzeko modu baliogabea. Konpondu 'yay -Y --bottomup --save' exekutatzen"
 
-#: callbacks.go:87 print.go:536
+#: pkg/download/abs.go:22
+#, fuzzy
+msgid "invalid repository"
+msgstr "Biltegia"
+
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "balio baliogabea: %d ez dago %d eta %d artean"
 
-#: keys.go:110
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "inportatzeko gakorik ez"
 
-#: cmd.go:323
-msgid "no packages match search"
-msgstr "paketerik ez dator bat bilaketarekin"
+#: pkg/query/errors.go:20
+msgid "no query was executed"
+msgstr ""
 
-#: config.go:112
+#: local_install.go:66
+msgid "no target directories specified"
+msgstr ""
+
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "ez"
 
-#: pkg/settings/parser.go:134
+#: pkg/sync/build/installer.go:242
+msgid "nothing to install for %s"
+msgstr ""
+
+#: pkg/settings/parser/parser.go:164
 msgid "only one operation may be used at a time"
 msgstr "aldi berean operazio bakarra erabil daiteke"
 
-#: print.go:430
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "ez da aurkitu '%s' paketea"
 
-#: depCheck.go:193
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr ""
-"pakete arteko gatazkak ezin dira noconfirm-ekin konpondu, bertan behera "
-"uzten"
+#: pkg/download/errors.go:15
+#, fuzzy
+msgid "package not found in AUR"
+msgstr "ez da aurkitu '%s' paketea"
 
-#: keys.go:101
+#: pkg/download/abs.go:23
+#, fuzzy
+msgid "package not found in repos"
+msgstr "ez da aurkitu '%s' paketea"
+
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "Pakete-oinarria"
+msgstr[1] "Pakete-oinarria"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "arazoa gakoak inportatzerakoan"
 
-#: install.go:178
-msgid "refusing to install AUR packages as root, aborting"
-msgstr "AUR paketeak root gisa instalatzeari uko egiten, bertan behera uzten"
-
-#: clean.go:116
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "AUR paketeak cachetik kentzen..."
 
-#: clean.go:188 clean.go:216
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "jarraipen gabeko AUR fitxategiak cachetik kentzen..."
 
-#: install.go:1129
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr ""
 "%s(e)rako PKGDESTa makepkg-ek zerrendatzen du, baina ez da existitzen: %s"
 
-#: main.go:146
+#: pkg/sync/sync.go:45
+#, fuzzy
+msgid "there is nothing to do"
+msgstr " ez dago ezer egiteko"
+
+#: pkg/db/ialpm/alpm.go:247
 msgid "unable to CreateHandle: %s"
 msgstr "ezin da CreateHandle burutu: %s"
 
-#: cmd.go:177
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "sostengurik gabeko eragiketa"
 
-#: cmd.go:443
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "bertsio ezezaguna"
 
-#: config.go:111
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "bai"
+
+#~ msgid " (Target"
+#~ msgstr " (Helburua"
+
+#~ msgid " (Wanted by: "
+#~ msgstr " (Honek behar du: "
+
+#~ msgid " Input too long"
+#~ msgstr " Sarrera luzeegia"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "%s instalatzeak ezabatuko du:"
+
+#~ msgid "%s already downloaded -- use -f to overwrite"
+#~ msgstr "%s deskargatuta dago -- erabili -f gainidazteko"
+
+#~ msgid "%s and %s unset"
+#~ msgstr "%s eta %s ezarri gabe"
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s ez da betetzen, instalazio ilara ezabatzen"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "Gatazkak bilatzen..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "Barneko gatazkak bilatzen..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr "Pakete gatazkatsuak eskuz egiaztatu beharko dira"
+
+#~ msgid "Downloaded PKGBUILD (%d/%d): %s"
+#~ msgstr "(%d/%d) PKGBUILDak deskargatuta: %s"
+
+#~ msgid "Missing ABS packages:"
+#~ msgstr "Faltan dauden ABS paketeak:"
+
+#~ msgid "Querying AUR..."
+#~ msgstr "AURen bilatzen..."
+
+#~ msgid ""
+#~ "\n"
+#~ "Inner conflicts found:"
+#~ msgstr ""
+#~ "\n"
+#~ "Barne gatazkak aurkitu dira:"
+
+#~ msgid ""
+#~ "\n"
+#~ "Package conflicts found:"
+#~ msgstr ""
+#~ "\n"
+#~ "Pakete arteko gaztakak aurkitu dira:"
+
+#~ msgid "error cloning %s: %s"
+#~ msgstr "errorea %s klonatzerakoan: %s"
+
+#~ msgid "error during AUR search: %s"
+#~ msgstr "errorea AURen bilatzerakoan: %s"
+
+#~ msgid "failed to create BuildDir directory '%s': %s"
+#~ msgstr "'%s' BuildDir direktorioa sortzeak huts egin du: %s"
+
+#~ msgid "failed to get pkgbuild: %s: %s"
+#~ msgstr "PKGBUILD lortzeak huts egin du: %s: %s"
+
+#~ msgid "failed to link %s: %s"
+#~ msgstr "%s estekatzeak huts egin du: %s"
+
+#~ msgid "failed to open vcs file '%s': %s"
+#~ msgstr "'%s' VCS fitxategia irekitzeak huts egin du: %s"
+
+#~ msgid "failed to read vcs file '%s': %s"
+#~ msgstr "'%s' VCS fitxategia irakurtzeak huts egin du: %s"
+
+#~ msgid "invalid sort mode. Fix with yay -Y --bottomup --save"
+#~ msgstr ""
+#~ "ordenatzeko modu baliogabea. Konpondu 'yay -Y --bottomup --save' "
+#~ "exekutatzen"
+
+#~ msgid "no packages match search"
+#~ msgstr "paketerik ez dator bat bilaketarekin"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr ""
+#~ "pakete arteko gatazkak ezin dira noconfirm-ekin konpondu, bertan behera "
+#~ "uzten"
+
+#~ msgid "refusing to install AUR packages as root, aborting"
+#~ msgstr ""
+#~ "AUR paketeak root gisa instalatzeari uko egiten, bertan behera uzten"
 
 #~ msgid "failed to create cache directory '%s': %s"
 #~ msgstr "'%s' cache direktorioa sortzeak huts egin du: %s"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -13,59 +13,61 @@
 msgid ""
 msgstr ""
 "Last-Translator: Mathias Brugger, 2023\n"
-"Language-Team: French (France) (https://app.transifex.com/yay-1/teams/123732/fr_FR/)\n"
+"Language-Team: French (France) (https://app.transifex.com/yay-1/teams/123732/"
+"fr_FR/)\n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr_FR\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr "(Les fichiers de compilation existent)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Installé)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Installé]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " il n'y a rien à faire"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr "%s [A]Tous [Ab]Annuler [I]nstallés [No]nInstallés ou (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s déjà créé -- compilation évitée"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s n'est pas défini"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s est présent."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s est à jour -- omission"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "à mettre à jours/installer."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "Va aussi être installé pour cette opération."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, requis par : %s"
 
@@ -85,29 +87,85 @@ msgstr "%s : impossible d'utiliser la cible avec l'option --repo -- omission"
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s : mise à jour du paquet ignorée (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr ""
 "%s : le paquet local (%s) est plus récent que le paquet disponible sur AUR "
 "(%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "%s : veuillez définir les variables d'environnement AUR_USERNAME et "
 "AUR_PASSWORD pour voter"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) Téléchargement du PKGBUILD depuis ABS : %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD téléchargé : %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD téléchargé : %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Lecture de SRCINFO : %s"
 
@@ -127,7 +185,7 @@ msgstr "(Orphelin)"
 msgid "(Out-of-date: %s)"
 msgstr "(Obsolète : %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL AUR"
 
@@ -135,7 +193,7 @@ msgstr "URL AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Ajoutez %s ou %s à vos variables d'environnement"
 
@@ -147,7 +205,7 @@ msgstr "Évitez d'utiliser yay en tant que root ou via sudo."
 msgid "Check Dependency"
 msgstr "Vérifier la dépendance"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Vérification des dépendances"
 
@@ -155,15 +213,15 @@ msgstr "Vérification des dépendances"
 msgid "Checking development packages..."
 msgstr "Vérification des paquets de développement..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Nettoyage (%d/%d) : %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "En conflit avec"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Suppression (%d/%d) : %s"
 
@@ -171,15 +229,15 @@ msgstr "Suppression (%d/%d) : %s"
 msgid "Dependency"
 msgstr "Dépendance"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Dépend de"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Description"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Afficher les diffs ?"
 
@@ -187,19 +245,19 @@ msgstr "Afficher les diffs ?"
 msgid "Disable 'provides' setting by default"
 msgstr "Désactiver le paramètre 'fourni' par défaut"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Voulez-vous supprimer TOUS les paquets AUR du cache ?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Voulez-vous supprimer TOUS les fichiers AUR non suivis ?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Voulez-vous supprimer tous les autres paquets AUR du cache ?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Édition du PKGBUILD avec ?"
 
@@ -207,7 +265,7 @@ msgstr "Édition du PKGBUILD avec ?"
 msgid "Error during AUR search: %s\n"
 msgstr "Erreur durant la recherche AUR : %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Exclure des paquets peut causer une mise à jour partielle et casser le "
@@ -217,35 +275,35 @@ msgstr ""
 msgid "Explicit"
 msgstr "Explicite"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Paquets installés explicitement : %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Impossible de trouver un paquet AUR correspondant pour"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr ""
 "Impossible d'installer la couche nécessaire, direction la couche suivante."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 "Impossible d’installer les paquets suivants. Une intervention manuelle est "
 "requise :"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Premier envoi"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Paquets AUR marqués comme obsolètes :"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Paquets étrangers installés : %s"
 
@@ -253,31 +311,31 @@ msgstr "Paquets étrangers installés : %s"
 msgid "Found git repo: %s"
 msgstr "Dépôt git trouvé : %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB terminée. Aucun package installé"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Groupes"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Import ?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Import des clés avec gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Mots-clés"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Dernières modifications"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Licences"
 
@@ -285,7 +343,7 @@ msgstr "Licences"
 msgid "Local"
 msgstr "Local"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Mainteneur"
 
@@ -293,11 +351,11 @@ msgstr "Mainteneur"
 msgid "Make Dependency"
 msgstr "Dépendance de construction"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Construction des dépendances"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Paquets de débogage AUR manquants :"
 
@@ -305,35 +363,40 @@ msgstr "Paquets de débogage AUR manquants :"
 msgid "Missing"
 msgstr "Manquant"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Nom"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Pas de paquet AUR trouvé pour"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Pas de paquet AUR trouvé pour"
+
+#: print.go:225
 msgid "None"
 msgstr "Aucun"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Dépendances optionnelles"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Paquets AUR orphelins (non maintenus) :"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Obsolète"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Clés PGP dont l'import est nécessaire :"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD à jour, omission du téléchargement : %s"
 
@@ -341,57 +404,60 @@ msgstr "PKGBUILD à jour, omission du téléchargement : %s"
 msgid "PKGBUILDs to edit?"
 msgstr "PKGBUILDs à modifier ?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "Package Base ID"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Base des paquets"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Paquets absents de AUR :"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Paquets à nettoyer avant compilation (cleanBuild) ?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Paquets à exclure"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr "Paquets à exclure : (ex. \"1 2 3\", \"1-3\", \"^4\" ou nom du dépôt)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Paquets à installer (ex. 1 2 3, 1-3 or ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularité"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Poursuivre l'installation ?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Fournit"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr ""
-"Supprimer les dépendances nécessaires à la compilation après l'installation "
-"?"
+"Supprimer les dépendances nécessaires à la compilation après l'installation ?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Dépôt AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Dépôt"
 
@@ -411,15 +477,15 @@ msgstr "Recherche de mises à jour dans les bases de données..."
 msgid "Showing repo packages only"
 msgstr "Affichage des dépôts des paquets uniquement"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Taille du cache de pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Taille du cache de yay %s:%s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL de l'instantané"
 
@@ -427,72 +493,71 @@ msgstr "URL de l'instantané"
 msgid "Sync"
 msgstr "Synchroniser"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Dix plus gros paquets :"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
-msgstr ""
-"Les paquets suivants ne sont pas compatibles avec votre architecture :"
+msgstr "Les paquets suivants ne sont pas compatibles avec votre architecture :"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Il y a %d paquets fournissant %s disponibles :"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Il y a probablement une autre instance Pacman en cours. Attente..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Taille totale occupée par les paquets : %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Nombre total de paquets installés :%s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Essayer de les compiler quand même ?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Impossible de nettoyer :"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Impossible de trouver les paquets suivants :"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Impossible de traiter le vote pour le paquet :%s. Erreur :%s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Impossible de supprimer %s: %s "
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Version"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Votes"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay version v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]Aucun"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -500,7 +565,7 @@ msgstr ""
 "\n"
 "Répertoire de compilation :"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -512,20 +577,20 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "abandon dû à l'utilisateur"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr ""
 " argument '-' spécifié sans fournir de donnée via l'entrée standard stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "impossible de trouver le PKGBUILD and .SRCINFO dans le répertoire"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "impossible de trouver le paquet : %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "impossible de trouver PKGDEST pour : %s"
 
@@ -533,25 +598,24 @@ msgstr "impossible de trouver PKGDEST pour : %s"
 msgid "could not find all required packages"
 msgstr "impossible de trouver tous les paquets requis"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "impossible de trouver d’archive pour les paquets listés dans %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "dépendance"
 
 #: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr ""
-"échec du contrôle de développement pour le paquet : %s a rencontré une "
-"erreur"
+"échec du contrôle de développement pour le paquet : %s a rencontré une erreur"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "l'éditeur de texte n'a pas été quitté correctement, annulation : %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "erreur lors du téléchargement des sources : %s"
 
@@ -559,19 +623,19 @@ msgstr "erreur lors du téléchargement des sources : %s"
 msgid "error fetching %s: %s"
 msgstr "erreur lors de la récupération %s : %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "erreur à l'installation des dépôts des paquets"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "erreur à l'installation:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "erreur lors de la construction : %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "erreur lors de la fusion %s : %s"
 
@@ -579,20 +643,20 @@ msgstr "erreur lors de la fusion %s : %s"
 msgid "error reading %s"
 msgstr "erreur lors de la lecture : %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "erreur lors de la mise à jour des bases de données"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "erreur lors de la réinitialisation %s : %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr ""
 "erreur lors de la mise à jour de la raison d'installation du paquet vers %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "explicite"
 
@@ -600,27 +664,27 @@ msgstr "explicite"
 msgid "failed to create directory '%s': %s"
 msgstr "impossible de créer le répertoire '%s' : %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "échec lors de l'ouverture du fichier de configuration '%s' : %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "échec lors de la lecture %s -- omission : %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "échec lors de la lecture %s : %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "impossible d'analyser le .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "échec lors de la lecture du fichier de configuration '%s' : %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "impossible de récupérer le cache AUR"
 
@@ -634,7 +698,7 @@ msgstr ""
 msgid "input too long"
 msgstr "entrée trop longue"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "nombre invalide : %s"
 
@@ -642,7 +706,7 @@ msgstr "nombre invalide : %s"
 msgid "invalid option '%s'"
 msgstr "option invalide '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "paramètres incorrects : '--deps' et '--explicit' ne devaient pas être "
@@ -652,11 +716,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "référentiel invalide"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "valeur invalide : %d n'est pas entre %d et %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "aucune clé à importer"
 
@@ -664,15 +728,15 @@ msgstr "aucune clé à importer"
 msgid "no query was executed"
 msgstr "aucune requête n'a été exécutée"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "pas de répertoire cible spécifié"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "non"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "rien à installer pour %s"
 
@@ -680,7 +744,11 @@ msgstr "rien à installer pour %s"
 msgid "only one operation may be used at a time"
 msgstr "une seule opération peut être réalisée à la fois"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "paquet '%s' n'a pas été trouvé"
 
@@ -692,31 +760,30 @@ msgstr "paquet non trouvé dans AUR"
 msgid "package not found in repos"
 msgstr "paquet non trouvé dans les référentiels"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "paquet"
 msgstr[1] "paquets"
 msgstr[2] "paquets"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "erreur lors de l'import des clés"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "suppression des paquets AUR du cache..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "suppression des fichiers AUR non suivis du cache..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
-msgstr ""
-"le fchier PKGDEST pour %s est listé par makepkg mais n'existe pas : %s"
+msgstr "le fchier PKGDEST pour %s est listé par makepkg mais n'existe pas : %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "il n’y a rien à faire"
 
@@ -724,14 +791,14 @@ msgstr "il n’y a rien à faire"
 msgid "unable to CreateHandle: %s"
 msgstr "impossible de créer le répertoire : %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "opération non gérée"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "version inconnue"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -1,64 +1,64 @@
-# 
+#
 # Translators:
 # Yaron Shahrabani <sh.yaron@gmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>, 2023\n"
 "Language-Team: Hebrew (https://app.transifex.com/yay-1/teams/123732/he/)\n"
+"Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: he\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
+"1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (קיימים קובצי בנייה)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (מותקנת)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [מותקנת]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "אין מטרות לביצוע"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
-msgstr ""
-"%s [A]-הכול [Ab]-ביטול [I]-מותקנות [No]-לא מותקנות או (1 2 3, 1-3, ‎^4)"
+msgstr "%s [A]-הכול [Ab]-ביטול [I]-מותקנות [No]-לא מותקנות או (1 2 3, 1-3, ‎^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s כבר נבנתה -- לא תיבנה שוב"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s לא מוגדר"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s קיימת."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s עדכנית -- מדלגים"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s לשדרוג/התקנה."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "גם %s תותקן לשם הפעולה הזאת."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, נדרשה ע״י: %s"
 
@@ -78,25 +78,81 @@ msgstr "%s: אי אפשר להשתמש ביעד עם האפשרות ‎--repo --
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: מתעלמים משדרוג חבילה (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: מקומית (%s) חדשה יותר מ־AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr "%s: נא להגדיר את משתני הסביבה AUR_USERNAME ו־AUR_PASSWORD כדי להצביע"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD ירד מ־ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD שירד: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD שירד: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) מתבצע פענוח של SRCINFO: %s"
 
@@ -116,7 +172,7 @@ msgstr "(יתומה)"
 msgid "(Out-of-date: %s)"
 msgstr "(לא עדכנית: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "כתובת AUR"
 
@@ -124,7 +180,7 @@ msgstr "כתובת AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "יש להוסיף %s או %s למשתני הסביבה שלך"
 
@@ -136,7 +192,7 @@ msgstr "כדאי להימנע מהפעלה תחת root/sudo."
 msgid "Check Dependency"
 msgstr "בדיקת תלות"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "בדיקת תלויות"
 
@@ -144,15 +200,15 @@ msgstr "בדיקת תלויות"
 msgid "Checking development packages..."
 msgstr "חבילות הפיתוח נבדקות…"
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "מתבצע ניקיון (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "סותר את"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "מתבצעת מחיקה (%d/%d): %s"
 
@@ -160,15 +216,15 @@ msgstr "מתבצעת מחיקה (%d/%d): %s"
 msgid "Dependency"
 msgstr "תלות"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "תלויה ב־"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "תיאור"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "הבדלים להצגה?"
 
@@ -176,19 +232,19 @@ msgstr "הבדלים להצגה?"
 msgid "Disable 'provides' setting by default"
 msgstr "להשבית את הגדרת ‚provides’ (מספקת) כברירת מחדל"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "להסיר את כל חבילות ה־AUR מהמטמון?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "להסיר את כל קובצי ה־AUR שאינם במעקב?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "להסיר את כל חבילות ה־AUR האחרות מהמטמון?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "לערוך את PKGBUILD עם?"
 
@@ -196,7 +252,7 @@ msgstr "לערוך את PKGBUILD עם?"
 msgid "Error during AUR search: %s\n"
 msgstr "שגיאה בחיפוש AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr "החרגת חבילות עשויה להוביל לשדרוג חלקי ולפגוע במערכות"
 
@@ -204,32 +260,32 @@ msgstr "החרגת חבילות עשויה להוביל לשדרוג חלקי ו
 msgid "Explicit"
 msgstr "מפורש"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "חבילות שהותקנו מפורשות: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "נכשל האיתור בחבילת AUR עבור"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "התקנת השכבה נכשלה, מתבצעת התקדמות לשכבה הבאה."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "התקנת החבילות הבאות נכשלה. נדרשת התערבות ידנית:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "הוגשה לראשונה"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "חבילות AUR שסומנו כלא עדכניות:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "חבילות זרות מותקנות: %s"
 
@@ -237,31 +293,31 @@ msgstr "חבילות זרות מותקנות: %s"
 msgid "Found git repo: %s"
 msgstr "נמצא מאגר git: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "יצירת מסד הנתונים (GenDB) הסתיימה. לא הותקנו חבילות"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "קבוצות"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "לייבא?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "מתבצע ייבוא מפתחות עם gpg…"
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "מילות מפתח"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "שינוי אחרון"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "רישיונות"
 
@@ -269,7 +325,7 @@ msgstr "רישיונות"
 msgid "Local"
 msgstr "מקומי"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "תחזוקה"
 
@@ -277,11 +333,11 @@ msgstr "תחזוקה"
 msgid "Make Dependency"
 msgstr "תלות בנייה"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "תלויות בנייה"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "חבילות ניפוי שגיאות חסרות ב־AUR:"
 
@@ -289,35 +345,40 @@ msgstr "חבילות ניפוי שגיאות חסרות ב־AUR:"
 msgid "Missing"
 msgstr "חסרות"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "שם"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "לא נמצאה חבילת AUR עבור"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "לא נמצאה חבילת AUR עבור"
+
+#: print.go:225
 msgid "None"
 msgstr "ללא"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "תלויות רשות"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "חבילות AUR יתומות (לא מתוחזקות):"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "לא עדכניות"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "מפתחות PGP שיש לייבא:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD עדכני, לא תתבצע הורדה: %s"
 
@@ -325,55 +386,59 @@ msgstr "PKGBUILD עדכני, לא תתבצע הורדה: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "קובצי PKGBUILD לעריכה?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "מזהה בסיס החבילה"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "בסיס חבילה"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "חבילות שאינן ב־AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "חבילות לבנייה מההתחלה (cleanBuild)?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "חבילות להחרגה"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr "חבילות שיוחרגו: (למשל: „1 2 3”, „1-3”, „‎^4” או שם המאגר)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "חבילות להתקנה (למשל: 1 2 3, 1-3 או ‎^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "פופולריות"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "להמשיך בהתקנה?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "מספקת"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "להסיר תלויות בנייה לאחר ההתקנה?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "מאגר AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "מאגר"
 
@@ -393,15 +458,15 @@ msgstr "מתבצע חיפוש אחר עדכונים במסדי הנתונים…
 msgid "Showing repo packages only"
 msgstr "מוצגות חבילות מאגר בלבד"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "גודל המטמון של pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "גודל המטמון של yay %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "כתובת לכידה"
 
@@ -409,71 +474,71 @@ msgstr "כתובת לכידה"
 msgid "Sync"
 msgstr "סנכרון"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "עשרת החבילות הגדולות:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "החבילות הבאות אינן תואמות לארכיטקטורת המעבד שלך:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "יש %d ספקים זמינים עבור %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "יכול להיות שעוד מופע של Pacman פעיל. ממתינים…"
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "הגודל הכולל שתופסות החבילות: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "סך כל החבילות המותקנות: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "לנסות לבנות אותן בכל מקרה?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "כתובת"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "לא ניתן לפנות:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "לא ניתן למצוא את החבילות הבאות:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "לא ניתן לטפל בהצבעות חבילה עבור: %s. שגיאה: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "לא ניתן להסיר את %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "גרסה"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "הצבעות"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay גרסה ‎v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]-כלום"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -481,7 +546,7 @@ msgstr ""
 "\n"
 "תיקיית בנייה:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -493,19 +558,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "בוטל לבקשת המשתמש"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "סופק המשתנה ‚-’ ללא שום קלט ל־stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "לא ניתן לאתר PKGBUILD ו־‎.SRCINFO בתיקייה"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "לא ניתן למצוא את שם החבילה: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "לא ניתן למצוא PKGDEST עבור: %s"
 
@@ -513,11 +578,11 @@ msgstr "לא ניתן למצוא PKGDEST עבור: %s"
 msgid "could not find all required packages"
 msgstr "לא ניתן למצוא את כל החבילות הנחוצות"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "לא ניתן למצוא ארכיוני חבילות כלשהם שמופיעים תחת %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "תלות"
 
@@ -525,11 +590,11 @@ msgstr "תלות"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "בדיקת פיתוח לחבילה נכשלה: ‚%s’ נתקל בשגיאה"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "העורך לא יצא כמו שצריך, הפעולה מבוטלת: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "שגיאה בהורדת קוד מקור: %s"
 
@@ -537,19 +602,19 @@ msgstr "שגיאה בהורדת קוד מקור: %s"
 msgid "error fetching %s: %s"
 msgstr "שגיאה במשיכת %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "שגיאה בהתקנת חבילות מאגר"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "שגיאה בהתקנה:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "שגיאה בבנייה: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "שגיאה במיזוג %s: %s"
 
@@ -557,19 +622,19 @@ msgstr "שגיאה במיזוג %s: %s"
 msgid "error reading %s"
 msgstr "שגיאה בקריאת %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "שגיאה ברענון מסדי נתונים"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "שגיאה באיפוס %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "שגיאה בעדכון סיבת התקנת החבילה לכדי %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "מפורש"
 
@@ -577,27 +642,27 @@ msgstr "מפורש"
 msgid "failed to create directory '%s': %s"
 msgstr "יצירת התיקייה ‚%s’ נכשלה: %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "פתיחת קובץ ההגדרות ‚%s’ נכשלה: %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "הפענוח של %s נכשל -- מדלגים: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "הפענוח של %s נכשל: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "פענוח ה־‎.SRCINFO נכשל"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "קריאת קובץ ההגדרות ‚%s’ נכשלה: %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "משיכת המטמון של ה־aur נכשלה"
 
@@ -609,7 +674,7 @@ msgstr "התעלמות משדרוג חבילת פיתוח (devel - לא נמצא
 msgid "input too long"
 msgstr "הקלט ארוך מדי"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "מס׳ שגוי: %s"
 
@@ -617,7 +682,7 @@ msgstr "מס׳ שגוי: %s"
 msgid "invalid option '%s'"
 msgstr "האפשרות ‚%s’ שגויה"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr "אפשרות שגויה: אסור להשתמש ב־‚‎--deps' וב־‚‎--explicit’ יחד"
 
@@ -625,11 +690,11 @@ msgstr "אפשרות שגויה: אסור להשתמש ב־‚‎--deps' וב־�
 msgid "invalid repository"
 msgstr "מאגר שגוי"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "ערך שגוי: %d לא בין %d לבין %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "אין מפתחות לייבוא"
 
@@ -637,15 +702,15 @@ msgstr "אין מפתחות לייבוא"
 msgid "no query was executed"
 msgstr "לא הופעלה שאילתה"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "לא צוינו תיקיות יעד"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "לא"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "אין מה להתקין עבור %s"
 
@@ -653,7 +718,11 @@ msgstr "אין מה להתקין עבור %s"
 msgid "only one operation may be used at a time"
 msgstr "אפשר להשתמש בפעולה אחת בכל רגע נתון"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "החבילה ‚%s’ נכשלה"
 
@@ -665,7 +734,7 @@ msgstr "החבילה לא נמצאה ב־AUR"
 msgid "package not found in repos"
 msgstr "החבילה לא נמצאה במאגרים"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "חבילה"
@@ -673,23 +742,23 @@ msgstr[1] "חבילות"
 msgstr[2] "חבילות"
 msgstr[3] "חבילות"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "תקלה בייבוא מפתחות"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "חבילות AUR נמחקות מהמטמון…"
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "קובצי AUR שאינם במעקב נמחקים מהמטמון…"
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "ה־PKGDEST עבור %s מוצג על ידי makepkg אך אינו קיים: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "אין מטרות לביצוע"
 
@@ -697,14 +766,14 @@ msgstr "אין מטרות לביצוע"
 msgid "unable to CreateHandle: %s"
 msgstr "לא ניתן ליצור כינוי (CreateHandle): %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "פעולה שלא טופלה"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "גרסה-לא-ידועה"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "כן"

--- a/po/id.po
+++ b/po/id.po
@@ -1,66 +1,67 @@
-# 
+#
 # Translators:
 # Ludovico, 2022
 # Linerly ., 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Linerly ., 2023\n"
-"Language-Team: Indonesian (https://app.transifex.com/yay-1/teams/123732/id/)\n"
+"Language-Team: Indonesian (https://app.transifex.com/yay-1/teams/123732/"
+"id/)\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr "(File Pembangunan Sudah Ada)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr "(Terpasang)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr "[Terpasang]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "tidak ada yang dapat dilakukan"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]Semua [Ab]Batalkan [I]Terpasang [No]BelumTerpasang atau (1 2 3, 1-3, "
 "^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s sudah dibuat -- melewatkan pembangunan"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s tidak diatur"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s sudah ada."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s sudah yang terbaru -- melewatkan"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s untuk ditingkatkan/pasang."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "%s juga akan dipasang untuk tindakan ini."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, dibutuhkan oleh: %s"
 
@@ -80,27 +81,83 @@ msgstr "%s: tidak dapat menggunakan target dengan opsi --repo -- melewatkan"
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: mengabaikan peningkatan paket (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: lokal (%s) lebih baru dari yang AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "%s: mohon tetapkan variabel lingkungan AUR_USERNAME dan AUR_PASSWORD untuk "
 "pemungutan suara"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD terunduh dari ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD terunduh: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD terunduh: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Menguraikan SRCINFO: %s"
 
@@ -120,7 +177,7 @@ msgstr "(Tertinggal)"
 msgid "(Out-of-date: %s)"
 msgstr "(Kedaluwarsa: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL AUR"
 
@@ -128,7 +185,7 @@ msgstr "URL AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Tambahkan %s atau %s ke variabel lingkungan Anda"
 
@@ -140,7 +197,7 @@ msgstr "Hindari menjalankan yay sebagai root/sudo."
 msgid "Check Dependency"
 msgstr "Periksa Ketergantungan"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Periksa Ketergantungan"
 
@@ -148,15 +205,15 @@ msgstr "Periksa Ketergantungan"
 msgid "Checking development packages..."
 msgstr "Memeriksa paket-paket pengembangan..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Membersihkan (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Berkonflik Dengan"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Menghapus (%d/%d): %s"
 
@@ -164,15 +221,15 @@ msgstr "Menghapus (%d/%d): %s"
 msgid "Dependency"
 msgstr "Ketergantungan"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Tergantung Pada"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Deskripsi"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Tampilkan perbedaan?"
 
@@ -180,19 +237,19 @@ msgstr "Tampilkan perbedaan?"
 msgid "Disable 'provides' setting by default"
 msgstr "Nonaktifkan pengaturan 'menyediakan' secara bawaan"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Apakah Anda ingin menghapus SEMUA paket AUR dari cache?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Apakah Anda ingin menghapus SEMUA file AUR yang tidak dilacak?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Apakah Anda ingin menghapus semua paket AUR lainnya dari cache?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Edit PKGBUILD dengan?"
 
@@ -200,7 +257,7 @@ msgstr "Edit PKGBUILD dengan?"
 msgid "Error during AUR search: %s\n"
 msgstr "Terjadi kesalahan melakukan pencarian AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Tidak menyertakan paket dapat menyebabkan peningkatan parsial dan merusak "
@@ -210,32 +267,32 @@ msgstr ""
 msgid "Explicit"
 msgstr "Eksplisit"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Paket yang terpasang secara eksplisit: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Gagal mencari paket AUR untuk"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Gagal memasang lapisan, menggulirkan ke lapisan berikutnya."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "Gagal memasang paket berikut. Intervensi manual dibutuhkan:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Pengiriman Pertama"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Paket AUR Yang Ditandai Sebagai Kedaluwarsa:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Total paket-paket asing yang terpasang: %s"
 
@@ -243,31 +300,31 @@ msgstr "Total paket-paket asing yang terpasang: %s"
 msgid "Found git repo: %s"
 msgstr "Ditemukan repositori git: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB selesai. Tidak ada paket yang terpasang"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Grup"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Impor?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Mengimpor kunci-kunci dengan gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Kata Kunci"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Terakhir Diubah"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Lisensi"
 
@@ -275,7 +332,7 @@ msgstr "Lisensi"
 msgid "Local"
 msgstr "Lokal"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Pemelihara"
 
@@ -283,11 +340,11 @@ msgstr "Pemelihara"
 msgid "Make Dependency"
 msgstr "Ketergantungan Make"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Dependensi Make"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Paket Debug AUR Yang Tidak Ditemukan:"
 
@@ -295,35 +352,40 @@ msgstr "Paket Debug AUR Yang Tidak Ditemukan:"
 msgid "Missing"
 msgstr "Tidak Ditemukan"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Nama"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Tidak ada paket AUR yang ditemukan untuk"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Tidak ada paket AUR yang ditemukan untuk"
+
+#: print.go:225
 msgid "None"
 msgstr "Tidak Ada"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Dependensi Opsional"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Paket AUR Tersendiri (tidak dipelihara):"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Kedaluwarsa"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Kunci-kunci PGP membutuhkan pengimporan:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD sudah terbaru, melewati pengunduhan: %s"
 
@@ -331,57 +393,61 @@ msgstr "PKGBUILD sudah terbaru, melewati pengunduhan: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "PKGBUILD apa saja untuk diedit?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID Basis Paket"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Basis Paket"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Paket yang tidak ada di AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Paket-paket di bangunBersih?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Paket untuk tidak disertakan"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr ""
 "Paket-paket yang tidak disertakan: (mis: \"1 2 3\", \"1-3\", \"^4\", atau "
 "nama repositori)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Paket-paket untuk dipasang (mis: 1 2 3, 1-3, atau ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularitas"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Lanjutkan dengan pemasangan?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Menyediakan"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Hapus dependensi make setelah pemasangan?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repositori AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repositori"
 
@@ -401,15 +467,15 @@ msgstr "Mencari basis data untuk pembaruan..."
 msgid "Showing repo packages only"
 msgstr "Menampilkan paket-paket repositori saja"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Ukuran cache pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Ukuran cache yay%s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL Snapshot"
 
@@ -417,71 +483,71 @@ msgstr "URL Snapshot"
 msgid "Sync"
 msgstr "Sinkron"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Sepuluh paket terbesar:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Paket-paket berikut ini tidak kompatibel dengan arsitektur Anda:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Tersedia %d penyedia untuk %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Mungkin ada instansi Pacman yang lain. Menunggu..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Total Ukuran ditempati oleh paket-paket: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Total paket-paket terpasang: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Coba membangun saja?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Tidak dapat membersihkan:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Tidak dapat mencari paket-paket berikut ini:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Tidak dapat menangani pemungutan suara paket untuk: %s. kesalahan: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Tidak dapat menghapus %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Versi"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Suara"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay versi v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[T]idak Ada"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -489,7 +555,7 @@ msgstr ""
 "\n"
 "Direktori pembangunan:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -501,19 +567,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "membatalkan karena pengguna"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "argumen '-' ditentukan tanpa masukan pada stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "tidak dapat menemukan PKGBUILD dan .SRCINFO di direktori"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "tidak dapat menemukan nama paket: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "tidak dapat menemukan PKGDEST untuk: %s"
 
@@ -521,11 +587,11 @@ msgstr "tidak dapat menemukan PKGDEST untuk: %s"
 msgid "could not find all required packages"
 msgstr "tidak dapat menemukan semua paket yang dibutuhkan"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "tidak dapat mencari paket arsip apa pun yang terdaftar di %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "ketergantungan"
 
@@ -533,11 +599,11 @@ msgstr "ketergantungan"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "pemeriksaan devel untuk paket gagal: '%s' mengalami sebuah kesalahan"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "editor tidak berhasil keluar, membatalkan: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "terjadi kesalahan mengunduh sumber-sumber: %s"
 
@@ -545,19 +611,19 @@ msgstr "terjadi kesalahan mengunduh sumber-sumber: %s"
 msgid "error fetching %s: %s"
 msgstr "terjadi kesalahan mendapatkan %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "terjadi kesalahan memasang paket-paket repositori"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "terjadi kesalahan memasang:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "terjadi kesalahan membuat: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "terjadi kesalahan menggabungkan %s: %s"
 
@@ -565,19 +631,19 @@ msgstr "terjadi kesalahan menggabungkan %s: %s"
 msgid "error reading %s"
 msgstr "terjadi kesalahan membaca %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "terjadi kesalahan memuat ulang basis data"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "terjadi kesalahan mengatur ulang %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "terjadi kesalahan memperbarui alasan pemasangan paket ke %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "eksplisit"
 
@@ -585,40 +651,39 @@ msgstr "eksplisit"
 msgid "failed to create directory '%s': %s"
 msgstr "gagal untuk membuat direktori '%s': %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "gagal untuk membuka file konfigurasi '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "gagal untuk menguraikan %s -- melewatkan: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "gagal untuk menguraikan %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "gagal mengurai .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "gagal untuk membaca file konfigurasi '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "gagal mendapatkan Cache aur"
 
 #: pkg/upgrade/sources.go:27
 msgid "ignoring package devel upgrade (no AUR info found):"
-msgstr ""
-"mengabaikan pembaruan paket devel (tidak ada info AUR yang ditemukan):"
+msgstr "mengabaikan pembaruan paket devel (tidak ada info AUR yang ditemukan):"
 
 #: pkg/text/errors.go:8
 msgid "input too long"
 msgstr "input terlalu panjang"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "Nomor tidak valid: %s"
 
@@ -626,7 +691,7 @@ msgstr "Nomor tidak valid: %s"
 msgid "invalid option '%s'"
 msgstr "opsi '%s' tidak valid"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "opsi tidak valid: '--deps' dan '--explicit' tidak boleh digunakan bersama"
@@ -635,11 +700,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "repositori tidak valid"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "nilai tidak valid: %d tidak di antara %d dan %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "tidak ada kunci-kunci untuk diimpor"
 
@@ -647,15 +712,15 @@ msgstr "tidak ada kunci-kunci untuk diimpor"
 msgid "no query was executed"
 msgstr "tidak ada pencarian yang dilakukan"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "tidak ada sasaran direktori yang ditetapkan"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "tidak"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "tidka ada yang untuk dipasang untuk %s"
 
@@ -663,7 +728,11 @@ msgstr "tidka ada yang untuk dipasang untuk %s"
 msgid "only one operation may be used at a time"
 msgstr "hanya satu operasi yang dapat digunakan"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "paket '%s' tidak ditemukan"
 
@@ -675,28 +744,28 @@ msgstr "paket tidak ditemukan di AUR"
 msgid "package not found in repos"
 msgstr "paket tidak ditemukan di repositori"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "paket"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "terjadi masalah mengimpor kunci-kunci"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "menghapus paket-paket AUR dari cache..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "menghapus file AUR yang tidak dilacak dari cache..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "PKGDEST untuk %s didaftarkan oleh makepkg tetapi tidak ada: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "tidak ada yang dapat dilakukan"
 
@@ -704,14 +773,14 @@ msgstr "tidak ada yang dapat dilakukan"
 msgid "unable to CreateHandle: %s"
 msgstr "tidak dapat CreateHandle: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "operasi tidak diproses"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "versi-tidak-diketahui"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "ya"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1,68 +1,70 @@
-# 
+#
 # Translators:
 # Cardellino, 2021
 # Giulio Terigi, 2022
 # Simone Dotto <simonedotto@protonmail.com>, 2022
 # jheitz223, 2022
 # Vincenzo Reale <vinx.reale@gmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Vincenzo Reale <vinx.reale@gmail.com>, 2023\n"
-"Language-Team: Italian (Italy) (https://app.transifex.com/yay-1/teams/123732/it_IT/)\n"
+"Language-Team: Italian (Italy) (https://app.transifex.com/yay-1/teams/123732/"
+"it_IT/)\n"
+"Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it_IT\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (I file di compilazione sono già presenti)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Installato)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Installato]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " non c'è nulla da fare"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]Tutti [Ab]Annulla [I]nstallati [No]nInstallati oppure (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s già fatto -- compilazione saltata"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s non è impostato"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s è presente."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s è aggiornato -- ignorato"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s da aggiornare/installare."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "%s sarà inoltre installato per questa operazione."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, richiesto da: %s"
 
@@ -82,27 +84,83 @@ msgstr "%s: non si può usare il target con l'opzione --repo -- ignorato"
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: aggiornamento dei pacchetti ignorato (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: il pacchetto locale (%s) è più nuovo del pacchetto AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "%s: imposta le variabili d'ambiente AUR_USERNAME e AUR_PASSWORD prima di "
 "votare"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD scaricato da ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD scaricato: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD scaricato: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Analisi SRCINFO: %s"
 
@@ -122,7 +180,7 @@ msgstr "(Orfano)"
 msgid "(Out-of-date: %s)"
 msgstr "(Obsoleto: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL di AUR"
 
@@ -130,7 +188,7 @@ msgstr "URL di AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Aggiungi %s o %s alle tue variabili d'ambiente"
 
@@ -142,7 +200,7 @@ msgstr "Evita di eseguire yay come root/sudo."
 msgid "Check Dependency"
 msgstr "Controllo dipendenza"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Controllo dipendenze"
 
@@ -150,15 +208,15 @@ msgstr "Controllo dipendenze"
 msgid "Checking development packages..."
 msgstr "Verifica dei pacchetti di sviluppo in corso..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Pulizia (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Conflitti con"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Eliminazione (%d/%d): %s"
 
@@ -166,15 +224,15 @@ msgstr "Eliminazione (%d/%d): %s"
 msgid "Dependency"
 msgstr "Dipendenza"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Dipende da"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Descrizione"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Differenze da mostrare?"
 
@@ -182,19 +240,19 @@ msgstr "Differenze da mostrare?"
 msgid "Disable 'provides' setting by default"
 msgstr "Disabilita l'impostazione 'provides' in modo predefinito"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Vuoi rimuovere TUTTI i pacchetti AUR dalla cache?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Vuoi rimuovere TUTTI i file AUR non monitorati?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Vuoi rimuovere tutti gli altri pacchetti AUR dalla cache?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Con cosa modificare il PKGBUILD?"
 
@@ -202,7 +260,7 @@ msgstr "Con cosa modificare il PKGBUILD?"
 msgid "Error during AUR search: %s\n"
 msgstr "Errore durante la ricerca in AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "L'esclusione di pacchetti potrebbe causare aggiornamenti parziali e "
@@ -212,35 +270,35 @@ msgstr ""
 msgid "Explicit"
 msgstr "Esplicito"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Pacchetti installati esplicitamente: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Impossibile trovare il pacchetto AUR per"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr ""
 "Installazione del livello non riuscita, passaggio al livello successivo."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 "Installazione dei seguenti pacchetti non riuscita. È richiesto l'intervento "
 "manuale:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Primo invio"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Pacchetti AUR con flag obsoleto:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Totale dei pacchetti estranei installati: %s"
 
@@ -248,31 +306,31 @@ msgstr "Totale dei pacchetti estranei installati: %s"
 msgid "Found git repo: %s"
 msgstr "Trovato repository git: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB terminato. Nessun pacchetto è stato installato"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Gruppi"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Importare?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Importazione delle chiavi con gpg in corso..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Parole chiave"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Ultima modifica"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Licenze"
 
@@ -280,7 +338,7 @@ msgstr "Licenze"
 msgid "Local"
 msgstr "Locale"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Responsabile"
 
@@ -288,11 +346,11 @@ msgstr "Responsabile"
 msgid "Make Dependency"
 msgstr "Dipendenza Make"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Make dipendenze"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Pacchetti AUR di debug mancanti:"
 
@@ -300,35 +358,40 @@ msgstr "Pacchetti AUR di debug mancanti:"
 msgid "Missing"
 msgstr "Mancante"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Nome"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Nessun pacchetto AUR trovato per"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Nessun pacchetto AUR trovato per"
+
+#: print.go:225
 msgid "None"
 msgstr "Nessuno"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Dipendenze opzionali"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Pacchetti AUR orfani (non mantenuti):"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Obsoleto"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Le chiavi PGP devono essere importate:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD aggiornato, scaricamento ignorato: %s"
 
@@ -336,55 +399,60 @@ msgstr "PKGBUILD aggiornato, scaricamento ignorato: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "Quali PKGBUILD modificare?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID pacchetto base"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Pacchetto base"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Pacchetti non in AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Pacchetti da compilare in modo pulito?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Pacchetti da escludere"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Pacchetti da escludere: (es: \"1 2 3\", \"1-3\", \"^4\" o il nome del repo)"
+msgstr ""
+"Pacchetti da escludere: (es: \"1 2 3\", \"1-3\", \"^4\" o il nome del repo)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Pacchetti da installare (es: 1 2 3, 1-3 o ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popolarità"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Procedere con l'installazione?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Fornisce"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Rimuovere le dipendenze di make dopo l'installazione?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repository AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repository"
 
@@ -404,15 +472,15 @@ msgstr "Ricerca di aggiornamenti nei database in corso..."
 msgid "Showing repo packages only"
 msgstr "Visualizzazione dei soli pacchetti del repo"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Dimensione della cache di pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Dimensione della cache di yay %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL snapshot"
 
@@ -420,72 +488,72 @@ msgstr "URL snapshot"
 msgid "Sync"
 msgstr "Sincronizza"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "I dieci pacchetti più grandi:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "I seguenti pacchetti non sono compatibili con la tua architettura:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Ci sono %d fornitori disponibili per %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr ""
 "Potrebbe esserci un'altra istanza di Pacman in esecuzione. In attesa... "
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Dimensione totale occupata dai pacchetti: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Totale dei pacchetti installati: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Provare a compilarli comunque?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Impossibile pulire:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Impossibile trovare i seguenti pacchetti:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Impossibile gestire il voto per: %s. errore: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Impossibile rimuovere %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Versione"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Voti"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Versione di yay v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]essuno"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -493,7 +561,7 @@ msgstr ""
 "\n"
 "Cartella di compilazione:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -505,19 +573,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "interruzione su richiesta dell'utente in corso"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "argomento '-' specificato senza input su stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "impossibile trovare PKGBUILD e .SRCINFO nella cartella"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "impossibile trovare un pacchetto di nome: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "impossibile trovare il PKGDEST per: %s"
 
@@ -525,11 +593,11 @@ msgstr "impossibile trovare il PKGDEST per: %s"
 msgid "could not find all required packages"
 msgstr "impossibile trovare tutti i pacchetti richiesti"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "impossibile trovare alcun archivio di pacchetti elencato in %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "dipendenza"
 
@@ -538,11 +606,11 @@ msgid "devel check for package failed: '%s' encountered an error"
 msgstr ""
 "devel check non riuscito per il pacchetto: '%s' ha riscontrato un errore"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "l'editor non è uscito correttamente, interruzione in corso: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "errore durante lo scaricamento dei sorgenti: %s"
 
@@ -550,19 +618,19 @@ msgstr "errore durante lo scaricamento dei sorgenti: %s"
 msgid "error fetching %s: %s"
 msgstr "errore durante il recupero di %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "errore durante l'installazione dei pacchetti del repo"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "installazione non riuscita:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "errore durante la creazione: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "errore durante l'unione di %s: %s "
 
@@ -570,21 +638,20 @@ msgstr "errore durante l'unione di %s: %s "
 msgid "error reading %s"
 msgstr "errore durante la lettura di %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "errore durante l'aggiornamento dei database"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "errore durante il ripristino di %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr ""
-"aggiornamento della ragione d'installazione del pacchetto a %s non è "
-"riuscito"
+"aggiornamento della ragione d'installazione del pacchetto a %s non è riuscito"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "esplicito"
 
@@ -592,27 +659,27 @@ msgstr "esplicito"
 msgid "failed to create directory '%s': %s"
 msgstr "creazione della cartella '%s' non riuscita: %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "apertura del file di configurazione '%s' non riuscita: %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "analisi di %s non riuscita -- ignorato: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "analisi di %s non riuscita: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "analisi .SRCINFO non riuscita"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "lettura del file di configurazione '%s' non riuscita: %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "recupero della cache di AUR non riuscito"
 
@@ -626,7 +693,7 @@ msgstr ""
 msgid "input too long"
 msgstr "input troppo lungo"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "numero non valido: %s"
 
@@ -634,7 +701,7 @@ msgstr "numero non valido: %s"
 msgid "invalid option '%s'"
 msgstr "opzione non valida '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "opzione non valida: '--deps' e '--explicit' non possono essere usate insieme"
@@ -643,11 +710,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "repository non valido"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "valore non valido: %d non è compreso tra %d e %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "nessuna chiave da importare"
 
@@ -655,15 +722,15 @@ msgstr "nessuna chiave da importare"
 msgid "no query was executed"
 msgstr "nessuna richiesta è stata eseguita"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "nessuna cartella di destinazione specificata"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "no"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "nulla da installare per %s"
 
@@ -671,7 +738,11 @@ msgstr "nulla da installare per %s"
 msgid "only one operation may be used at a time"
 msgstr "è possibile eseguire una sola operazione alla volta"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "il pacchetto '%s' non è stato trovato"
 
@@ -683,30 +754,30 @@ msgstr "pacchetto non trovato su AUR"
 msgid "package not found in repos"
 msgstr "pacchetto non trovato nei repository"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "pacchetto"
 msgstr[1] "pacchetti"
 msgstr[2] "pacchetti"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "problema durante l'importazione delle chiavi"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "eliminazione dei pacchetti AUR dalla cache..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "eliminazione dei file AUR non tracciati dalla cache..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "il PKGDEST per %s è elencato da makepkg, ma non esiste: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr " non c'è nulla da fare"
 
@@ -714,14 +785,14 @@ msgstr " non c'è nulla da fare"
 msgid "unable to CreateHandle: %s"
 msgstr "impossibile creare un handle: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "operazione non gestita"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "versione-sconosciuta"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "sì"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,422 +8,558 @@ msgstr ""
 "PO-Revision-Date: 2021-08-13 22:55+0000\n"
 "Last-Translator: J G <transifex@jguer.space>, 2021\n"
 "Language-Team: Japanese (https://www.transifex.com/yay-1/teams/123732/ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: xgotext\n"
 
-#: install.go:563
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (ビルドファイルが存在)"
 
-#: install.go:559
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (インストール済み)"
 
-#: depCheck.go:279
-msgid " (Target"
-msgstr " (対象"
-
-#: depCheck.go:281
-msgid " (Wanted by: "
-msgstr " (必要としているパッケージ: "
-
-#: callbacks.go:72
-msgid " Input too long"
-msgstr " 入力が長すぎます"
-
-#: cmd.go:446
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [インストール済み]"
 
-#: cmd.go:402 install.go:166 install.go:200
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " 何もすることがありません"
 
-#: depCheck.go:170
-msgid "Installing %s will remove:"
-msgstr "%s をインストールすることで削除されるパッケージ:"
-
-#: install.go:583 install.go:658 install.go:665
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
-msgstr "%s [A]全て [Ab]中止 [I]インストール済み [No]未インストール または (1 2 3, 1-3, ^4)"
+msgstr ""
+"%s [A]全て [Ab]中止 [I]インストール済み [No]未インストール または (1 2 3, "
+"1-3, ^4)"
 
-#: download.go:273
-msgid "%s already downloaded -- use -f to overwrite"
-msgstr "%s は既にダウンロードされています -- -f で上書きできます"
-
-#: install.go:1086
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s は既に作成済みです -- ビルドをスキップします"
 
-#: pkg/settings/runtime.go:50 pkg/settings/runtime.go:62
-msgid "%s and %s unset"
-msgstr "%s と %s が設定されていません"
-
-#: config.go:76
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s が設定されていません"
 
-#: exec.go:71
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s が存在します。"
 
-#: install.go:1075
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s は最新です -- スキップ"
 
-#: install.go:1008
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s が満たされていません、インストールキューを消去"
-
-#: install.go:752
-msgid "%s: No changes -- skipping"
-msgstr "%s: 変更なし -- スキップ"
-
-#: utils.go:48
-msgid "%s: can't use target with option --aur -- skipping"
-msgstr "%s: 対象に --aur オプションを使うことができません -- スキップ"
-
-#: utils.go:43
-msgid "%s: can't use target with option --repo -- skipping"
-msgstr "%s: 対象に --repo オプションを使うことができません -- スキップ"
-
-#: upgrade.go:274
-msgid "%s: ignoring package upgrade (%s => %s)"
-msgstr "%s: パッケージのアップグレードを無視 (%s => %s)"
-
-#: upgrade.go:291
-msgid "%s: local (%s) is newer than AUR (%s)"
-msgstr "%s: ローカルのパッケージ (%s) は AUR (%s) よりも新しいバージョンです"
-
-#: download.go:298
-msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
-msgstr "(%d/%d) ABS から PKGBUILD をダウンロード: %s"
-
-#: install.go:805
-msgid "(%d/%d) Parsing SRCINFO: %s"
-msgstr "(%d/%d) SRCINFO を解析中: %s"
-
-#: print.go:86 print.go:127
-msgid "(Installed)"
-msgstr "(インストール済み)"
-
-#: print.go:84 print.go:125
-msgid "(Installed: %s)"
-msgstr "(インストール済み: %s)"
-
-#: print.go:75
-msgid "(Orphaned)"
-msgstr "(メンテナ不在)"
-
-#: print.go:79
-msgid "(Out-of-date: %s)"
-msgstr "(古いバージョン: %s)"
-
-#: print.go:275
-msgid "AUR URL"
-msgstr "AUR URL"
-
-#: config.go:77
-msgid "Add %s or %s to your environment variables"
-msgstr "%s または %s を環境変数に追加してください"
-
-#: main.go:182
-msgid "Avoid running yay as root/sudo."
-msgstr "yay を root や sudo で実行しないでください。"
-
-#: print.go:281
-msgid "Check Deps"
-msgstr "チェック時の依存パッケージ"
-
-#: upgrade.go:167
-msgid "Checking development packages..."
-msgstr "開発パッケージを確認..."
-
-#: depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "衝突を確認..."
-
-#: depCheck.go:144
-msgid "Checking for inner conflicts..."
-msgstr "内部衝突を確認..."
-
-#: clean.go:224
-msgid "Cleaning (%d/%d): %s"
-msgstr "消去 (%d/%d): %s"
-
-#: depCheck.go:196
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr "衝突するパッケージを手動で確認する必要があります"
-
-#: print.go:283
-msgid "Conflicts With"
-msgstr "衝突するパッケージ"
-
-#: depCheck.go:273
-msgid "Could not find all required packages:"
-msgstr "必要なパッケージを全て確認することができません:"
-
-#: clean.go:240
-msgid "Deleting (%d/%d): %s"
-msgstr "削除 (%d/%d): %s"
-
-#: print.go:279
-msgid "Depends On"
-msgstr "依存するパッケージ"
-
-#: print.go:273
-msgid "Description"
-msgstr "説明"
-
-#: install.go:657
-msgid "Diffs to show?"
-msgstr "差異を表示しますか？"
-
-#: clean.go:91
-msgid "Do you want to remove ALL AUR packages from cache?"
-msgstr "キャッシュから全ての AUR パッケージを削除しますか？"
-
-#: clean.go:108
-msgid "Do you want to remove ALL untracked AUR files?"
-msgstr "未追跡の AUR ファイルを全て削除しますか？"
-
-#: clean.go:93
-msgid "Do you want to remove all other AUR packages from cache?"
-msgstr "キャッシュから他の全ての AUR パッケージを削除しますか？"
-
-#: install.go:893
-msgid "Downloaded PKGBUILD (%d/%d): %s"
-msgstr "PKGBUILD のダウンロード (%d/%d): %s"
-
-#: config.go:80
-msgid "Edit PKGBUILD with?"
-msgstr "PKGBUILD をどのエディタで編集しますか？"
-
-#: cmd.go:346
-msgid "Error during AUR search: %s\n"
-msgstr "AUR 検索時のエラー: %s\n"
-
-#: print.go:342
-msgid "Explicitly installed packages: %s"
-msgstr "明示的にインストールしたパッケージ: %s"
-
-#: print.go:287
-msgid "First Submitted"
-msgstr "最初の投稿"
-
-#: print.go:41
-msgid "Flagged Out Of Date AUR Packages:"
-msgstr "古いバージョンのフラグが立てられた AUR パッケージ:"
-
-#: vcs.go:147
-msgid "Found git repo: %s"
-msgstr "git リポジトリを発見しました: %s"
-
-#: vcs.go:64
-msgid "GenDB finished. No packages were installed"
-msgstr "GenDB が完了しました。パッケージのインストールは行われません"
-
-#: print.go:276
-msgid "Groups"
-msgstr "グループ"
-
-#: keys.go:84
-msgid "Import?"
-msgstr "インポートしますか？"
-
-#: keys.go:97
-msgid "Importing keys with gpg..."
-msgstr "鍵を gpg でインポートします..."
-
-#: print.go:271
-msgid "Keywords"
-msgstr "キーワード"
-
-#: print.go:288
-msgid "Last Modified"
-msgstr "最終更新"
-
-#: print.go:277
-msgid "Licenses"
-msgstr "ライセンス"
-
-#: print.go:284
-msgid "Maintainer"
-msgstr "メンテナ"
-
-#: print.go:280
-msgid "Make Deps"
-msgstr "ビルド時の依存パッケージ"
-
-#: download.go:281
-msgid "Missing ABS packages:"
-msgstr "存在しない ABS パッケージ:"
-
-#: print.go:25
-msgid "Missing AUR Packages:"
-msgstr "存在しない AUR パッケージ:"
-
-#: print.go:270
-msgid "Name"
-msgstr "名前"
-
-#: pkg/text/print.go:50
-msgid "None"
-msgstr "なし"
-
-#: print.go:282
-msgid "Optional Deps"
-msgstr "任意の依存パッケージ"
-
-#: print.go:33
-msgid "Orphaned AUR Packages:"
-msgstr "メンテナが存在しない AUR パッケージ:"
-
-#: print.go:291 print.go:293
-msgid "Out-of-date"
-msgstr "古いバージョン"
-
-#: keys.go:115
-msgid "PGP keys need importing:"
-msgstr "PGP 鍵をインポートする必要があります:"
-
-#: install.go:874
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
-msgstr "PKGBUILD は最新です、スキップ (%d/%d): %s"
-
-#: install.go:664
-msgid "PKGBUILDs to edit?"
-msgstr "PKGBUILD を編集しますか？"
-
-#: print.go:298
-msgid "Package Base ID"
-msgstr "パッケージベース ID"
-
-#: print.go:299
-msgid "Package Base"
-msgstr "パッケージベース"
-
-#: install.go:582
-msgid "Packages to cleanBuild?"
-msgstr "パッケージをクリーンビルドしますか？"
-
-#: upgrade.go:365
-msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "除外するパッケージ: (例: \"1 2 3\", \"1-3\", \"^4\" またはリポジトリ名)"
-
-#: cmd.go:350
-msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
-msgstr "インストールするパッケージ (例: 1 2 3, 1-3 または ^4)"
-
-#: upgrade.go:362
-msgid "Packages to upgrade."
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
 msgstr "アップグレードするパッケージ。"
 
-#: print.go:286
-msgid "Popularity"
-msgstr "人気度"
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
 
-#: install.go:269 install.go:309
-msgid "Proceed with install?"
-msgstr "インストールを実行しますか？"
-
-#: print.go:278
-msgid "Provides"
-msgstr "提供"
-
-#: query.go:509
-msgid "Querying AUR..."
-msgstr "AUR を検索..."
-
-#: install.go:221
-msgid "Remove make dependencies after install?"
-msgstr "ビルド時の依存パッケージをインストール後に削除しますか？"
-
-#: print.go:495
-msgid "Repository AUR"
-msgstr "リポジトリ AUR"
-
-#: callbacks.go:46 print.go:269
-msgid "Repository"
-msgstr "リポジトリ"
-
-#: upgrade.go:150
-msgid "Searching AUR for updates..."
-msgstr "AUR からアップデートを検索..."
-
-#: upgrade.go:140
-msgid "Searching databases for updates..."
-msgstr "データベースからアップデートを検索..."
-
-#: cmd.go:347 query.go:194
-msgid "Showing repo packages only"
-msgstr "リポジトリのパッケージだけを表示"
-
-#: print.go:300
-msgid "Snapshot URL"
-msgstr "スナップショット URL"
-
-#: print.go:345
-msgid "Ten biggest packages:"
-msgstr "最も巨大な10のパッケージ:"
-
-#: install.go:481
-msgid "The following packages are not compatible with your architecture:"
-msgstr "以下のパッケージはあなたの使っているアーキテクチャと互換性がありません:"
-
-#: callbacks.go:36 print.go:492
-msgid "There are %d providers available for %s:\n"
-msgstr "%d 個のパッケージが %s を提供しています:\n"
-
-#: exec.go:72
-msgid "There may be another Pacman instance running. Waiting..."
-msgstr "他の Pacman インスタンスが実行中です。待機します..."
-
-#: print.go:343
-msgid "Total Size occupied by packages: %s"
-msgstr "パッケージによって使用される合計容量: %s"
-
-#: print.go:341
-msgid "Total foreign installed packages: %s"
-msgstr "全ての外部からインストールされたパッケージ: %s"
-
-#: print.go:340
-msgid "Total installed packages: %s"
-msgstr "全てのインストールされたパッケージ: %s"
-
-#: install.go:488
-msgid "Try to build them anyway?"
-msgstr "それでもパッケージをビルドしますか？"
-
-#: print.go:274
-msgid "URL"
-msgstr "URL"
-
-#: print.go:272
-msgid "Version"
-msgstr "バージョン"
-
-#: print.go:285
-msgid "Votes"
-msgstr "投票"
-
-#: print.go:338
-msgid "Yay version v%s"
-msgstr "Yay バージョン v%s"
-
-#: install.go:583 install.go:658 install.go:665
-msgid "[N]one"
-msgstr "[N]なし"
-
-#: keys.go:122
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s、必要とするパッケージ: %s"
 
-#: clean.go:96
+#: pkg/menus/diff_menu.go:49
+msgid "%s: No changes -- skipping"
+msgstr "%s: 変更なし -- スキップ"
+
+#: pkg/query/filter.go:22
+msgid "%s: can't use target with option --aur -- skipping"
+msgstr "%s: 対象に --aur オプションを使うことができません -- スキップ"
+
+#: pkg/query/filter.go:17
+msgid "%s: can't use target with option --repo -- skipping"
+msgstr "%s: 対象に --repo オプションを使うことができません -- スキップ"
+
+#: pkg/upgrade/sources.go:57
+msgid "%s: ignoring package upgrade (%s => %s)"
+msgstr "%s: パッケージのアップグレードを無視 (%s => %s)"
+
+#: pkg/query/aur_warnings.go:46
+msgid "%s: local (%s) is newer than AUR (%s)"
+msgstr "%s: ローカルのパッケージ (%s) は AUR (%s) よりも新しいバージョンです"
+
+#: vote.go:51
+msgid ""
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
+msgstr ""
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
+
+#: pkg/download/unified.go:192
+msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
+msgstr "(%d/%d) ABS から PKGBUILD をダウンロード: %s"
+
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
+#, fuzzy
+msgid "(%d/%d) Downloaded PKGBUILD: %s"
+msgstr "(%d/%d) ABS から PKGBUILD をダウンロード: %s"
+
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) ABS から PKGBUILD をダウンロード: %s"
+
+#: pkg/sync/srcinfo/service.go:109
+msgid "(%d/%d) Parsing SRCINFO: %s"
+msgstr "(%d/%d) SRCINFO を解析中: %s"
+
+#: pkg/query/types.go:72 pkg/query/types.go:103
+msgid "(Installed)"
+msgstr "(インストール済み)"
+
+#: pkg/query/types.go:70 pkg/query/types.go:101
+msgid "(Installed: %s)"
+msgstr "(インストール済み: %s)"
+
+#: pkg/query/types.go:61
+msgid "(Orphaned)"
+msgstr "(メンテナ不在)"
+
+#: pkg/query/types.go:65
+msgid "(Out-of-date: %s)"
+msgstr "(古いバージョン: %s)"
+
+#: print.go:44
+msgid "AUR URL"
+msgstr "AUR URL"
+
+#: pkg/dep/dep_graph.go:75
+#, fuzzy
+msgid "AUR"
+msgstr "URL"
+
+#: pkg/menus/edit_menu.go:58
+msgid "Add %s or %s to your environment variables"
+msgstr "%s または %s を環境変数に追加してください"
+
+#: main.go:60
+msgid "Avoid running yay as root/sudo."
+msgstr "yay を root や sudo で実行しないでください。"
+
+#: pkg/dep/dep_graph.go:63
+#, fuzzy
+msgid "Check Dependency"
+msgstr "チェック時の依存パッケージ"
+
+#: print.go:41
+msgid "Check Deps"
+msgstr "チェック時の依存パッケージ"
+
+#: pkg/upgrade/service.go:90
+msgid "Checking development packages..."
+msgstr "開発パッケージを確認..."
+
+#: pkg/sync/workdir/clean.go:45
+msgid "Cleaning (%d/%d): %s"
+msgstr "消去 (%d/%d): %s"
+
+#: print.go:42
+msgid "Conflicts With"
+msgstr "衝突するパッケージ"
+
+#: pkg/menus/clean_menu.go:62
+msgid "Deleting (%d/%d): %s"
+msgstr "削除 (%d/%d): %s"
+
+#: pkg/dep/dep_graph.go:61
+#, fuzzy
+msgid "Dependency"
+msgstr "依存するパッケージ"
+
+#: print.go:38
+msgid "Depends On"
+msgstr "依存するパッケージ"
+
+#: print.go:33
+msgid "Description"
+msgstr "説明"
+
+#: pkg/menus/diff_menu.go:160
+msgid "Diffs to show?"
+msgstr "差異を表示しますか？"
+
+#: pkg/settings/migrations.go:25
+msgid "Disable 'provides' setting by default"
+msgstr ""
+
+#: clean.go:78
+msgid "Do you want to remove ALL AUR packages from cache?"
+msgstr "キャッシュから全ての AUR パッケージを削除しますか？"
+
+#: clean.go:95
+msgid "Do you want to remove ALL untracked AUR files?"
+msgstr "未追跡の AUR ファイルを全て削除しますか？"
+
+#: clean.go:80
+msgid "Do you want to remove all other AUR packages from cache?"
+msgstr "キャッシュから他の全ての AUR パッケージを削除しますか？"
+
+#: pkg/menus/edit_menu.go:61
+msgid "Edit PKGBUILD with?"
+msgstr "PKGBUILD をどのエディタで編集しますか？"
+
+#: pkg/query/errors.go:13
+msgid "Error during AUR search: %s\n"
+msgstr "AUR 検索時のエラー: %s\n"
+
+#: pkg/upgrade/service.go:296
+msgid "Excluding packages may cause partial upgrades and break systems"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:60
+msgid "Explicit"
+msgstr ""
+
+#: print.go:91
+msgid "Explicitly installed packages: %s"
+msgstr "明示的にインストールしたパッケージ: %s"
+
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
+#, fuzzy
+msgid "Failed to find AUR package for"
+msgstr "古いバージョンのフラグが立てられた AUR パッケージ:"
+
+#: pkg/sync/build/installer.go:120
+msgid "Failed to install layer, rolling up to next layer."
+msgstr ""
+
+#: pkg/sync/build/errors.go:16
+msgid ""
+"Failed to install the following packages. Manual intervention is required:"
+msgstr ""
+
+#: print.go:45
+msgid "First Submitted"
+msgstr "最初の投稿"
+
+#: pkg/query/aur_warnings.go:79
+msgid "Flagged Out Of Date AUR Packages:"
+msgstr "古いバージョンのフラグが立てられた AUR パッケージ:"
+
+#: print.go:90
+#, fuzzy
+msgid "Foreign installed packages: %s"
+msgstr "全ての外部からインストールされたパッケージ: %s"
+
+#: pkg/vcs/vcs.go:144
+msgid "Found git repo: %s"
+msgstr "git リポジトリを発見しました: %s"
+
+#: vcs.go:72
+msgid "GenDB finished. No packages were installed"
+msgstr "GenDB が完了しました。パッケージのインストールは行われません"
+
+#: print.go:36
+msgid "Groups"
+msgstr "グループ"
+
+#: pkg/sync/srcinfo/pgp/keys.go:88
+msgid "Import?"
+msgstr "インポートしますか？"
+
+#: pkg/sync/srcinfo/pgp/keys.go:97
+msgid "Importing keys with gpg..."
+msgstr "鍵を gpg でインポートします..."
+
+#: print.go:46
+msgid "Keywords"
+msgstr "キーワード"
+
+#: print.go:47
+msgid "Last Modified"
+msgstr "最終更新"
+
+#: print.go:35
+msgid "Licenses"
+msgstr "ライセンス"
+
+#: pkg/dep/dep_graph.go:77
+msgid "Local"
+msgstr ""
+
+#: print.go:48
+msgid "Maintainer"
+msgstr "メンテナ"
+
+#: pkg/dep/dep_graph.go:62
+#, fuzzy
+msgid "Make Dependency"
+msgstr "ビルド時の依存パッケージ"
+
+#: print.go:40
+msgid "Make Deps"
+msgstr "ビルド時の依存パッケージ"
+
+#: pkg/query/aur_warnings.go:71
+#, fuzzy
+msgid "Missing AUR Debug Packages:"
+msgstr "存在しない AUR パッケージ:"
+
+#: pkg/dep/dep_graph.go:79
+msgid "Missing"
+msgstr ""
+
+#: print.go:31
+msgid "Name"
+msgstr "名前"
+
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
+msgid "No AUR package found for"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:182
+msgid "No package found for"
+msgstr ""
+
+#: print.go:225
+msgid "None"
+msgstr "なし"
+
+#: print.go:39
+msgid "Optional Deps"
+msgstr "任意の依存パッケージ"
+
+#: pkg/query/aur_warnings.go:75
+#, fuzzy
+msgid "Orphan (unmaintained) AUR Packages:"
+msgstr "メンテナが存在しない AUR パッケージ:"
+
+#: print.go:53 print.go:55
+msgid "Out-of-date"
+msgstr "古いバージョン"
+
+#: pkg/sync/srcinfo/pgp/keys.go:115
+msgid "PGP keys need importing:"
+msgstr "PGP 鍵をインポートする必要があります:"
+
+#: pkg/sync/workdir/preparer.go:252
+#, fuzzy
+msgid "PKGBUILD up to date, skipping download: %s"
+msgstr "PKGBUILD は最新です、スキップ (%d/%d): %s"
+
+#: pkg/menus/edit_menu.go:130
+msgid "PKGBUILDs to edit?"
+msgstr "PKGBUILD を編集しますか？"
+
+#: print.go:60
+msgid "Package Base ID"
+msgstr "パッケージベース ID"
+
+#: print.go:61
+msgid "Package Base"
+msgstr "パッケージベース"
+
+#: pkg/query/aur_warnings.go:67
+msgid "Packages not in AUR:"
+msgstr ""
+
+#: pkg/menus/clean_menu.go:54
+msgid "Packages to cleanBuild?"
+msgstr "パッケージをクリーンビルドしますか？"
+
+#: pkg/dep/dep_graph.go:202
+#, fuzzy
+msgid "Packages to exclude"
+msgstr "アップグレードするパッケージ。"
+
+#: pkg/upgrade/service.go:295
+msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
+msgstr ""
+"除外するパッケージ: (例: \"1 2 3\", \"1-3\", \"^4\" またはリポジトリ名)"
+
+#: cmd.go:402
+msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
+msgstr "インストールするパッケージ (例: 1 2 3, 1-3 または ^4)"
+
+#: print.go:49
+msgid "Popularity"
+msgstr "人気度"
+
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
+msgid "Proceed with install?"
+msgstr "インストールを実行しますか？"
+
+#: print.go:37
+msgid "Provides"
+msgstr "提供"
+
+#: pkg/sync/workdir/preparer.go:125
+msgid "Remove make dependencies after install?"
+msgstr "ビルド時の依存パッケージをインストール後に削除しますか？"
+
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
+msgid "Repository AUR"
+msgstr "リポジトリ AUR"
+
+#: print.go:30 pkg/db/ialpm/alpm.go:191
+msgid "Repository"
+msgstr "リポジトリ"
+
+#: pkg/dep/dep_graph.go:78
+msgid "SRCINFO"
+msgstr ""
+
+#: pkg/upgrade/service.go:72
+msgid "Searching AUR for updates..."
+msgstr "AUR からアップデートを検索..."
+
+#: pkg/upgrade/service.go:160
+msgid "Searching databases for updates..."
+msgstr "データベースからアップデートを検索..."
+
+#: pkg/query/query_builder.go:214
+msgid "Showing repo packages only"
+msgstr "リポジトリのパッケージだけを表示"
+
+#: print.go:95
+#, fuzzy
+msgid "Size of pacman cache %s: %s"
+msgstr "%s のパースに失敗: %s"
+
+#: print.go:98
+#, fuzzy
+msgid "Size of yay cache %s: %s"
+msgstr "%s のパースに失敗: %s"
+
+#: print.go:62
+msgid "Snapshot URL"
+msgstr "スナップショット URL"
+
+#: pkg/dep/dep_graph.go:76
+msgid "Sync"
+msgstr ""
+
+#: print.go:100
+msgid "Ten biggest packages:"
+msgstr "最も巨大な10のパッケージ:"
+
+#: pkg/sync/sync.go:124
+msgid "The following packages are not compatible with your architecture:"
+msgstr ""
+"以下のパッケージはあなたの使っているアーキテクチャと互換性がありません:"
+
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
+#, fuzzy
+msgid "There are %d providers available for %s:"
+msgstr "%d 個のパッケージが %s を提供しています:\n"
+
+#: pkg/settings/exe/cmd_builder.go:258
+msgid "There may be another Pacman instance running. Waiting..."
+msgstr "他の Pacman インスタンスが実行中です。待機します..."
+
+#: print.go:92
+msgid "Total Size occupied by packages: %s"
+msgstr "パッケージによって使用される合計容量: %s"
+
+#: print.go:89
+msgid "Total installed packages: %s"
+msgstr "全てのインストールされたパッケージ: %s"
+
+#: pkg/sync/sync.go:132
+msgid "Try to build them anyway?"
+msgstr "それでもパッケージをビルドしますか？"
+
+#: print.go:34
+msgid "URL"
+msgstr "URL"
+
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
+#, fuzzy
+msgid "Unable to clean:"
+msgstr "ハンドルを作成できません: %s"
+
+#: get.go:42 get.go:74
+msgid "Unable to find the following packages:"
+msgstr ""
+
+#: vote.go:20
+msgid "Unable to handle package vote for: %s. err: %s"
+msgstr ""
+
+#: clean.go:170
+#, fuzzy
+msgid "Unable to remove %s: %s"
+msgstr "%s のパースに失敗: %s"
+
+#: print.go:32
+msgid "Version"
+msgstr "バージョン"
+
+#: print.go:50
+msgid "Votes"
+msgstr "投票"
+
+#: print.go:87
+msgid "Yay version v%s"
+msgstr "Yay バージョン v%s"
+
+#: pkg/menus/menu.go:49
+msgid "[N]one"
+msgstr "[N]なし"
+
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -431,7 +567,7 @@ msgstr ""
 "\n"
 "ビルドディレクトリ:"
 
-#: callbacks.go:56 print.go:505
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -439,197 +575,322 @@ msgstr ""
 "\n"
 "数字を入力してください (デフォルト=1): "
 
-#: depCheck.go:153
-msgid ""
-"\n"
-"Inner conflicts found:"
-msgstr ""
-"\n"
-"内部衝突が存在します:"
-
-#: depCheck.go:167
-msgid ""
-"\n"
-"Package conflicts found:"
-msgstr ""
-"\n"
-"パッケージの衝突が存在します:"
-
-#: install.go:270 install.go:310 install.go:489 install.go:593 install.go:676
+#: pkg/settings/errors.go:29
 msgid "aborting due to user"
 msgstr "ユーザーによって中止"
 
-#: install.go:515
+#: pkg/settings/parser/parser.go:620
+msgid "argument '-' specified without input on stdin"
+msgstr ""
+
+#: local_install.go:26
+msgid "cannot find PKGBUILD and .SRCINFO in directory"
+msgstr ""
+
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "パッケージの名前を見つけることができません: %v"
 
-#: install.go:1048 install.go:1120
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "PKGDEST を見つけることができません: %s"
 
-#: install.go:792
+#: errors.go:9
+#, fuzzy
+msgid "could not find all required packages"
+msgstr "必要なパッケージを全て確認することができません:"
+
+#: pkg/sync/build/errors.go:61
+msgid "could not find any package archives listed in %s"
+msgstr ""
+
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
+#, fuzzy
+msgid "dependency"
+msgstr "依存するパッケージ"
+
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
+msgid "devel check for package failed: '%s' encountered an error"
+msgstr ""
+
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "エディタが正しく終了しませんでした、中止: %s"
 
-#: download.go:84 download.go:109
-msgid "error cloning %s: %s"
-msgstr "%s の複製時にエラー: %s"
-
-#: install.go:924
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "ソースのダウンロード時にエラー: %s"
 
-#: query.go:193
-msgid "error during AUR search: %s"
-msgstr "AUR の検索時にエラー: %s"
-
-#: download.go:96 download.go:121
+#: pkg/download/errors.go:25
 msgid "error fetching %s: %s"
 msgstr "%s の取得時にエラー: %s"
 
-#: install.go:333 install.go:442
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "リポジトリのパッケージのインストール時にエラー"
 
-#: install.go:1032 install.go:1072 install.go:1083 install.go:1095
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
+#, fuzzy
+msgid "error installing:"
+msgstr "リポジトリのパッケージのインストール時にエラー"
+
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "ビルド時にエラー: %s"
 
-#: download.go:135
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "%s のマージ時にエラー: %s"
 
-#: download.go:89 download.go:114
+#: pkg/download/unified.go:59
 msgid "error reading %s"
 msgstr "%s の読み取り時にエラー"
 
-#: install.go:75
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "データベースの更新時にエラー"
 
-#: clean.go:228 download.go:130
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "%s の再設定時にエラー: %s"
 
-#: main.go:68
-msgid "failed to create BuildDir directory '%s': %s"
-msgstr "BuildDir ディレクトリ '%s' の作成に失敗: %s"
+#: pkg/sync/build/errors.go:53
+msgid "error updating package install reason to %s"
+msgstr ""
 
-#: pkg/settings/runtime.go:79
+#: pkg/sync/build/errors.go:48
+msgid "explicit"
+msgstr ""
+
+#: pkg/settings/errors.go:23
 msgid "failed to create directory '%s': %s"
 msgstr "設定ディレクトリ '%s' の作成に失敗: %s"
 
-#: download.go:288
-msgid "failed to get pkgbuild: %s: %s"
-msgstr "pkgbuild の取得に失敗: %s: %s"
-
-#: download.go:296
-msgid "failed to link %s: %s"
-msgstr "%s のリンクに失敗: %s"
-
-#: main.go:29
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "設定ファイル '%s' のオープンに失敗: %s"
 
-#: main.go:51
-msgid "failed to open vcs file '%s': %s"
-msgstr "vcs ファイル '%s' のオープンに失敗: %s"
-
-#: install.go:810
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "%s のパースに失敗 -- スキップ: %s"
 
-#: install.go:813
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "%s のパースに失敗: %s"
 
-#: main.go:36
+#: local_install.go:77
+#, fuzzy
+msgid "failed to parse .SRCINFO"
+msgstr "%s のパースに失敗: %s"
+
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "設定ファイル '%s' の読み込みに失敗: %s"
 
-#: main.go:58
-msgid "failed to read vcs file '%s': %s"
-msgstr "vcs ファイル '%s' の読み込みに失敗: %s"
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
+msgid "failed to retrieve aur Cache"
+msgstr ""
 
-#: cmd.go:360 config.go:147 print.go:521
+#: pkg/upgrade/sources.go:27
+#, fuzzy
+msgid "ignoring package devel upgrade (no AUR info found):"
+msgstr "%s: パッケージのアップグレードを無視 (%s => %s)"
+
+#: pkg/text/errors.go:8
 msgid "input too long"
 msgstr "入力が長すぎます"
 
-#: callbacks.go:82 print.go:531
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "不正な数字: %s"
 
-#: pkg/settings/parser.go:144
+#: pkg/settings/parser/parser.go:174
 msgid "invalid option '%s'"
 msgstr "不正なオプション '%s'"
 
-#: cmd.go:342 cmd.go:376 cmd.go:393 print.go:62 print.go:105 query.go:189
-msgid "invalid sort mode. Fix with yay -Y --bottomup --save"
-msgstr "不正なソートモードです。yay -Y --bottomup --save で修正してください"
+#: cmd.go:207
+msgid "invalid option: '--deps' and '--explicit' may not be used together"
+msgstr ""
 
-#: callbacks.go:87 print.go:536
+#: pkg/download/abs.go:22
+#, fuzzy
+msgid "invalid repository"
+msgstr "リポジトリ"
+
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "不正な値: %d は %d と %d の間にありません"
 
-#: keys.go:110
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "インポートする鍵がありません"
 
-#: cmd.go:323
-msgid "no packages match search"
-msgstr "検索にマッチするパッケージがありません"
+#: pkg/query/errors.go:20
+msgid "no query was executed"
+msgstr ""
 
-#: config.go:112
+#: local_install.go:66
+msgid "no target directories specified"
+msgstr ""
+
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "no"
 
-#: pkg/settings/parser.go:134
+#: pkg/sync/build/installer.go:242
+msgid "nothing to install for %s"
+msgstr ""
+
+#: pkg/settings/parser/parser.go:164
 msgid "only one operation may be used at a time"
 msgstr "一度に使用できる操作はひとつだけです"
 
-#: print.go:430
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "パッケージ '%s' が見つかりませんでした"
 
-#: depCheck.go:193
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr "パッケージの衝突は noconfirm で解決できません、中止"
+#: pkg/download/errors.go:15
+#, fuzzy
+msgid "package not found in AUR"
+msgstr "パッケージ '%s' が見つかりませんでした"
 
-#: keys.go:101
+#: pkg/download/abs.go:23
+#, fuzzy
+msgid "package not found in repos"
+msgstr "パッケージ '%s' が見つかりませんでした"
+
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "パッケージベース"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "鍵のインポート時にエラー"
 
-#: install.go:178
-msgid "refusing to install AUR packages as root, aborting"
-msgstr "AUR パッケージの root によるインストールを拒否します、中止"
-
-#: clean.go:116
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "キャッシュから AUR パッケージを削除..."
 
-#: clean.go:188 clean.go:216
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "キャッシュから未追跡の AUR ファイルを削除..."
 
-#: install.go:1129
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "%s の PKGDEST が makepkg によって指定されていますが存在しません: %s"
 
-#: main.go:146
+#: pkg/sync/sync.go:45
+#, fuzzy
+msgid "there is nothing to do"
+msgstr " 何もすることがありません"
+
+#: pkg/db/ialpm/alpm.go:247
 msgid "unable to CreateHandle: %s"
 msgstr "ハンドルを作成できません: %s"
 
-#: cmd.go:177
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "ハンドルが存在しない操作"
 
-#: cmd.go:443
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "不明なバージョン"
 
-#: config.go:111
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "yes"
+
+#~ msgid " (Target"
+#~ msgstr " (対象"
+
+#~ msgid " (Wanted by: "
+#~ msgstr " (必要としているパッケージ: "
+
+#~ msgid " Input too long"
+#~ msgstr " 入力が長すぎます"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "%s をインストールすることで削除されるパッケージ:"
+
+#~ msgid "%s already downloaded -- use -f to overwrite"
+#~ msgstr "%s は既にダウンロードされています -- -f で上書きできます"
+
+#~ msgid "%s and %s unset"
+#~ msgstr "%s と %s が設定されていません"
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s が満たされていません、インストールキューを消去"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "衝突を確認..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "内部衝突を確認..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr "衝突するパッケージを手動で確認する必要があります"
+
+#~ msgid "Downloaded PKGBUILD (%d/%d): %s"
+#~ msgstr "PKGBUILD のダウンロード (%d/%d): %s"
+
+#~ msgid "Missing ABS packages:"
+#~ msgstr "存在しない ABS パッケージ:"
+
+#~ msgid "Querying AUR..."
+#~ msgstr "AUR を検索..."
+
+#~ msgid ""
+#~ "\n"
+#~ "Inner conflicts found:"
+#~ msgstr ""
+#~ "\n"
+#~ "内部衝突が存在します:"
+
+#~ msgid ""
+#~ "\n"
+#~ "Package conflicts found:"
+#~ msgstr ""
+#~ "\n"
+#~ "パッケージの衝突が存在します:"
+
+#~ msgid "error cloning %s: %s"
+#~ msgstr "%s の複製時にエラー: %s"
+
+#~ msgid "error during AUR search: %s"
+#~ msgstr "AUR の検索時にエラー: %s"
+
+#~ msgid "failed to create BuildDir directory '%s': %s"
+#~ msgstr "BuildDir ディレクトリ '%s' の作成に失敗: %s"
+
+#~ msgid "failed to get pkgbuild: %s: %s"
+#~ msgstr "pkgbuild の取得に失敗: %s: %s"
+
+#~ msgid "failed to link %s: %s"
+#~ msgstr "%s のリンクに失敗: %s"
+
+#~ msgid "failed to open vcs file '%s': %s"
+#~ msgstr "vcs ファイル '%s' のオープンに失敗: %s"
+
+#~ msgid "failed to read vcs file '%s': %s"
+#~ msgstr "vcs ファイル '%s' の読み込みに失敗: %s"
+
+#~ msgid "invalid sort mode. Fix with yay -Y --bottomup --save"
+#~ msgstr "不正なソートモードです。yay -Y --bottomup --save で修正してください"
+
+#~ msgid "no packages match search"
+#~ msgstr "検索にマッチするパッケージがありません"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr "パッケージの衝突は noconfirm で解決できません、中止"
+
+#~ msgid "refusing to install AUR packages as root, aborting"
+#~ msgstr "AUR パッケージの root によるインストールを拒否します、中止"
 
 #~ msgid "failed to create cache directory '%s': %s"
 #~ msgstr "キャッシュディレクトリ '%s' の作成に失敗: %s"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,64 +1,64 @@
-# 
+#
 # Translators:
 # J G, 2021
 # JungHee Lee <daemul72@gmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: JungHee Lee <daemul72@gmail.com>, 2023\n"
 "Language-Team: Korean (https://app.transifex.com/yay-1/teams/123732/ko/)\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (빌드 파일 존재)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (설치됨)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [설치됨]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " 할 작업 없음"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr "%s [A]모두 [Ab]중단 [I]설치됨 [No]설치안함 / (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s 이미 빌드됨 -- 빌드 건너뛰는 중"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s 지정되지 않음"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s가 존재합니다."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s 최신 버전임 -- 건너뛰는 중"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "업그레이드/설치하려면 %s 선택합니다."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "이 작업을 위해 %s 또한 설치됩니다."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, 필요한 패키지: %s"
 
@@ -78,25 +78,81 @@ msgstr "%s: 대상에 --repo 옵션 사용할 수 없음 -- 건너뛰는 중"
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: 패키지 업그레이드 무시하는 중 (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: 로컬 (%s) 버전이 AUR (%s)보다 높음"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr "%s: 투표를 위해 AUR_USERNAME 및 AUR_PASSWORD 환경 변수를 설정하십시오"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) ABS에서 PKGBUILD 다운로드됨: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD 다운로드됨: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD 다운로드됨: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) SRCINFO 분석하는 중: %s"
 
@@ -116,7 +172,7 @@ msgstr "(고립됨)"
 msgid "(Out-of-date: %s)"
 msgstr "(오래됨: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR URL"
 
@@ -124,7 +180,7 @@ msgstr "AUR URL"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "%s 또는 %s를 환경 변수에 추가합니다"
 
@@ -136,7 +192,7 @@ msgstr "root/sudo로 yay를 실행하지 마세요."
 msgid "Check Dependency"
 msgstr "종속성 확인"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "종속성 확인"
 
@@ -144,15 +200,15 @@ msgstr "종속성 확인"
 msgid "Checking development packages..."
 msgstr "개발 패키지 확인하는 중..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "비우는 중 (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "충돌하는 패키지"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "삭제하는 중 (%d/%d): %s"
 
@@ -160,15 +216,15 @@ msgstr "삭제하는 중 (%d/%d): %s"
 msgid "Dependency"
 msgstr "종속성"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "종속하는 패키지"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "설명"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "표시할 차이점(Diff)이 있나요?"
 
@@ -176,19 +232,19 @@ msgstr "표시할 차이점(Diff)이 있나요?"
 msgid "Disable 'provides' setting by default"
 msgstr "기본적으로 '제공 패키지' 설정 비활성화"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "캐시에 있는 AUR 패키지를 모두 제거하시겠습니까?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "추척되지 않은 AUR 파일을 모두 제거하시겠습니까?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "캐시의 다른 AUR 패키지를 모두 제거하시겠습니까?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "다음으로 PKGBUILD를 편집하시겠습니까?"
 
@@ -196,7 +252,7 @@ msgstr "다음으로 PKGBUILD를 편집하시겠습니까?"
 msgid "Error during AUR search: %s\n"
 msgstr "AUR 검색 중 오류: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr "패키지를 제외하면 부분 업그레이드 및 시스템 중단이 발생할 수 있습니다."
 
@@ -204,32 +260,32 @@ msgstr "패키지를 제외하면 부분 업그레이드 및 시스템 중단이
 msgid "Explicit"
 msgstr "명시적"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "명시적으로 설치된 패키지: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "다음에 대한 AUR 패키지를 찾지 못함"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "레이어를 설치하지 못하여, 다음 레이어로 롤업합니다."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "다음 패키지를 설치하지 못했습니다. 수동 개입이 필요합니다:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "처음 제출됨"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "오래된 AUR 패키지로 플래그 지정됨:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "외부 설치된 패키지: %s"
 
@@ -237,31 +293,31 @@ msgstr "외부 설치된 패키지: %s"
 msgid "Found git repo: %s"
 msgstr "git 저장소 찾음: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB 완료됨. 패키지가 설치되지 않았습니다"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "그룹"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "가져올까요?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "gpg로 키 가져오는 중..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "키워드"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "마지막 수정됨"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "라이선스"
 
@@ -269,7 +325,7 @@ msgstr "라이선스"
 msgid "Local"
 msgstr "로컬"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "유지관리자"
 
@@ -277,11 +333,11 @@ msgstr "유지관리자"
 msgid "Make Dependency"
 msgstr "종속성 만들기"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "종속성 만들기"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "누락된 AUR 디버그 패키지:"
 
@@ -289,35 +345,40 @@ msgstr "누락된 AUR 디버그 패키지:"
 msgid "Missing"
 msgstr "누락됨"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "이름"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "다음에 대한 AUR 패키지를 찾을 수 없음"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "다음에 대한 AUR 패키지를 찾을 수 없음"
+
+#: print.go:225
 msgid "None"
 msgstr "없음"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "선택적 종속성"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "고립 (유지 관리되지 않는) AUR 패키지:"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "오래됨"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "가져와야 할 PGP 키:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD 최신 버전임, 다운로드 건너뛰는 중: %s"
 
@@ -325,55 +386,59 @@ msgstr "PKGBUILD 최신 버전임, 다운로드 건너뛰는 중: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "PKGBUILD를 편집하시겠습니까?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "패키지 베이스 ID"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "패키지 베이스"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "AUR에 없는 패키지:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "cleanBuild할 패키지는 무엇인가요?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "제외할 패키지"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr "제외할 패키지: (예: \"1 2 3\", \"1-3\", \"^4\" 혹은 저장소 이름)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "설치할 패키지: (예: 1 2 3, 1-3 혹은 ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "인기순"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "설치를 계속 진행하시겠습니까?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "제공 패키지"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "설치 후 make 종속성을 제거하시겠습니까?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "저장소 AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "저장소"
 
@@ -393,15 +458,15 @@ msgstr "데이터베이스에서 업데이트 검색하는 중..."
 msgid "Showing repo packages only"
 msgstr "저장소 패키지만 표시하는 중"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "pacman 캐시 %s의 크기: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "yay 캐시 %s의 크기: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "스냅숏 URL"
 
@@ -409,71 +474,71 @@ msgstr "스냅숏 URL"
 msgid "Sync"
 msgstr "동기화"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "가장 큰 10개 패키지:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "다음 패키지는 이 컴퓨터의 아키텍처와 호환되지 않음:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "%s에 사용할 수 있는 %d개 공급자가 있습니다:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "다른 pacman 인스턴스가 실행 중입니다. 대기 중..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "패키지가 차지하는 전체 크기: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "설치된 전체 패키지: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "그래도 빌드할까요?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "비울 수 없음:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "다음 패키지를 찾을 수 없음:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "다음의 패키지 투표를 처리할 수 없습니다: %s. 오류: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "%s 제거할 수 없음: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "버전"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "투표"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay 버전 v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]안함"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -481,7 +546,7 @@ msgstr ""
 "\n"
 "빌드 디렉터리:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -493,19 +558,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "사용자로 인해 중단됨"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "stdin에 대한 입력 없이 지정된 인자 '-'"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "디렉터리에서 PKGBUILD 및 .SRCINFO를 찾을 수 없음"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "패키지 이름을 찾을 수 없음: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "PKGDEST를 찾을 수 없음: %s"
 
@@ -513,11 +578,11 @@ msgstr "PKGDEST를 찾을 수 없음: %s"
 msgid "could not find all required packages"
 msgstr "필요한 패키지를 모두 찾을 수 없음"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "%s에 나열된 패키지 아카이브를 찾을 수 없음"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "종속성"
 
@@ -525,11 +590,11 @@ msgstr "종속성"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "패키지에 대한 devel 확인 실패함: '%s'에 하나의 오류가 발생했습니다"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "편집기가 제대로 종료되지 않음, 중단하는 중: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "소스 다운로드 중 오류: %s"
 
@@ -537,19 +602,19 @@ msgstr "소스 다운로드 중 오류: %s"
 msgid "error fetching %s: %s"
 msgstr "%s 가져오는 중 오류: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "저장소 패키지 설치 중 오류"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "설치 중 오류:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "빌드 중 오류: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "%s 병합하는 중 오류: %s"
 
@@ -557,19 +622,19 @@ msgstr "%s 병합하는 중 오류: %s"
 msgid "error reading %s"
 msgstr "%s 읽는 중 오류"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "데이터베이스 갱신하는 중 오류"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "%s 재설정하는 중 오류: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "패키지 설치 근거를 %s로 업데이트하는 중 오류"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "명시적"
 
@@ -577,27 +642,27 @@ msgstr "명시적"
 msgid "failed to create directory '%s': %s"
 msgstr "'%s' 디렉터리 만들기 실패함: %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr " '%s' 구성 파일 열기 실패함: %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "%s 분석 실패함 -- 건너뜁니다: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "%s 분석 실패함: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr ".SRCINFO를 분석하지 못했습니다"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "'%s' 구성 파일 읽기 실패함: %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "AUR 캐시를 검색하지 못했습니다"
 
@@ -609,7 +674,7 @@ msgstr "패키지 개발 업그레이드 무시하는 중 (AUR 정보를 찾을 
 msgid "input too long"
 msgstr "너무 긴 입력"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "잘못된 숫자: %s"
 
@@ -617,7 +682,7 @@ msgstr "잘못된 숫자: %s"
 msgid "invalid option '%s'"
 msgstr "잘못된 옵션 '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr "잘못된 옵션: '--deps'와 '--explicit'는 함께 사용할 수 없습니다"
 
@@ -625,11 +690,11 @@ msgstr "잘못된 옵션: '--deps'와 '--explicit'는 함께 사용할 수 없�
 msgid "invalid repository"
 msgstr "잘못된 저장소"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "잘못된 값: %d가 %d와 %d 사이에 있지 않음"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "가져올 키 없음"
 
@@ -637,15 +702,15 @@ msgstr "가져올 키 없음"
 msgid "no query was executed"
 msgstr "실행된 쿼리가 없습니다"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "지정된 대상 디렉터리가 없습니다"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "아니요"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "%s 용으로 설치할 항목 없음"
 
@@ -653,7 +718,11 @@ msgstr "%s 용으로 설치할 항목 없음"
 msgid "only one operation may be used at a time"
 msgstr "한번에 한 작업만 쓸 수 있음"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "'%s' 패키지를 찾지 못했습니다"
 
@@ -665,28 +734,28 @@ msgstr "AUR에서 패키지를 찾을 수 없습니다"
 msgid "package not found in repos"
 msgstr "저장소에서 패키지를 찾을 수 없습니다"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "패키지"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "키 가져오는 중 오류"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "캐시에서 AUR 패키지 제거하는 중..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "캐시에서 추적되지 않은 AUR 패키지 제거하는 중..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "makepkg에 등록된 %s의 PKGDEST가 존재하지 않음: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "할 작업 없음"
 
@@ -694,14 +763,14 @@ msgstr "할 작업 없음"
 msgid "unable to CreateHandle: %s"
 msgstr "CreateHandle 할 수 없음: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "핸들되지 않은 작업"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "알 수 없는 버전"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "예"

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -13,424 +13,556 @@ msgstr ""
 "|| n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: install.go:563
+#: pkg/menus/menu.go:32
 #, fuzzy
 msgid " (Build Files Exist)"
 msgstr " (ściągnięto pliki źródłowe)"
 
-#: install.go:559
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (zainstalowano)"
 
-#: depCheck.go:279
-msgid " (Target"
-msgstr " (Cel"
-
-#: depCheck.go:281
-msgid " (Wanted by: "
-msgstr " (Zależność od: "
-
-#: callbacks.go:72
-msgid " Input too long"
-msgstr " Zbyt długie dane wejściowe"
-
-#: cmd.go:446
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [zainstalowano]"
 
-#: cmd.go:402 install.go:166 install.go:200
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " nic nie pozostało do zrobienia"
 
-#: depCheck.go:170
-msgid "Installing %s will remove:"
-msgstr "Zainstalowanie %s usunie:"
-
-#: install.go:583 install.go:658 install.go:665
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]Wszystkie [Ab]Anuluj [I]Zainstalowane [No]Nie zainstalowane lub (1 2 "
 "3, 1-3, ^4)"
 
-#: download.go:273
-msgid "%s already downloaded -- use -f to overwrite"
-msgstr "%s już jest ściągnięty - użyj -f aby nadpisać"
-
-#: install.go:1086
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s już jest zbudowany - pomijam budowanie"
 
-#: pkg/settings/runtime.go:50 pkg/settings/runtime.go:62
-msgid "%s and %s unset"
-msgstr "%s i %s są nieokreślone"
-
-#: config.go:76
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s jest nieokreślony"
 
-#: exec.go:71
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s jest już obecny."
 
-#: install.go:1075
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s jest aktualny - pomijam"
 
-#: install.go:1008
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s nie spełniony, czyszczę kolejkę instalacji"
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
+msgstr "Paczki do aktualizacji."
 
-#: install.go:752
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
+
+#: pkg/sync/srcinfo/pgp/keys.go:124
+msgid "%s, required by: %s"
+msgstr "%s, wymagane przez: %s"
+
+#: pkg/menus/diff_menu.go:49
 msgid "%s: No changes -- skipping"
 msgstr "%s: Bez zmian - pomijam"
 
-#: utils.go:48
+#: pkg/query/filter.go:22
 msgid "%s: can't use target with option --aur -- skipping"
 msgstr "%s: nie jest dostępny z --aur - pomijam"
 
-#: utils.go:43
+#: pkg/query/filter.go:17
 msgid "%s: can't use target with option --repo -- skipping"
 msgstr "%s: nie jest dostępny z --repo - pomijam"
 
-#: upgrade.go:274
+#: pkg/upgrade/sources.go:57
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: ignoruję aktualizację paczki (%s => %s)"
 
-#: upgrade.go:291
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: wersja lokalna (%s) jest nowsza niż ta z AUR (%s)"
 
-#: download.go:298
+#: vote.go:51
+msgid ""
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
+msgstr ""
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
+
+#: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) Ściągnięto PKGBUILD z ABS-u: %s"
 
-#: install.go:805
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
+#, fuzzy
+msgid "(%d/%d) Downloaded PKGBUILD: %s"
+msgstr "(%d/%d) Ściągnięto PKGBUILD z ABS-u: %s"
+
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) Ściągnięto PKGBUILD z ABS-u: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Przetwarzam SRCINFO: %s"
 
-#: print.go:86 print.go:127
+#: pkg/query/types.go:72 pkg/query/types.go:103
 msgid "(Installed)"
 msgstr "(zainstalowano)"
 
-#: print.go:84 print.go:125
+#: pkg/query/types.go:70 pkg/query/types.go:101
 msgid "(Installed: %s)"
 msgstr "(Zainstalowano: %s)"
 
-#: print.go:75
+#: pkg/query/types.go:61
 msgid "(Orphaned)"
 msgstr "(osierocony)"
 
-#: print.go:79
+#: pkg/query/types.go:65
 msgid "(Out-of-date: %s)"
 msgstr "(Nieaktualny od: %s)"
 
-#: print.go:275
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR URL"
 
-#: config.go:77
+#: pkg/dep/dep_graph.go:75
+#, fuzzy
+msgid "AUR"
+msgstr "URL"
+
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Dodaj %s lub %s do zmiennych środowiskowych"
 
-#: main.go:182
+#: main.go:60
 msgid "Avoid running yay as root/sudo."
 msgstr "Unikaj uruchamiania yay jako root lub z sudo."
 
-#: print.go:281
+#: pkg/dep/dep_graph.go:63
+#, fuzzy
+msgid "Check Dependency"
+msgstr "Sprawdź zależności"
+
+#: print.go:41
 msgid "Check Deps"
 msgstr "Sprawdź zależności"
 
-#: upgrade.go:167
+#: pkg/upgrade/service.go:90
 msgid "Checking development packages..."
 msgstr "Sprawdzanie paczek w wersjach rozwojowych..."
 
-#: depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "Sprawdzanie konfliktów..."
-
-#: depCheck.go:144
-msgid "Checking for inner conflicts..."
-msgstr "Sprawdzanie konfliktów wewnętrznych..."
-
-#: clean.go:224
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Czyszczenie (%d/%d): %s"
 
-#: depCheck.go:196
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr "Kolidujące paczki muszą być zatwierdzone ręcznie"
-
-#: print.go:283
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Koliduje z"
 
-#: depCheck.go:273
-msgid "Could not find all required packages:"
-msgstr "Nie znaleziono następujących zadanych paczek:"
-
-#: clean.go:240
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Usuwanie (%d/%d): %s"
 
-#: print.go:279
+#: pkg/dep/dep_graph.go:61
+#, fuzzy
+msgid "Dependency"
+msgstr "Zależy od"
+
+#: print.go:38
 msgid "Depends On"
 msgstr "Zależy od"
 
-#: print.go:273
+#: print.go:33
 msgid "Description"
 msgstr "Opis"
 
-#: install.go:657
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Pokazać różnice?"
 
-#: clean.go:91
+#: pkg/settings/migrations.go:25
+msgid "Disable 'provides' setting by default"
+msgstr ""
+
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Czy chcesz usunąć WSZYSTKIE paczki AUR z pamięci podręcznej?"
 
-#: clean.go:108
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Czy chcesz usunąć WSZYSTKIE nieśledzone pliki AUR?"
 
-#: clean.go:93
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Czy chcesz usunąć wszystkie inne paczki AUR z pamięci podręczniej?"
 
-#: install.go:893
-msgid "Downloaded PKGBUILD (%d/%d): %s"
-msgstr "Ściągnięto PKGBUILD (%d/%d): %s"
-
-#: config.go:80
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Edytor PKGBUILD-ów?"
 
-#: cmd.go:346
+#: pkg/query/errors.go:13
 msgid "Error during AUR search: %s\n"
 msgstr "Błąd podczas wyszukiwania w AUR: %s\n"
 
-#: print.go:342
+#: pkg/upgrade/service.go:296
+msgid "Excluding packages may cause partial upgrades and break systems"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:60
+msgid "Explicit"
+msgstr ""
+
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Jawnie zainstalowane paczki: %s"
 
-#: print.go:287
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
+#, fuzzy
+msgid "Failed to find AUR package for"
+msgstr "Paczki AUR oznaczone jako nieaktualne:"
+
+#: pkg/sync/build/installer.go:120
+msgid "Failed to install layer, rolling up to next layer."
+msgstr ""
+
+#: pkg/sync/build/errors.go:16
+msgid ""
+"Failed to install the following packages. Manual intervention is required:"
+msgstr ""
+
+#: print.go:45
 msgid "First Submitted"
 msgstr "Zamieszczono po raz pierwszy"
 
-#: print.go:41
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Paczki AUR oznaczone jako nieaktualne:"
 
-#: vcs.go:147
+#: print.go:90
+#, fuzzy
+msgid "Foreign installed packages: %s"
+msgstr "Łączna liczba zainstalowanych zewnętrznych paczek: %s"
+
+#: pkg/vcs/vcs.go:144
 msgid "Found git repo: %s"
 msgstr "Znaleziono repozytorium git: %s"
 
-#: vcs.go:64
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "Zakończono GenDB. Nie zainstalowano żadnych paczek"
 
-#: print.go:276
+#: print.go:36
 msgid "Groups"
 msgstr "Grupy"
 
-#: keys.go:84
+#: pkg/sync/srcinfo/pgp/keys.go:88
 #, fuzzy
 msgid "Import?"
 msgstr "Zaimportować?"
 
-#: keys.go:97
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Importowanie kluczy przy użyciu gpg..."
 
-#: print.go:271
+#: print.go:46
 msgid "Keywords"
 msgstr "Słowa kluczowe"
 
-#: print.go:288
+#: print.go:47
 msgid "Last Modified"
 msgstr "Ostatnio zmodyfikowano"
 
-#: print.go:277
+#: print.go:35
 msgid "Licenses"
 msgstr "Licencje"
 
-#: print.go:284
+#: pkg/dep/dep_graph.go:77
+msgid "Local"
+msgstr ""
+
+#: print.go:48
 msgid "Maintainer"
 msgstr "Opiekun"
 
-#: print.go:280
+#: pkg/dep/dep_graph.go:62
+#, fuzzy
+msgid "Make Dependency"
+msgstr "Zbuduj zależności"
+
+#: print.go:40
 msgid "Make Deps"
 msgstr "Zbuduj zależności"
 
-#: download.go:281
-msgid "Missing ABS packages:"
-msgstr "Brakujące paczki z ABS-a:"
-
-#: print.go:25
-msgid "Missing AUR Packages:"
+#: pkg/query/aur_warnings.go:71
+#, fuzzy
+msgid "Missing AUR Debug Packages:"
 msgstr "Brakujące paczki z AUR:"
 
-#: print.go:270
+#: pkg/dep/dep_graph.go:79
+msgid "Missing"
+msgstr ""
+
+#: print.go:31
 msgid "Name"
 msgstr "Nazwa"
 
-#: pkg/text/print.go:50
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
+msgid "No AUR package found for"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:182
+msgid "No package found for"
+msgstr ""
+
+#: print.go:225
 msgid "None"
 msgstr "Brak"
 
-#: print.go:282
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Opcjonalne zależności"
 
-#: print.go:33
-msgid "Orphaned AUR Packages:"
+#: pkg/query/aur_warnings.go:75
+#, fuzzy
+msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Osierocone paczki z AUR:"
 
-#: print.go:291 print.go:293
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Nieaktualne"
 
-#: keys.go:115
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Klucze PGP wymagające zaimportowania:"
 
-#: install.go:874
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
+#: pkg/sync/workdir/preparer.go:252
+#, fuzzy
+msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "Aktualny PKGBUILD, pomijam (%d/%d): %s"
 
-#: install.go:664
+#: pkg/menus/edit_menu.go:130
 msgid "PKGBUILDs to edit?"
 msgstr "Edytować PKGBUILD-y?"
 
-#: print.go:298
+#: print.go:60
 #, fuzzy
 msgid "Package Base ID"
 msgstr "Package Base ID"
 
-#: print.go:299
+#: print.go:61
 #, fuzzy
 msgid "Package Base"
 msgstr "Package Base"
 
-#: install.go:582
+#: pkg/query/aur_warnings.go:67
+msgid "Packages not in AUR:"
+msgstr ""
+
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Paczki do zbudowania od zera?"
 
-#: upgrade.go:365
+#: pkg/dep/dep_graph.go:202
+#, fuzzy
+msgid "Packages to exclude"
+msgstr "Paczki do aktualizacji."
+
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr ""
 "Wykluczone paczki: (np.: \"1 2 3\", \"1-3\", \"^4\" lub nazwa repozytorium)"
 
-#: cmd.go:350
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Paczki do zainstalowania (np.: 1 2 3, 1-3 or ^4)"
 
-#: upgrade.go:362
-msgid "Packages to upgrade."
-msgstr "Paczki do aktualizacji."
-
-#: print.go:286
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularność"
 
-#: install.go:269 install.go:309
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Kontynuować instalację?"
 
-#: print.go:278
+#: print.go:37
 msgid "Provides"
 msgstr "Dostarcza"
 
-#: query.go:509
-msgid "Querying AUR..."
-msgstr "Odpytuję AUR..."
-
-#: install.go:221
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Usunąć zależności potrzebne do zbudowania po instalacji?"
 
-#: print.go:495
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repozytorium AUR"
 
-#: callbacks.go:46 print.go:269
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repozytorium"
 
-#: upgrade.go:150
+#: pkg/dep/dep_graph.go:78
+msgid "SRCINFO"
+msgstr ""
+
+#: pkg/upgrade/service.go:72
 msgid "Searching AUR for updates..."
 msgstr "Przeszukuję AUR za aktualizacjami..."
 
-#: upgrade.go:140
+#: pkg/upgrade/service.go:160
 msgid "Searching databases for updates..."
 msgstr "Przeszukuję bazy danych za aktualizacjami..."
 
-#: cmd.go:347 query.go:194
+#: pkg/query/query_builder.go:214
 msgid "Showing repo packages only"
 msgstr "Pokazuję tylko paczki z repozytoriów"
 
-#: print.go:300
+#: print.go:95
+#, fuzzy
+msgid "Size of pacman cache %s: %s"
+msgstr "nie udało się przetworzyć %s: %s"
+
+#: print.go:98
+#, fuzzy
+msgid "Size of yay cache %s: %s"
+msgstr "nie udało się przetworzyć %s: %s"
+
+#: print.go:62
 #, fuzzy
 msgid "Snapshot URL"
 msgstr "Snapshot URL"
 
-#: print.go:345
+#: pkg/dep/dep_graph.go:76
+msgid "Sync"
+msgstr ""
+
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Dziesięć największych paczek:"
 
-#: install.go:481
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Te paczki nie są kompatybilne z architekturą Twojego systemu:"
 
-#: callbacks.go:36 print.go:492
-msgid "There are %d providers available for %s:\n"
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
+#, fuzzy
+msgid "There are %d providers available for %s:"
 msgstr "Jest %d możliwych źródeł dla %s:\n"
 
-#: exec.go:72
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Prawdopodobnie działa teraz inna instancja Pacmana. Czekam..."
 
-#: print.go:343
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Łączny rozmiar zajmowany przez paczki: %s"
 
-#: print.go:341
-msgid "Total foreign installed packages: %s"
-msgstr "Łączna liczba zainstalowanych zewnętrznych paczek: %s"
-
-#: print.go:340
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Łączna liczba zainstalowanych paczek: %s"
 
-#: install.go:488
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Spróbować je zbudować mimo wszystko?"
 
-#: print.go:274
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: print.go:272
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
+#, fuzzy
+msgid "Unable to clean:"
+msgstr "błąd przy CreateHandle: %s"
+
+#: get.go:42 get.go:74
+msgid "Unable to find the following packages:"
+msgstr ""
+
+#: vote.go:20
+msgid "Unable to handle package vote for: %s. err: %s"
+msgstr ""
+
+#: clean.go:170
+#, fuzzy
+msgid "Unable to remove %s: %s"
+msgstr "nie udało się przetworzyć %s: %s"
+
+#: print.go:32
 msgid "Version"
 msgstr "Wersja"
 
-#: print.go:285
+#: print.go:50
 msgid "Votes"
 msgstr "Głosów"
 
-#: print.go:338
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Wersja yaya v%s"
 
-#: install.go:583 install.go:658 install.go:665
+#: pkg/menus/menu.go:49
 #, fuzzy
 msgid "[N]one"
 msgstr "[N]Żadne"
 
-#: keys.go:122
-msgid "%s, required by: %s"
-msgstr "%s, wymagane przez: %s"
-
-#: clean.go:96
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -438,7 +570,7 @@ msgstr ""
 "\n"
 "Folder kompilacji:"
 
-#: callbacks.go:56 print.go:505
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -446,200 +578,327 @@ msgstr ""
 "\n"
 "Wybierz wartość (domyślnie=1): "
 
-#: depCheck.go:153
-msgid ""
-"\n"
-"Inner conflicts found:"
-msgstr ""
-"\n"
-"Znalezione wewnętrzne konflikty:"
-
-#: depCheck.go:167
-msgid ""
-"\n"
-"Package conflicts found:"
-msgstr ""
-"\n"
-"Znalezione kolidujące paczki:"
-
-#: install.go:270 install.go:310 install.go:489 install.go:593 install.go:676
+#: pkg/settings/errors.go:29
 msgid "aborting due to user"
 msgstr "przerwane przez użytkownika"
 
-#: install.go:515
+#: pkg/settings/parser/parser.go:620
+msgid "argument '-' specified without input on stdin"
+msgstr ""
+
+#: local_install.go:26
+msgid "cannot find PKGBUILD and .SRCINFO in directory"
+msgstr ""
+
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "nie odnalazłem paczki: %v"
 
-#: install.go:1048 install.go:1120
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "nie odnalazłem PKGDEST dla: %s"
 
-#: install.go:792
+#: errors.go:9
+#, fuzzy
+msgid "could not find all required packages"
+msgstr "Nie znaleziono następujących zadanych paczek:"
+
+#: pkg/sync/build/errors.go:61
+msgid "could not find any package archives listed in %s"
+msgstr ""
+
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
+#, fuzzy
+msgid "dependency"
+msgstr "Zależy od"
+
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
+msgid "devel check for package failed: '%s' encountered an error"
+msgstr ""
+
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "edytor nie zamknął się poprawnie, anuluję: %s"
 
-#: download.go:84 download.go:109
-msgid "error cloning %s: %s"
-msgstr "błąd klonowania %s: %s"
-
-#: install.go:924
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "błąd ściągania źródeł: %s"
 
-#: query.go:193
-msgid "error during AUR search: %s"
-msgstr "błąd podczas przeszukiwania AUR: %s"
-
-#: download.go:96 download.go:121
+#: pkg/download/errors.go:25
 msgid "error fetching %s: %s"
 msgstr "błąd podczas ściągania %s: %s"
 
-#: install.go:333 install.go:442
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "błąd podczas instalowania paczek z repozytorium"
 
-#: install.go:1032 install.go:1072 install.go:1083 install.go:1095
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
+#, fuzzy
+msgid "error installing:"
+msgstr "błąd podczas instalowania paczek z repozytorium"
+
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "błąd podczas budowania: %s"
 
-#: download.go:135
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "błąd podczas scalania %s: %s"
 
-#: download.go:89 download.go:114
+#: pkg/download/unified.go:59
 msgid "error reading %s"
 msgstr "błąd podczas odczytywania %s"
 
-#: install.go:75
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "błąd odświeżania baz danych"
 
-#: clean.go:228 download.go:130
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "błąd podczas resetowania %s: %s"
 
-#: main.go:68
-msgid "failed to create BuildDir directory '%s': %s"
-msgstr "nie udało się stworzyć katalogu kompilacji '%s': %s"
+#: pkg/sync/build/errors.go:53
+msgid "error updating package install reason to %s"
+msgstr ""
 
-#: pkg/settings/runtime.go:79
+#: pkg/sync/build/errors.go:48
+msgid "explicit"
+msgstr ""
+
+#: pkg/settings/errors.go:23
 msgid "failed to create directory '%s': %s"
 msgstr "nie udało się stworzyć katalogu konfiguracyjnego '%s': %s"
 
-#: download.go:288
-msgid "failed to get pkgbuild: %s: %s"
-msgstr "nie udało się ściągnąć PKGBUILD-a: %s: %s"
-
-#: download.go:296
-#, fuzzy
-msgid "failed to link %s: %s"
-msgstr "nie udało się linkowanie %s: %s"
-
-#: main.go:29
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "nie udało się otwarcie pliku konfiguracyjnego '%s': %s"
 
-#: main.go:51
-msgid "failed to open vcs file '%s': %s"
-msgstr "nie udało się otworzyć pliku VCS '%s': %s"
-
-#: install.go:810
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "nie udało się przetworzyć %s - pomijam: %s"
 
-#: install.go:813
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "nie udało się przetworzyć %s: %s"
 
-#: main.go:36
+#: local_install.go:77
+#, fuzzy
+msgid "failed to parse .SRCINFO"
+msgstr "nie udało się przetworzyć %s: %s"
+
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "nie udało się odczytać pliku konfiguracyjnego '%s': %s"
 
-#: main.go:58
-msgid "failed to read vcs file '%s': %s"
-msgstr "nie udało się odczytać pliku VCS '%s': %s"
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
+msgid "failed to retrieve aur Cache"
+msgstr ""
 
-#: cmd.go:360 config.go:147 print.go:521
+#: pkg/upgrade/sources.go:27
+#, fuzzy
+msgid "ignoring package devel upgrade (no AUR info found):"
+msgstr "%s: ignoruję aktualizację paczki (%s => %s)"
+
+#: pkg/text/errors.go:8
 msgid "input too long"
 msgstr "zbyt długie dane wejściowe"
 
-#: callbacks.go:82 print.go:531
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "niepoprawna liczba: %s"
 
-#: pkg/settings/parser.go:144
+#: pkg/settings/parser/parser.go:174
 msgid "invalid option '%s'"
 msgstr "niepoprawna opcja '%s'"
 
-#: cmd.go:342 cmd.go:376 cmd.go:393 print.go:62 print.go:105 query.go:189
-msgid "invalid sort mode. Fix with yay -Y --bottomup --save"
-msgstr "niepoprawny tryb sortowania. Napraw przez yay -Y --bottomup --save"
+#: cmd.go:207
+msgid "invalid option: '--deps' and '--explicit' may not be used together"
+msgstr ""
 
-#: callbacks.go:87 print.go:536
+#: pkg/download/abs.go:22
+#, fuzzy
+msgid "invalid repository"
+msgstr "Repozytorium"
+
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "niepoprawna wartość: %d nie jest pomiędzy %d a %d"
 
-#: keys.go:110
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "brak kluczy do zaimportowania"
 
-#: cmd.go:323
-msgid "no packages match search"
-msgstr "żadne paczki nie pasują do zapytania"
+#: pkg/query/errors.go:20
+msgid "no query was executed"
+msgstr ""
 
-#: config.go:112
+#: local_install.go:66
+msgid "no target directories specified"
+msgstr ""
+
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "nie"
 
-#: pkg/settings/parser.go:134
+#: pkg/sync/build/installer.go:242
+msgid "nothing to install for %s"
+msgstr ""
+
+#: pkg/settings/parser/parser.go:164
 msgid "only one operation may be used at a time"
 msgstr "tylko jedna operacja może być zadana na raz"
 
-#: print.go:430
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "paczka '%s' nie została odnaleziona"
 
-#: depCheck.go:193
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr "kolizji paczek nie da się rozwiązać przez noconfirm, anuluję"
+#: pkg/download/errors.go:15
+#, fuzzy
+msgid "package not found in AUR"
+msgstr "paczka '%s' nie została odnaleziona"
 
-#: keys.go:101
+#: pkg/download/abs.go:23
+#, fuzzy
+msgid "package not found in repos"
+msgstr "paczka '%s' nie została odnaleziona"
+
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "Package Base"
+msgstr[1] "Package Base"
+msgstr[2] "Package Base"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "błąd importowania kluczy"
 
-#: install.go:178
-#, fuzzy
-msgid "refusing to install AUR packages as root, aborting"
-msgstr "nie będę instalować paczek z AUR jako root, anuluję"
-
-#: clean.go:116
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "usuwanie paczek z AUR z pamięci podręcznej..."
 
-#: clean.go:188 clean.go:216
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "usuwanie nieśledzonych plików z AUR z pamięci podręcznej..."
 
-#: install.go:1129
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "PKGDEST dla %s jest wyszczególniony w makepkg, ale nie istnieje: %s"
 
-#: main.go:146
+#: pkg/sync/sync.go:45
+#, fuzzy
+msgid "there is nothing to do"
+msgstr " nic nie pozostało do zrobienia"
+
+#: pkg/db/ialpm/alpm.go:247
 #, fuzzy
 msgid "unable to CreateHandle: %s"
 msgstr "błąd przy CreateHandle: %s"
 
-#: cmd.go:177
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "nieobsłużona operacja"
 
-#: cmd.go:443
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "nieznana-wersja"
 
-#: config.go:111
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "tak"
+
+#~ msgid " (Target"
+#~ msgstr " (Cel"
+
+#~ msgid " (Wanted by: "
+#~ msgstr " (Zależność od: "
+
+#~ msgid " Input too long"
+#~ msgstr " Zbyt długie dane wejściowe"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "Zainstalowanie %s usunie:"
+
+#~ msgid "%s already downloaded -- use -f to overwrite"
+#~ msgstr "%s już jest ściągnięty - użyj -f aby nadpisać"
+
+#~ msgid "%s and %s unset"
+#~ msgstr "%s i %s są nieokreślone"
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s nie spełniony, czyszczę kolejkę instalacji"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "Sprawdzanie konfliktów..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "Sprawdzanie konfliktów wewnętrznych..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr "Kolidujące paczki muszą być zatwierdzone ręcznie"
+
+#~ msgid "Downloaded PKGBUILD (%d/%d): %s"
+#~ msgstr "Ściągnięto PKGBUILD (%d/%d): %s"
+
+#~ msgid "Missing ABS packages:"
+#~ msgstr "Brakujące paczki z ABS-a:"
+
+#~ msgid "Querying AUR..."
+#~ msgstr "Odpytuję AUR..."
+
+#~ msgid ""
+#~ "\n"
+#~ "Inner conflicts found:"
+#~ msgstr ""
+#~ "\n"
+#~ "Znalezione wewnętrzne konflikty:"
+
+#~ msgid ""
+#~ "\n"
+#~ "Package conflicts found:"
+#~ msgstr ""
+#~ "\n"
+#~ "Znalezione kolidujące paczki:"
+
+#~ msgid "error cloning %s: %s"
+#~ msgstr "błąd klonowania %s: %s"
+
+#~ msgid "error during AUR search: %s"
+#~ msgstr "błąd podczas przeszukiwania AUR: %s"
+
+#~ msgid "failed to create BuildDir directory '%s': %s"
+#~ msgstr "nie udało się stworzyć katalogu kompilacji '%s': %s"
+
+#~ msgid "failed to get pkgbuild: %s: %s"
+#~ msgstr "nie udało się ściągnąć PKGBUILD-a: %s: %s"
+
+#, fuzzy
+#~ msgid "failed to link %s: %s"
+#~ msgstr "nie udało się linkowanie %s: %s"
+
+#~ msgid "failed to open vcs file '%s': %s"
+#~ msgstr "nie udało się otworzyć pliku VCS '%s': %s"
+
+#~ msgid "failed to read vcs file '%s': %s"
+#~ msgstr "nie udało się odczytać pliku VCS '%s': %s"
+
+#~ msgid "invalid sort mode. Fix with yay -Y --bottomup --save"
+#~ msgstr "niepoprawny tryb sortowania. Napraw przez yay -Y --bottomup --save"
+
+#~ msgid "no packages match search"
+#~ msgstr "żadne paczki nie pasują do zapytania"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr "kolizji paczek nie da się rozwiązać przez noconfirm, anuluję"
+
+#, fuzzy
+#~ msgid "refusing to install AUR packages as root, aborting"
+#~ msgstr "nie będę instalować paczek z AUR jako root, anuluję"
 
 #~ msgid "failed to create cache directory '%s': %s"
 #~ msgstr "nie udało się stworzyć katalogu pamięci podręczniej '%s': %s"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,66 +1,68 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Eduardo Ervideira, 2023
 # Hugo Carvalho <hugokarvalho@hotmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>, 2023\n"
-"Language-Team: Portuguese (https://app.transifex.com/yay-1/teams/123732/pt/)\n"
+"Language-Team: Portuguese (https://app.transifex.com/yay-1/teams/123732/"
+"pt/)\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (Existem ficheiros de compilação)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Instalado)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Instalado]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " não há nada a fazer"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]Todos [Ab]ortar [I]nstalado [No]Não instalado or (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s já efetuado -- a ignorar compilação"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s não está definido"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s está presente."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s está atualizado -- a ignorar"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s a atualizar/instalar."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "%s também será instalado para esta operação. "
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, necessário para: %s"
 
@@ -70,8 +72,7 @@ msgstr "%s: Sem modificações -- a ignorar"
 
 #: pkg/query/filter.go:22
 msgid "%s: can't use target with option --aur -- skipping"
-msgstr ""
-"%s: não é possível utilizar a opção --aur com este pacote -- a ignorar"
+msgstr "%s: não é possível utilizar a opção --aur com este pacote -- a ignorar"
 
 #: pkg/query/filter.go:17
 msgid "%s: can't use target with option --repo -- skipping"
@@ -82,26 +83,82 @@ msgstr ""
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: a ignorar atualização de pacote (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: local (%s) é mais recente que AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "%s: definir variáveis de ambiente AUR_USERNAME e AUR_PASSWORD para votação"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD ABS transferido: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD transferido: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD transferido: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Analisando SRCINFO: %s"
 
@@ -121,7 +178,7 @@ msgstr "(Orfão)"
 msgid "(Out-of-date: %s)"
 msgstr "(Desatualizado: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL AUR"
 
@@ -129,7 +186,7 @@ msgstr "URL AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Adicione %s ou %s às suas variáveis de ambiente"
 
@@ -141,7 +198,7 @@ msgstr "Evite executar o yay como root/sudo."
 msgid "Check Dependency"
 msgstr "Verificar dependências"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Dependências de verificação"
 
@@ -149,15 +206,15 @@ msgstr "Dependências de verificação"
 msgid "Checking development packages..."
 msgstr "A verificar pacotes de desenvolvimento..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "A limpar (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Em conflito com"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "A eliminar (%d/%d): %s"
 
@@ -165,15 +222,15 @@ msgstr "A eliminar (%d/%d): %s"
 msgid "Dependency"
 msgstr "Dependências"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Depende de"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Descrição"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Diffs a mostrar?"
 
@@ -181,19 +238,19 @@ msgstr "Diffs a mostrar?"
 msgid "Disable 'provides' setting by default"
 msgstr "Desativar a definição 'fornece' por defeito"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Quer remover todos os pacotes AUR da cache?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Quer remover todos os ficheiros AUR não rastreados?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Quer remover todos os outros pacotes AUR da cache?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Editar PKGBUILD com?"
 
@@ -201,7 +258,7 @@ msgstr "Editar PKGBUILD com?"
 msgid "Error during AUR search: %s\n"
 msgstr "Erro durante a pesquisa AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "A exclusão de pacotes pode causar atualizações parciais e quebra de sistemas"
@@ -210,33 +267,33 @@ msgstr ""
 msgid "Explicit"
 msgstr "Explícito"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Pacotes explicitamente instalados: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Falha ao localizar pacote AUR para"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Falha ao instalar camada, indo até à camada seguinte."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 "Falha ao instalar os seguintes pacotes. É necessária a intervenção manual:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Primeira submissão"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Pacotes AUR marcados como desatualizados:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Pacotes externos instalados: %s"
 
@@ -244,31 +301,31 @@ msgstr "Pacotes externos instalados: %s"
 msgid "Found git repo: %s"
 msgstr "Repositório git encontrado: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB terminado. Nenhum pacote foi instalado"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Grupos"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Importar?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "A importar chaves com gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Palavras-chave"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Última Modificação"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Licenças"
 
@@ -276,7 +333,7 @@ msgstr "Licenças"
 msgid "Local"
 msgstr "Local"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Responsável pela manutenção"
 
@@ -284,11 +341,11 @@ msgstr "Responsável pela manutenção"
 msgid "Make Dependency"
 msgstr "Criar dependências"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Dependências Make"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Pacotes de depuração AUR em falta:"
 
@@ -296,35 +353,40 @@ msgstr "Pacotes de depuração AUR em falta:"
 msgid "Missing"
 msgstr "Em falta"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Nome"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Nenhum pacote AUR localizado para"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Nenhum pacote AUR localizado para"
+
+#: print.go:225
 msgid "None"
 msgstr "Nenhum"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Dependências opcionais"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Pacotes AUR órfãos (não mantidos):"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Desatualizado"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Chaves PGP a importar:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD atualizado, a ignorar a transferência: %s"
 
@@ -332,55 +394,59 @@ msgstr "PKGBUILD atualizado, a ignorar a transferência: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "PKGBUILDs a editar?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID do Pacote Base"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Pacote Base"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Pacotes que não estão no AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Pacotes a compilar a limpo?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Pacotes a excluir"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr "Pacotes a excluir:  (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Pacotes a instalar (eg: 1 2 3, 1-3 or ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularidade"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Proceder com a instalação?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Fornece"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Remover as dependências de make pós-instalação?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repositório AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repositório"
 
@@ -400,15 +466,15 @@ msgstr "A procurar atualizações nos repositórios..."
 msgid "Showing repo packages only"
 msgstr "Mostrando apenas pacotes do repositório"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Tamanho da cache do pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Tamanho da cache do yay %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL Snapshot"
 
@@ -416,71 +482,71 @@ msgstr "URL Snapshot"
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Dez maiores pacotes:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Os seguintes pacotes não são compatíveis com a sua arquitetura:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Existem %d provedores disponíveis para %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Poderá haver outro Pacman em execução. Aguardar..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Tamanho total ocupado por pacotes: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Total instalado de pacotes: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Tentar compilar mesmo assim?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Não foi possível limpar:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Não foi possível encontrar os seguintes pacotes:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Não foi possível gerir votação de pacote para: %s err: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Não foi possível remover %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Versão"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Votos"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Versão Yay v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]enhum"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -488,7 +554,7 @@ msgstr ""
 "\n"
 "Diretório de compilação:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -500,19 +566,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "a abortar por opção do utilizador"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "argumento '-' especificado sem entrada em stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "não foi possível localizar PKGBUILD e .SRCINFO no diretório"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "nome de pacote não encontrado: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "não encontrado PKGDEST para: %s"
 
@@ -520,11 +586,11 @@ msgstr "não encontrado PKGDEST para: %s"
 msgid "could not find all required packages"
 msgstr "não foi possível localizar todos os pacotes necessários"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "não foi possível localizar nenhum arquivo de pacotes listados em %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "dependência"
 
@@ -533,11 +599,11 @@ msgid "devel check for package failed: '%s' encountered an error"
 msgstr ""
 "falha na pesquisa por pacotes de desenvolvimento: '%s' encontrou um erro"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "editor não terminou com sucesso, abortando: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "erro ao descarregar fontes: %s"
 
@@ -545,19 +611,19 @@ msgstr "erro ao descarregar fontes: %s"
 msgid "error fetching %s: %s"
 msgstr "erro ao buscar %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "erro ao instalar pacotes de repositório"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "erro ao instalar:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "erro ao compilar: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "erro ao fundir %s: %s"
 
@@ -565,19 +631,19 @@ msgstr "erro ao fundir %s: %s"
 msgid "error reading %s"
 msgstr "erro ao ler %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "erro ao recarregar base de dados"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "erro ao repor %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "erro ao atualizar instalação do pacote motivo para %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "explícito"
 
@@ -585,27 +651,27 @@ msgstr "explícito"
 msgid "failed to create directory '%s': %s"
 msgstr "falha ao criar pasta '%s': %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "falha ao abrir arquivo de configuração '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "falha ao analisar %s -- ignorando: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "falha ao analisar %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "falha ao analisar .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "falha ao ler ficheiro de configuração '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "falha ao recuperar cache aur"
 
@@ -619,7 +685,7 @@ msgstr ""
 msgid "input too long"
 msgstr "input demasiado longo"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "número inválido: %s"
 
@@ -627,7 +693,7 @@ msgstr "número inválido: %s"
 msgid "invalid option '%s'"
 msgstr "opção inválida '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "opção inválida: '--deps' e '--explicit' não podem ser usados em conjunto"
@@ -636,11 +702,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "repositório inválido"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "valor inválido: %d não está entre %d e %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "nenhuma chave a importar"
 
@@ -648,15 +714,15 @@ msgstr "nenhuma chave a importar"
 msgid "no query was executed"
 msgstr "nenhuma análise foi executada"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "nenhum diretório de destino especificado"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "não"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "nada a instalar para %s"
 
@@ -664,7 +730,11 @@ msgstr "nada a instalar para %s"
 msgid "only one operation may be used at a time"
 msgstr "apenas uma operação pode ser utilizada ao mesmo tempo"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "pacote '%s' não foi encontrado"
 
@@ -676,30 +746,30 @@ msgstr "pacote não encontrado no AUR"
 msgid "package not found in repos"
 msgstr "pacote não encontrado nos repositórios"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "pacote"
 msgstr[1] "pacotes"
 msgstr[2] "pacotes"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "problema ao importar chaves"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "a remover pacotes AUR da cache..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "a remover ficheiros AUR não rastreados da cache..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "o PKGDEST para %s é listado pelo makepkg mas não existe: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "não há nada a fazer"
 
@@ -707,14 +777,14 @@ msgstr "não há nada a fazer"
 msgid "unable to CreateHandle: %s"
 msgstr "não é possível executar CreateHandle: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "operação não implementada"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "versão-desconhecida"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "sim"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Otto Micheletti <michelettiotto@gmail.com>, 2021
@@ -6,64 +6,66 @@
 # Zisa, 2022
 # Caio Pereira, 2023
 # Fernando Macedo, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Fernando Macedo, 2023\n"
-"Language-Team: Portuguese (Brazil) (https://app.transifex.com/yay-1/teams/123732/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://app.transifex.com/yay-1/"
+"teams/123732/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (Arquivos de Build Existem)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Instalado)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Instalado]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " não há nada a ser feito"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]Todos [Ab]Abortar [I]Instalados [No]Não Instalados ou (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s já construído -- pulando build"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s não está definido"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s está presente."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s está atualizado -- pulando"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "para atualizar/instalar."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "também será instalado para essa operação."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, requeridos por: %s"
 
@@ -85,27 +87,83 @@ msgstr ""
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: ignorando atualização do pacote (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: local (%s) é mais recente que o AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "por favor configure as variáveis de ambiente AUR_USERNAME e AUR_PASSWORD "
 "para votar"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD baixado do ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD transferido: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD transferido: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Analisando SRCINFO: %s"
 
@@ -125,7 +183,7 @@ msgstr "(Orfão)"
 msgid "(Out-of-date: %s)"
 msgstr "(Desatualizado: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "URL do AUR"
 
@@ -133,7 +191,7 @@ msgstr "URL do AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Adicione %s ou %s às suas variáveis de ambiente"
 
@@ -145,7 +203,7 @@ msgstr "Evite executar o yay como root/sudo."
 msgid "Check Dependency"
 msgstr "Verificar dependências"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Dependências de verificação"
 
@@ -153,15 +211,15 @@ msgstr "Dependências de verificação"
 msgid "Checking development packages..."
 msgstr "Verificando pacotes em desenvolvimento..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Limpando (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Em conflito com"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Removendo (%d/%d): %s"
 
@@ -169,15 +227,15 @@ msgstr "Removendo (%d/%d): %s"
 msgid "Dependency"
 msgstr "Dependências"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Depende de"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Descrição"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Exibir Diffs?"
 
@@ -185,19 +243,19 @@ msgstr "Exibir Diffs?"
 msgid "Disable 'provides' setting by default"
 msgstr "Desativar a definição 'fornece' por padrão"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Você deseja remover TODOS os pacotes AUR do cache?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Você deseja remover TODOS os pacotes AUR não monitorados?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Você deseja remover todos os outros pacotes AUR do cache?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Editar PKGBUILD com?"
 
@@ -205,7 +263,7 @@ msgstr "Editar PKGBUILD com?"
 msgid "Error during AUR search: %s\n"
 msgstr "Erro durante a busca no AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "A exclusão de pacotes pode causar atualizações parciais e quebrar sistemas"
@@ -214,33 +272,33 @@ msgstr ""
 msgid "Explicit"
 msgstr "Explícito"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Pacotes explicitamente instalados: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Falha ao localizar pacote AUR para"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Falha ao instalar camada, indo até à camada seguinte."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 "Falha ao instalar os seguintes pacotes. É necessária a intervenção manual:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Primeira Submissão"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Pacotes AUR marcados como desatualizados:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Pacotes externos instalados: %s"
 
@@ -248,31 +306,31 @@ msgstr "Pacotes externos instalados: %s"
 msgid "Found git repo: %s"
 msgstr "Repositório git encontrado: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB finalizado. Nenhum pacote foi instalado"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Grupos"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Importar?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Importando chaves com gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Palavras-chave"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Última modificação"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Licenças"
 
@@ -280,7 +338,7 @@ msgstr "Licenças"
 msgid "Local"
 msgstr "Local"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Mantenedor"
 
@@ -288,11 +346,11 @@ msgstr "Mantenedor"
 msgid "Make Dependency"
 msgstr "Criar dependências"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Dependências Make"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Pacotes de debug do AUR em falta:"
 
@@ -300,35 +358,40 @@ msgstr "Pacotes de debug do AUR em falta:"
 msgid "Missing"
 msgstr "Em falta"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Nome"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Nenhum pacote AUR localizado para"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Nenhum pacote AUR localizado para"
+
+#: print.go:225
 msgid "None"
 msgstr "Nenhum"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Depêndencias Opcionais"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Pacotes AUR órfãos (não mantidos):"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Desatualizado"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Chaves PGP que precisam ser importadas:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD atualizado, ignorando a transferência: %s"
 
@@ -336,55 +399,60 @@ msgstr "PKGBUILD atualizado, ignorando a transferência: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "PKGBUILDs a serem editados?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID do Pacote Base"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Pacotes Base"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Pacotes que não estão no AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Limpar e construir quais pacotes?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Pacotes a excluir"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Pacotes a excluir: (ex: \"1 2 3\", \"1-3\", \"^4\" ou nome do repositório)"
+msgstr ""
+"Pacotes a excluir: (ex: \"1 2 3\", \"1-3\", \"^4\" ou nome do repositório)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Pacotes a instalar (ex: 1 2 3, 1-3 ou ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularidade"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Prosseguir com a instalação?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Fornece"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Remover dependências make após a instalação?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Repositório AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Repositório"
 
@@ -404,15 +472,15 @@ msgstr "Procurando atualizações nos bancos de dados..."
 msgid "Showing repo packages only"
 msgstr "Mostrando somente pacotes do repositório"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Tamanho da cache do pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Tamanho da cache do yay %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL para Snapshot"
 
@@ -420,71 +488,71 @@ msgstr "URL para Snapshot"
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Dez maiores pacotes:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Os seguintes pacotes não são compatíveis com a sua arquitetura:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Existem %d fornecedores disponíveis para %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Pode haver outra instância do Pacman em execução. Aguardando..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Espaço total ocupado por pacotes: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Total de pacotes instalados: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Tentar construí-los mesmo assim?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Não foi possível limpar:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Não foi possível encontrar os seguintes pacotes:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Não foi possível gerir votação de pacote para: %s err: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Não foi possível remover %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Versão"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Votos"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Versão do Yay v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]Nenhum"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -492,7 +560,7 @@ msgstr ""
 "\n"
 "Diretório de Build:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -504,19 +572,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "abortando devido ao usuário"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "argumento '-' especificado sem entrada em stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "não foi possível localizar PKGBUILD e .SRCINFO no diretório"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "não foi possível encontrar o nome do pacote: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "não foi possível encontrar PKGDEST para: %s"
 
@@ -524,11 +592,11 @@ msgstr "não foi possível encontrar PKGDEST para: %s"
 msgid "could not find all required packages"
 msgstr "não foi possível localizar todos os pacotes necessários"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "não foi possível localizar nenhum arquivo de pacotes listados em %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "dependência"
 
@@ -536,11 +604,11 @@ msgstr "dependência"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "a busca por pacotes devel falhou: '%s' encontrou um erro"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "editor não finalizou com sucesso, abortando: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "erro ao descarregar as fontes: %s"
 
@@ -548,19 +616,19 @@ msgstr "erro ao descarregar as fontes: %s"
 msgid "error fetching %s: %s"
 msgstr "erro ao buscar %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "erro ao instalar pacotes do repositório"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "erro ao instalar:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "erro ao construir: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "erro ao mesclar %s: %s"
 
@@ -568,19 +636,19 @@ msgstr "erro ao mesclar %s: %s"
 msgid "error reading %s"
 msgstr "erro ao ler %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "erro ao recarregar base de dados"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "erro ao resetar %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "erro ao atualizar instalação do pacote motivo para %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "explícito"
 
@@ -588,27 +656,27 @@ msgstr "explícito"
 msgid "failed to create directory '%s': %s"
 msgstr "falha ao criar diretório '%s':%s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "falha ao abrir o arquivo de configuração '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "falha ao analisar %s -- pulando: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "falha ao analisar %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "falha ao analisar .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "falha ao ler o arquivo de configuração '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "falha ao recuperar cache aur"
 
@@ -622,7 +690,7 @@ msgstr ""
 msgid "input too long"
 msgstr "input muito longo"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "número inválido: %s"
 
@@ -630,7 +698,7 @@ msgstr "número inválido: %s"
 msgid "invalid option '%s'"
 msgstr "argumento inválido '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "opção inválida: os argumentos '--deps' e '--explicit' não podem ser usados "
@@ -640,11 +708,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "repositório inválido"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "valor inválido: %d não está entre %d e %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "nenhuma chave para ser importada"
 
@@ -652,15 +720,15 @@ msgstr "nenhuma chave para ser importada"
 msgid "no query was executed"
 msgstr "nenhuma busca foi executada"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "nenhum diretório de destino especificado"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "não"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "nada a instalar para %s"
 
@@ -668,7 +736,11 @@ msgstr "nada a instalar para %s"
 msgid "only one operation may be used at a time"
 msgstr "somente uma operação pode ser utilizada de cada vez"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "pacote '%s' não foi encontrado"
 
@@ -680,30 +752,30 @@ msgstr "pacote não encontrado no AUR"
 msgid "package not found in repos"
 msgstr "pacote não encontrado nos repositórios"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "pacote"
 msgstr[1] "pacotes"
 msgstr[2] "pacotes"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "problema ao importar as chaves"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "removendo pacotes AUR do cache..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "removendo arquivos do AUR não rastreados do cache..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "o PKGDEST para %s está listado pelo makepkg porém não existe: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr " não há nada a ser feito"
 
@@ -711,14 +783,14 @@ msgstr " não há nada a ser feito"
 msgid "unable to CreateHandle: %s"
 msgstr "não foi possível executar CreateHandle: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "operação sem manuseio"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "versão-desconhecida"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # Ravenso BlacK, 2022
 # Vladislav Zenkov, 2022
@@ -6,64 +6,66 @@
 # Victor Golovanenko <drygdryg2014@yandex.ru>, 2023
 # Dancheg97 F, 2023
 # falixkamishin falixx, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: falixkamishin falixx, 2023\n"
 "Language-Team: Russian (https://app.transifex.com/yay-1/teams/123732/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (Файлы сборки существуют)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr "(Установлено)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr "[Установлено]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "делать больше нечего"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [В]се [От]менить [У]становленные [Не]установленные или (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s уже собран -- сборка пропускается"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s не задан"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s уже существует."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s обновлён -- пропуск"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "обновить/установить."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "также будет установлен для этой операции."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, требуется пакету: %s"
 
@@ -83,27 +85,83 @@ msgstr "%s: невозможно использовать цель с парам
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: игнорирование обновления пакета (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: локальный пакет (%s) новее, чем в AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "%s: пожалуйста, укажите AUR_USERNAME и AUR_PASSWORD переменной среды для "
 "голосования"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) Загружен PKGBUILD из ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) Загружен PKGBUILD: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) Не удалось загрузить PKGBUILD: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Анализ SRCINFO: %s"
 
@@ -123,7 +181,7 @@ msgstr "(Осиротевший)"
 msgid "(Out-of-date: %s)"
 msgstr "(Устарел: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "Ссылка на AUR"
 
@@ -131,7 +189,7 @@ msgstr "Ссылка на AUR"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Добавьте %s или %s в переменные среды"
 
@@ -143,7 +201,7 @@ msgstr "Избегайте запуска yay от имени root/sudo."
 msgid "Check Dependency"
 msgstr "Проверка зависимости"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Зависимости, требуемые для проверки"
 
@@ -151,15 +209,15 @@ msgstr "Зависимости, требуемые для проверки"
 msgid "Checking development packages..."
 msgstr "Проверка пакетов разработки..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Очистка (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Конфликтует с"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Удаление (%d/%d): %s"
 
@@ -167,15 +225,15 @@ msgstr "Удаление (%d/%d): %s"
 msgid "Dependency"
 msgstr "Зависимость"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Зависит от"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Описание"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Показать изменения?"
 
@@ -183,19 +241,19 @@ msgstr "Показать изменения?"
 msgid "Disable 'provides' setting by default"
 msgstr "Отключите настройку 'обеспечивает' по умолчанию"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Вы хотите удалить ВСЕ пакеты AUR из кэша?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Вы хотите удалить ВСЕ неотслеживаемые файлы AUR?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Вы хотите удалить все остальные пакеты AUR из кэша?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Отредактировать PKGBUILD?"
 
@@ -203,7 +261,7 @@ msgstr "Отредактировать PKGBUILD?"
 msgid "Error during AUR search: %s\n"
 msgstr "Ошибка поиска в AUR: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Исключение пакетов может привести к частичному обновлению и сломать систему"
@@ -212,33 +270,33 @@ msgstr ""
 msgid "Explicit"
 msgstr "Явно"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Явно установленные пакеты: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Не удалось найти пакет AUR для"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Ошибка установки слоя, переход на следующий слой."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr ""
 "Не удалось установить следующие пакеты — требуется ручное вмешательство:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Впервые представленный"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Пакеты AUR, помеченные как устаревшие:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Cторонних пакетов установлено: "
 
@@ -246,31 +304,31 @@ msgstr "Cторонних пакетов установлено: "
 msgid "Found git repo: %s"
 msgstr "Найден git репозиторий: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "Генерирование БД завершено. Никакие пакеты не были установлены"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Группы"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Импортировать?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Импортирование ключей с помощью GPG..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Ключевые слова"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Последнее изменение"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Лицензии"
 
@@ -278,7 +336,7 @@ msgstr "Лицензии"
 msgid "Local"
 msgstr "Локальный"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Сопровождающий"
 
@@ -286,11 +344,11 @@ msgstr "Сопровождающий"
 msgid "Make Dependency"
 msgstr "Создание зависимости"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Зависимости, требуемые для сборки"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Отсутствующие в AUR пакеты для отладки:"
 
@@ -298,35 +356,40 @@ msgstr "Отсутствующие в AUR пакеты для отладки:"
 msgid "Missing"
 msgstr "Отсутствующие"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Название"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Не найден пакет AUR для"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Не найден пакет AUR для"
+
+#: print.go:225
 msgid "None"
 msgstr "Нет"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Дополнительные зависимости"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Осиротевшие (неподдерживаемые) пакеты AUR:"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Устарел"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Ключи PGP, требующие импорта:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD находится в актуальном состоянии, пропускается загрузка: %s"
 
@@ -334,55 +397,61 @@ msgstr "PKGBUILD находится в актуальном состоянии, 
 msgid "PKGBUILDs to edit?"
 msgstr "Отредактировать PKGBUILD?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "Идентификатор пакета"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Базовый пакет"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Пакет не найден в AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Пакеты для чистой сборки?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Пакеты для исключения"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Исключить пакеты: (напр.: \"1 2 3\", \"1-3\", \"^4\" или название репозитория)"
+msgstr ""
+"Исключить пакеты: (напр.: \"1 2 3\", \"1-3\", \"^4\" или название "
+"репозитория)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Пакеты для установки: (напр.: 1 2 3, 1-3 or ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Популярность"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Продолжить установку?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Предоставляет"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Удалить зависимости сборки после установки?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Репозиторий AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Репозиторий"
 
@@ -402,15 +471,15 @@ msgstr "Поиск обновлений в базах данных..."
 msgid "Showing repo packages only"
 msgstr "Показываются только пакеты из репозиториев"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Размер кэша pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Размер кэша yay %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "Ссылка снимка"
 
@@ -418,71 +487,71 @@ msgstr "Ссылка снимка"
 msgid "Sync"
 msgstr "Синхронизация"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Десять самых больших пакетов:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Следующие пакеты несовместимы с вашей архитектурой:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Существует %d пакетов которые удволетворяют %s"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Возможно, запущен другой процесс Pacman. Ожидание..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Суммарный размер, занятый пакетами: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Всего установлено пакетов: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Попытаться собрать, несмотря на несовместимость?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Невозможно очистить:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Не удалось найти следующие пакеты:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Не удалось обработать голосование за: %s. ошибка: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Не удается удалить %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Версия"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Голосов"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Версия Yay: v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[Н]ет"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -490,7 +559,7 @@ msgstr ""
 "\n"
 "Каталог сборки:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -502,19 +571,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "прервано пользователем"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "аргумент '-' задан без ввода из stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "не удалось найти PKGBUILD и .SRCINFO в каталоге"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "Неудалось найти пакет с названием: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "не удалось найти PKGDEST для: %s"
 
@@ -522,11 +591,11 @@ msgstr "не удалось найти PKGDEST для: %s"
 msgid "could not find all required packages"
 msgstr "не удалось найти все необходимые пакеты"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "Не удалось найти архивы пакетов в %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "зависимости"
 
@@ -534,11 +603,11 @@ msgstr "зависимости"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "проверка пакета '%s' не завершена из-за ошибки"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "неудачный выход из редактора, отмена: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "ошибка загрузки исходников: %s"
 
@@ -546,19 +615,19 @@ msgstr "ошибка загрузки исходников: %s"
 msgid "error fetching %s: %s"
 msgstr "ошибка скачивания %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "ошибка установки пакетов из репозиториев"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "ошибка установки:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "ошибка сборки: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "ошибка объединения %s: %s"
 
@@ -566,19 +635,19 @@ msgstr "ошибка объединения %s: %s"
 msgid "error reading %s"
 msgstr "ошибка чтения %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "ошибка обновления базы данных"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "ошибка сброса %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "ошибка изменения причины установки пакета на %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "явно"
 
@@ -586,27 +655,27 @@ msgstr "явно"
 msgid "failed to create directory '%s': %s"
 msgstr "ошибка создания каталога '%s': %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "ошибка открытия файла конфигурации '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "ошибка при анализе %s --- пропуск: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "ошибка при анализе %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "ошибка при анализе .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "не удалось прочитать файл конфигурации '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "не удалось получить кэш AUR"
 
@@ -618,7 +687,7 @@ msgstr "Игнорирование обновления пакета devel (ин
 msgid "input too long"
 msgstr "ввод слишком длинный"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "неверное число: %s"
 
@@ -626,7 +695,7 @@ msgstr "неверное число: %s"
 msgid "invalid option '%s'"
 msgstr "неверная опция '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "неверная опция: невозможно использовать опции '--deps' и '--explicit' "
@@ -636,11 +705,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "недействительный репозиторий"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "неверное значение: %d не в промежутке между %d и %d "
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "нет ключей для импорта"
 
@@ -648,15 +717,15 @@ msgstr "нет ключей для импорта"
 msgid "no query was executed"
 msgstr "запрос не был выполнен"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "не выбраны целевые директории"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "нет"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "нечего установить из %s"
 
@@ -664,7 +733,11 @@ msgstr "нечего установить из %s"
 msgid "only one operation may be used at a time"
 msgstr "только одна операция может быть вызвана за один раз"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "пакет '%s' не найден"
 
@@ -676,7 +749,7 @@ msgstr "пакет не найден в AUR"
 msgid "package not found in repos"
 msgstr "пакет не найден в репозиториях"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "пакет"
@@ -684,23 +757,23 @@ msgstr[1] "пакеты"
 msgstr[2] "пакеты"
 msgstr[3] "пакеты"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "проблема импортирования ключей"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "удаление пакетов AUR из кэша..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "удаление неотслеживаемых файлов AUR из кэша..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "файл PKGDEST для %s указан в выводе makepkg, но не существует: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "делать больше нечего"
 
@@ -708,14 +781,14 @@ msgstr "делать больше нечего"
 msgid "unable to CreateHandle: %s"
 msgstr "невозможно выполнить CreateHandle: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "необработанная операция"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "неизвестная версия"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "да"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -8,45 +8,40 @@
 msgid ""
 msgstr ""
 "Last-Translator: Demir Yerli, 2022\n"
-"Language-Team: Russian (Russia) (https://www.transifex.com/yay-1/teams/123732/ru_RU/)\n"
+"Language-Team: Russian (Russia) (https://www.transifex.com/yay-1/"
+"teams/123732/ru_RU/)\n"
+"Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru_RU\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: xgotext\n"
 
 #: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (файлы сборки существуют)"
 
-#: pkg/menus/menu.go:28
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Установлено)"
 
-#: pkg/dep/depCheck.go:312
-msgid " (Target"
-msgstr " (Цель"
-
-#: pkg/dep/depCheck.go:314
-msgid " (Wanted by: "
-msgstr " (Требуется пакету: "
-
-#: cmd.go:427
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Установлено]"
 
-#: cmd.go:386 install.go:158 install.go:192
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "делать нечего"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
-"%s [A]Все [Ab]Прервать [I]Установленные [No]Неустановленные или (1 2 3, 1-3,"
-" ^4)"
+"%s [A]Все [Ab]Прервать [I]Установленные [No]Неустановленные или (1 2 3, 1-3, "
+"^4)"
 
-#: install.go:729
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s уже собран --- сборка пропускается"
 
@@ -54,140 +49,209 @@ msgstr "%s уже собран --- сборка пропускается"
 msgid "%s is not set"
 msgstr "%s не задан"
 
-#: pkg/settings/exe/cmd_builder.go:198
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s уже существует."
 
-#: install.go:715
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%sобновлён до последней версии --- пропуск"
 
-#: install.go:640
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s не удовлетворена, очистка очереди установки"
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
+msgstr "Пакеты для обновления."
 
-#: pkg/pgp/keys.go:128
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
+
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, требуется пакету: %s"
 
-#: pkg/menus/diff_menu.go:50
+#: pkg/menus/diff_menu.go:49
 msgid "%s: No changes -- skipping"
 msgstr "%s: Нет изменений --- пропуск"
 
-#: pkg/query/filter.go:52
+#: pkg/query/filter.go:22
 msgid "%s: can't use target with option --aur -- skipping"
 msgstr "%s: невозможно использовать цель с опцией --aur --- пропуск"
 
-#: pkg/query/filter.go:47
+#: pkg/query/filter.go:17
 msgid "%s: can't use target with option --repo -- skipping"
 msgstr "%s: невозможно использовать цель с опцией --repo --- пропуск"
 
-#: pkg/upgrade/sources.go:82
+#: pkg/upgrade/sources.go:57
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: пропуск обновления пакета (%s => %s)"
 
-#: upgrade.go:138
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: локальная версия (%s) новее, чем в AUR (%s)"
 
-#: pkg/download/unified.go:187
+#: vote.go:51
+msgid ""
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
+msgstr ""
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
+
+#: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) Скачан PKGBUILD из ABS: %s"
 
-#: pkg/download/aur.go:83 pkg/download/unified.go:183
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) Скачан PKGBUILD: %s"
 
-#: install.go:517
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) Скачан PKGBUILD: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Анализ SRCINFO: %s"
 
-#: pkg/query/types.go:145 pkg/query/types.go:199
+#: pkg/query/types.go:72 pkg/query/types.go:103
 msgid "(Installed)"
 msgstr "(установлено)"
 
-#: pkg/query/types.go:143 pkg/query/types.go:197
+#: pkg/query/types.go:70 pkg/query/types.go:101
 msgid "(Installed: %s)"
 msgstr "(установлено: %s)"
 
-#: pkg/query/types.go:134
+#: pkg/query/types.go:61
 msgid "(Orphaned)"
 msgstr "(сирота в AUR)"
 
-#: pkg/query/types.go:138
+#: pkg/query/types.go:65
 msgid "(Out-of-date: %s)"
 msgstr "(устарел: %s)"
 
-#: print.go:28
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR URL"
+
+#: pkg/dep/dep_graph.go:75
+#, fuzzy
+msgid "AUR"
+msgstr "URL"
 
 #: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Добавьте %s или %s в переменные окружения"
 
-#: main.go:103
+#: main.go:60
 msgid "Avoid running yay as root/sudo."
 msgstr "Не запускайте yay от имени root/sudo."
 
-#: print.go:34
+#: pkg/dep/dep_graph.go:63
+#, fuzzy
+msgid "Check Dependency"
+msgstr "Зависимости проверки"
+
+#: print.go:41
 msgid "Check Deps"
 msgstr "Зависимости проверки"
 
-#: upgrade.go:88
+#: pkg/upgrade/service.go:90
 msgid "Checking development packages..."
 msgstr "Проверка пакетов в разработке (-git, -svn и т. п.)..."
 
-#: pkg/dep/depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "Проверка конфликтов..."
-
-#: pkg/dep/depCheck.go:145
-msgid "Checking for inner conflicts..."
-msgstr "Проверка внутренних конфликтов..."
-
-#: clean.go:206
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Очистка (%d/%d): %s"
 
-#: pkg/dep/depCheck.go:200
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr ""
-"Подтверждение удаления конфликтующих пакетов должно быть выполнено вручную"
-
-#: print.go:36
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Конфликтует с"
 
-#: pkg/dep/depCheck.go:305
-msgid "Could not find all required packages:"
-msgstr "Невозможно найти все требуемые пакеты:"
-
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Удаление (%d/%d): %s"
 
-#: print.go:32
+#: pkg/dep/dep_graph.go:61
+#, fuzzy
+msgid "Dependency"
+msgstr "Зависит от"
+
+#: print.go:38
 msgid "Depends On"
 msgstr "Зависит от"
 
-#: print.go:26
+#: print.go:33
 msgid "Description"
 msgstr "Описание"
 
-#: pkg/menus/diff_menu.go:157
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Показать изменения?"
 
-#: clean.go:72
+#: pkg/settings/migrations.go:25
+msgid "Disable 'provides' setting by default"
+msgstr ""
+
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Вы хотите удалить все пакеты AUR из кэша?"
 
-#: clean.go:89
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Вы хотите удалить все неотслеживаемые файлы AUR?"
 
-#: clean.go:74
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Вы хотите удалить все остальные пакеты AUR из кэша?"
 
@@ -199,247 +263,303 @@ msgstr "Отредактировать PKGBUILD?"
 msgid "Error during AUR search: %s\n"
 msgstr "Ошибка поиска в AUR: %s\n"
 
-#: print.go:85
+#: pkg/upgrade/service.go:296
+msgid "Excluding packages may cause partial upgrades and break systems"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:60
+msgid "Explicit"
+msgstr ""
+
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Пакеты, установленные по запросу пользователя: %s"
 
-#: print.go:40
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
+#, fuzzy
+msgid "Failed to find AUR package for"
+msgstr "Пакеты AUR, помеченные как устаревшие:"
+
+#: pkg/sync/build/installer.go:120
+msgid "Failed to install layer, rolling up to next layer."
+msgstr ""
+
+#: pkg/sync/build/errors.go:16
+msgid ""
+"Failed to install the following packages. Manual intervention is required:"
+msgstr ""
+
+#: print.go:45
 msgid "First Submitted"
 msgstr "Впервые загружен на AUR"
 
-#: pkg/query/aur_warnings.go:43
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Пакеты AUR, помеченные как устаревшие:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Установлено сторонних пакетов: %s"
 
-#: pkg/vcs/vcs.go:119
+#: pkg/vcs/vcs.go:144
 msgid "Found git repo: %s"
 msgstr "Найден git-репозиторий: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB завершён без установки пакетов"
 
-#: print.go:29
+#: print.go:36
 msgid "Groups"
 msgstr "Группы"
 
-#: pkg/pgp/keys.go:88
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Импортировать?"
 
-#: pkg/pgp/keys.go:101
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Импортирование ключей с помощью gpg..."
 
-#: pkg/dep/depCheck.go:155
-msgid "Inner conflicts found:"
-msgstr "Обнаружены внутренние конфликты:"
-
-#: pkg/dep/depCheck.go:173
-msgid "Installing %s will remove:"
-msgstr "Установка %s приведёт к удалению:"
-
-#: print.go:24
+#: print.go:46
 msgid "Keywords"
 msgstr "Ключевые слова"
 
-#: print.go:41
+#: print.go:47
 msgid "Last Modified"
 msgstr "Последнее изменение"
 
-#: print.go:30
+#: print.go:35
 msgid "Licenses"
 msgstr "Лицензии"
 
-#: print.go:37
+#: pkg/dep/dep_graph.go:77
+msgid "Local"
+msgstr ""
+
+#: print.go:48
 msgid "Maintainer"
 msgstr "Сопровождающий"
 
-#: print.go:33
+#: pkg/dep/dep_graph.go:62
+#, fuzzy
+msgid "Make Dependency"
+msgstr "Зависимости сборки"
+
+#: print.go:40
 msgid "Make Deps"
 msgstr "Зависимости сборки"
 
-#: pkg/query/aur_warnings.go:33
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Отсутствующие в AUR пакеты для отладки:"
 
-#: pkg/query/aur_warnings.go:28
-msgid "Missing AUR Packages:"
-msgstr "Отсутствующие в AUR пакеты:"
+#: pkg/dep/dep_graph.go:79
+msgid "Missing"
+msgstr ""
 
-#: print.go:23
+#: print.go:31
 msgid "Name"
 msgstr "Название"
 
-#: pkg/text/print.go:95
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
+#, fuzzy
+msgid "No AUR package found for"
+msgstr "пакет не найден в репозиториях"
+
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "пакет не найден в репозиториях"
+
+#: print.go:225
 msgid "None"
 msgstr "Нет"
 
-#: print.go:35
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Факультативные зависимости"
 
-#: pkg/query/aur_warnings.go:38
-msgid "Orphaned AUR Packages:"
+#: pkg/query/aur_warnings.go:75
+#, fuzzy
+msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Пакеты-сироты AUR без сопровождающего:"
 
-#: print.go:44 print.go:46
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Устарел"
 
-#: pkg/pgp/keys.go:119
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Ключи PGP, требующие импорта:"
 
-#: install.go:242 vcs.go:50
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
+#: pkg/sync/workdir/preparer.go:252
+#, fuzzy
+msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD обновлён, пропуск (%d/%d): %s"
 
-#: pkg/menus/edit_menu.go:123
+#: pkg/menus/edit_menu.go:130
 msgid "PKGBUILDs to edit?"
 msgstr "Отредактировать PKGBUILD?"
 
-#: print.go:51
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID группы пакетов"
 
-#: print.go:52
+#: print.go:61
 msgid "Package Base"
 msgstr "Группа пакетов"
 
-#: pkg/dep/depCheck.go:170
-msgid "Package conflicts found:"
-msgstr "Обнаружены конфликты пакетов:"
+#: pkg/query/aur_warnings.go:67
+#, fuzzy
+msgid "Packages not in AUR:"
+msgstr "пакет не найден в AUR"
 
-#: pkg/menus/clean_menu.go:44
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Пакеты, для которых требуется очистить кэш сборки?"
 
-#: upgrade.go:186
-msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
-msgstr "Пакеты для исключения: (пример: \"1 2 3\", \"1-3\", \"^4\" или имя в репозитории)"
+#: pkg/dep/dep_graph.go:202
+#, fuzzy
+msgid "Packages to exclude"
+msgstr "Пакеты для обновления."
 
-#: cmd.go:368
+#: pkg/upgrade/service.go:295
+msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
+msgstr ""
+"Пакеты для исключения: (пример: \"1 2 3\", \"1-3\", \"^4\" или имя в "
+"репозитории)"
+
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Пакеты для установки (пример: 1 2 3, 1-3 или ^4)"
 
-#: upgrade.go:183
-msgid "Packages to upgrade."
-msgstr "Пакеты для обновления."
-
-#: print.go:39
+#: print.go:49
 msgid "Popularity"
 msgstr "Популярность"
 
-#: pkg/menus/diff_menu.go:169 pkg/menus/edit_menu.go:134
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Продолжить установку?"
 
-#: print.go:31
+#: print.go:37
 msgid "Provides"
 msgstr "Обеспечивает"
 
-#: pkg/query/aur_info.go:88
-msgid "Querying AUR..."
-msgstr "Выполнение запроса в AUR..."
-
-#: install.go:213
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Удалить зависимости для сборки после установки?"
 
-#: pkg/dep/depPool.go:546
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Репозиторий AUR"
 
-#: print.go:22 pkg/db/ialpm/alpm.go:175
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Репозиторий"
 
-#: upgrade.go:68
+#: pkg/dep/dep_graph.go:78
+msgid "SRCINFO"
+msgstr ""
+
+#: pkg/upgrade/service.go:72
 msgid "Searching AUR for updates..."
 msgstr "Поиск обновлений в AUR..."
 
-#: upgrade.go:57
+#: pkg/upgrade/service.go:160
 msgid "Searching databases for updates..."
 msgstr "Поиск обновлений в базе данных..."
 
-#: pkg/query/mixed_sources.go:200 pkg/query/source.go:79
+#: pkg/query/query_builder.go:214
 msgid "Showing repo packages only"
 msgstr "Показываются только пакеты из репозиториев"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Размер кэша \"pacman\" %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Размер кэша \"yay\" %s: %s"
 
-#: print.go:53
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL архива"
 
-#: print.go:94
+#: pkg/dep/dep_graph.go:76
+msgid "Sync"
+msgstr ""
+
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "10 самых объёмных пакетов:"
 
-#: install.go:461
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Следующие пакеты несовместимы с архитектурой вашего процессора:"
 
-#: pkg/db/ialpm/alpm.go:163 pkg/dep/depPool.go:541
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Существует %d пакетов которые удволетворяют %s"
 
-#: pkg/settings/exe/cmd_builder.go:199
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Возможно, запущен другой экземпляр Pacman. Ожидание..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Суммарный размер, занятый пакетами: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Всего установлено пакетов: %s"
 
-#: install.go:469
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Попытаться собрать их, несмотря на несовместимость?"
 
-#: print.go:27
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:182
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Невозможно очистить:"
 
-#: get.go:42 get.go:73
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Не удалось найти следующие пакеты:"
 
-#: print.go:25
+#: vote.go:20
+msgid "Unable to handle package vote for: %s. err: %s"
+msgstr ""
+
+#: clean.go:170
+#, fuzzy
+msgid "Unable to remove %s: %s"
+msgstr "ошибка при анализе %s: %s"
+
+#: print.go:32
 msgid "Version"
 msgstr "Версия"
 
-#: print.go:38
+#: print.go:50
 msgid "Votes"
 msgstr "Голосов"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay версии v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]Нет"
 
-#: clean.go:77
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -447,7 +567,7 @@ msgstr ""
 "\n"
 "Каталог сборки:"
 
-#: pkg/db/ialpm/alpm.go:185 pkg/dep/depPool.go:556
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -459,23 +579,45 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "прерывание по запросу пользователя"
 
-#: install.go:496
+#: pkg/settings/parser/parser.go:620
+msgid "argument '-' specified without input on stdin"
+msgstr ""
+
+#: local_install.go:26
+msgid "cannot find PKGBUILD and .SRCINFO in directory"
+msgstr ""
+
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "невозможно найти пакет: %v"
 
-#: install.go:688 install.go:821
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "невозможно найти файл PKGDEST для: %s"
 
-#: pkg/vcs/vcs.go:69
+#: errors.go:9
+#, fuzzy
+msgid "could not find all required packages"
+msgstr "Невозможно найти все требуемые пакеты:"
+
+#: pkg/sync/build/errors.go:61
+msgid "could not find any package archives listed in %s"
+msgstr ""
+
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
+#, fuzzy
+msgid "dependency"
+msgstr "Зависит от"
+
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "Проверка для пакета '%s' не закончилась успехом"
 
-#: pkg/menus/edit_menu.go:108
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "выход из редактора был неуспешным, прерывание: %s"
 
-#: aur_source.go:26
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "ошибка загрузки исходников: %s"
 
@@ -483,65 +625,84 @@ msgstr "ошибка загрузки исходников: %s"
 msgid "error fetching %s: %s"
 msgstr "ошибка получения %s: %s"
 
-#: install.go:299 install.go:405
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "ошибка установки пакетов из репозиториев"
 
-#: install.go:671 install.go:712 install.go:726 install.go:740
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
+#, fuzzy
+msgid "error installing:"
+msgstr "ошибка установки пакетов из репозиториев"
+
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "ошибка сборки: %s"
 
-#: install.go:573
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "ошибка объединения %s: %s"
 
-#: pkg/download/unified.go:56
+#: pkg/download/unified.go:59
 msgid "error reading %s"
 msgstr "ошибка чтения %s"
 
-#: install.go:88
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "ошибка обновления базы данных"
 
-#: clean.go:212 install.go:566
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "ошибка сброса %s: %s"
 
-#: install.go:42
-msgid "error updating package install reason to dependency"
+#: pkg/sync/build/errors.go:53
+#, fuzzy
+msgid "error updating package install reason to %s"
 msgstr ""
-"ошибка при изменении причины установки пакета на \"установленный как "
-"зависимость\":"
+"ошибка при изменении причины установки пакета на \"явно установленный\":"
 
-#: install.go:60
-msgid "error updating package install reason to explicit"
-msgstr "ошибка при изменении причины установки пакета на \"явно установленный\":"
+#: pkg/sync/build/errors.go:48
+msgid "explicit"
+msgstr ""
 
 #: pkg/settings/errors.go:23
 msgid "failed to create directory '%s': %s"
 msgstr "ошибка создания каталога '%s': %s"
 
-#: pkg/settings/config.go:293
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "ошибка открытия файла конфигурации '%s': %s"
 
-#: install.go:522
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "ошибка при анализе %s --- пропуск: %s"
 
-#: install.go:526
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "ошибка при анализе %s: %s"
 
-#: pkg/settings/config.go:303
+#: local_install.go:77
+#, fuzzy
+msgid "failed to parse .SRCINFO"
+msgstr "ошибка при анализе %s: %s"
+
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "ошибка чтения файла конфигурации '%s': %s"
+
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
+msgid "failed to retrieve aur Cache"
+msgstr ""
+
+#: pkg/upgrade/sources.go:27
+#, fuzzy
+msgid "ignoring package devel upgrade (no AUR info found):"
+msgstr "%s: пропуск обновления пакета (%s => %s)"
 
 #: pkg/text/errors.go:8
 msgid "input too long"
 msgstr "ввод слишком длинный"
 
-#: pkg/db/ialpm/alpm.go:206 pkg/dep/depPool.go:576
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "некорректный номер: %s"
 
@@ -549,21 +710,21 @@ msgstr "некорректный номер: %s"
 msgid "invalid option '%s'"
 msgstr "некорректный параметр '%s'"
 
-#: cmd.go:202
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "некорректный параметр:  '--deps' и '--explicit' не могут быть использованы "
 "вместе"
 
-#: pkg/download/abs.go:21
+#: pkg/download/abs.go:22
 msgid "invalid repository"
 msgstr "недействительный репозиторий"
 
-#: pkg/db/ialpm/alpm.go:211 pkg/dep/depPool.go:581
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "некорректное значение: %d не лежит между %d и %d"
 
-#: pkg/pgp/keys.go:114
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "нет ключей для импорта"
 
@@ -571,59 +732,123 @@ msgstr "нет ключей для импорта"
 msgid "no query was executed"
 msgstr "запрос не был выполнен"
 
-#: pkg/text/text.go:60
+#: local_install.go:66
+msgid "no target directories specified"
+msgstr ""
+
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "нет"
+
+#: pkg/sync/build/installer.go:242
+msgid "nothing to install for %s"
+msgstr ""
 
 #: pkg/settings/parser/parser.go:164
 msgid "only one operation may be used at a time"
 msgstr "только одна операция может быть вызвана за один раз"
 
-#: print.go:185
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "пакет '%s' не найден"
-
-#: pkg/dep/depCheck.go:197
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr ""
-"конфликты пакетов не могут быть разрешены опцией noconfirm, прерывание"
 
 #: pkg/download/errors.go:15
 msgid "package not found in AUR"
 msgstr "пакет не найден в AUR"
 
-#: pkg/download/abs.go:22
+#: pkg/download/abs.go:23
 msgid "package not found in repos"
 msgstr "пакет не найден в репозиториях"
 
-#: pkg/pgp/keys.go:104
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "Группа пакетов"
+msgstr[1] "Группа пакетов"
+msgstr[2] "Группа пакетов"
+msgstr[3] "Группа пакетов"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "проблема импортирования ключей"
 
-#: clean.go:97
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "удаление пакетов AUR из кэша..."
 
-#: clean.go:167 clean.go:198
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "удаление неотслеживаемых файлов AUR из кэша..."
 
-#: install.go:830
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "файл PKGDEST для %s означен в выводе makepkg, но не существует: %s"
 
-#: pkg/db/ialpm/alpm.go:231
+#: pkg/sync/sync.go:45
+#, fuzzy
+msgid "there is nothing to do"
+msgstr "делать нечего"
+
+#: pkg/db/ialpm/alpm.go:247
 msgid "unable to CreateHandle: %s"
 msgstr "невозможно выполнить CreateHandle: %s"
 
-#: cmd.go:191
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "неизвестная операция"
 
-#: cmd.go:424
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "неизвестная версия"
 
-#: pkg/text/text.go:59
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "да"
+
+#~ msgid " (Target"
+#~ msgstr " (Цель"
+
+#~ msgid " (Wanted by: "
+#~ msgstr " (Требуется пакету: "
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s не удовлетворена, очистка очереди установки"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "Проверка конфликтов..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "Проверка внутренних конфликтов..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr ""
+#~ "Подтверждение удаления конфликтующих пакетов должно быть выполнено вручную"
+
+#~ msgid "Inner conflicts found:"
+#~ msgstr "Обнаружены внутренние конфликты:"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "Установка %s приведёт к удалению:"
+
+#~ msgid "Missing AUR Packages:"
+#~ msgstr "Отсутствующие в AUR пакеты:"
+
+#~ msgid "Package conflicts found:"
+#~ msgstr "Обнаружены конфликты пакетов:"
+
+#~ msgid "Querying AUR..."
+#~ msgstr "Выполнение запроса в AUR..."
+
+#~ msgid "error updating package install reason to dependency"
+#~ msgstr ""
+#~ "ошибка при изменении причины установки пакета на \"установленный как "
+#~ "зависимость\":"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr ""
+#~ "конфликты пакетов не могут быть разрешены опцией noconfirm, прерывание"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,67 +1,66 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Luna Jernberg <bittin@cafe8bitar.se>, 2023
 # August Wikerfors, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: August Wikerfors, 2023\n"
 "Language-Team: Swedish (https://app.transifex.com/yay-1/teams/123732/sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (Byggfiler finns)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (Installerad)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [Installerad]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " inget behöver göras"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
-"%s [A]lla [Ab]Avbryt [I]nstallerade [No]EjInstallerade eller (1 2 3, 1-3, "
-"^4)"
+"%s [A]lla [Ab]Avbryt [I]nstallerade [No]EjInstallerade eller (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s redan byggt -- hoppar över bygge"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s är inte inställd"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s finns."
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s är ajour -- hoppar över"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s att uppgradera/installera."
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "%s kommer också att installeras för denna operation."
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, krävs av: %s"
 
@@ -81,27 +80,83 @@ msgstr "%s: kan inte använda mål med växeln --repo -- hoppar över"
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: ignorerar paketuppgradering (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: lokalt paket (%s) är nyare än AUR (%s)"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
-"%s: vänligen ställ in miljövariablerna AUR_USERNAME och AUR_PASSWORD för att"
-" rösta"
+"%s: vänligen ställ in miljövariablerna AUR_USERNAME och AUR_PASSWORD för att "
+"rösta"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) Hämtat PKGBUILD från ABS: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) Hämtat PKGBUILD: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) Hämtat PKGBUILD: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Tolkar SRCINFO: %s"
 
@@ -121,7 +176,7 @@ msgstr "(Övergiven)"
 msgid "(Out-of-date: %s)"
 msgstr "(Föråldrade: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR-webbadress"
 
@@ -129,7 +184,7 @@ msgstr "AUR-webbadress"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Lägg till %s eller %s bland dina miljövariabler"
 
@@ -141,7 +196,7 @@ msgstr "Undvik att köra yay som root/sudo."
 msgid "Check Dependency"
 msgstr "Kontrollberoende"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Kontrollberoenden"
 
@@ -149,15 +204,15 @@ msgstr "Kontrollberoenden"
 msgid "Checking development packages..."
 msgstr "Kontrollerar utvecklingspaket..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Rensar (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Krockar med"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Tar bort (%d/%d): %s"
 
@@ -165,15 +220,15 @@ msgstr "Tar bort (%d/%d): %s"
 msgid "Dependency"
 msgstr "Beroende"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Beror av"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Beskrivning"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Visa diff?"
 
@@ -181,19 +236,19 @@ msgstr "Visa diff?"
 msgid "Disable 'provides' setting by default"
 msgstr "Inaktivera  \"tillhandahåller\" inställning som standard"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Vill du verkligen ta bort ALLA AUR-paket från cachen?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Vill du verkligen ta bort ALLA ospårade AUR-filer?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Vill du verkligen ta bort alla andra AUR-paket från cachen?"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "Redigera PKGBUILD med?"
 
@@ -201,7 +256,7 @@ msgstr "Redigera PKGBUILD med?"
 msgid "Error during AUR search: %s\n"
 msgstr "Fel vid AUR-sökning: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Att exkludera paket kan orsaka partiella uppgraderingar och ha sönder system"
@@ -210,32 +265,32 @@ msgstr ""
 msgid "Explicit"
 msgstr "Uttryckligen"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Uttryckligen installerade paket: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Misslyckades att hitta AUR paket för"
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Misslyckades att installera lager, rullar upp till nästa lager."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "Misslyckades att bygga följande paket. Manuell intervention krävs:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "Först skapad"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "AUR-paket markerade som föråldrade:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Okända installerade paket: %s"
 
@@ -243,31 +298,31 @@ msgstr "Okända installerade paket: %s"
 msgid "Found git repo: %s"
 msgstr "Hittade git-arkiv: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB klar. Inga paket installerades"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Grupper"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Importera?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Importerar nycklar med gpg..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Nyckelord"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Senast ändrad"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Licenser"
 
@@ -275,7 +330,7 @@ msgstr "Licenser"
 msgid "Local"
 msgstr "Lokal"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Underhållare"
 
@@ -283,11 +338,11 @@ msgstr "Underhållare"
 msgid "Make Dependency"
 msgstr "Byggberoende"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Byggberoenden"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Saknar AUR-felsökningspaket:"
 
@@ -295,35 +350,40 @@ msgstr "Saknar AUR-felsökningspaket:"
 msgid "Missing"
 msgstr "Saknas"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "Namn"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Inga AUR paket hittades för"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Inga AUR paket hittades för"
+
+#: print.go:225
 msgid "None"
 msgstr "Inga"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Valfria beroenden"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Föräldralösa (icke underhållna) AUR paket:"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Föråldrat"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "PGP-nycklar kräver import:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD uppdaterad, hoppar över nedladdning: %s"
 
@@ -331,57 +391,61 @@ msgstr "PKGBUILD uppdaterad, hoppar över nedladdning: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "Redigera PKGBUILD-filer?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "Grundpakets-ID"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Grundpaket"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "Paket som inte finns i AUR:"
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Bygg paket rent (cleanBuild)?"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Paket att exkludera"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr ""
 "Paket att hoppa över: (t.ex: \"1 2 3\", \"1-3\", \"^4\" eller "
 "centralkatalogsnamn)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Paket att installera (t.ex: 1 2 3, 1-3 eller ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popularitet"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Fortsätt med installation?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Tillhandahåller"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Ta bort byggberoenden efter installation?"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Centralkatalog AUR"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Centralkatalog"
 
@@ -401,15 +465,15 @@ msgstr "Söker efter uppdateringar i databaserna..."
 msgid "Showing repo packages only"
 msgstr "Visar endast centralkatalogspaket"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Storlek på pacman cache %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Storlek på yay cache %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "Snapshot-URL"
 
@@ -417,71 +481,71 @@ msgstr "Snapshot-URL"
 msgid "Sync"
 msgstr "Synk"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Tio största paketen:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Följande paket stöds inte av din arkitektur:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Det finns %d tillgängliga tillhandahållare för %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Det kan finns en till instans av pacman som kör. Väntar..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Total paketstorlek: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Antal installerade paket: %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Försök att bygga dem ändå?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "Webbadress"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Kunde inte rensa:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Det gick inte att hitta följande paket:"
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Kan inte hantera paketröstning för: %s . fel: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Kunde inte ta bort %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Version"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Röster"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay-version v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]Inga"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -489,7 +553,7 @@ msgstr ""
 "\n"
 "Byggkatalog:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -501,19 +565,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "avbryter på grund av användare"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "argument '-' specificerat utan indata på stdin"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "kan inte hitta PKGBUILD eller .SRCINFO i katalog"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "kunde inte hitta paketet: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "kunde inte hitta PKGDEST för: %s"
 
@@ -521,11 +585,11 @@ msgstr "kunde inte hitta PKGDEST för: %s"
 msgid "could not find all required packages"
 msgstr "kunde inte hitta alla paket som krävs"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "kunde inte hitta några paketarkiv listade i %s"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "beroende"
 
@@ -533,11 +597,11 @@ msgstr "beroende"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "Utvecklings koll för paket misslyckades '%s' stötte på ett fel"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "redigeraren avslutades inte korrekt, avbryter: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "fel vid nedladdning av källfiler: %s"
 
@@ -545,19 +609,19 @@ msgstr "fel vid nedladdning av källfiler: %s"
 msgid "error fetching %s: %s"
 msgstr "fel vid hämtning av %s: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "fel vid installation av centralkatalogspaket"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "fel vid installation:"
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "fel vid bygge: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "fel vid sammanslagning av %s: %s"
 
@@ -565,19 +629,19 @@ msgstr "fel vid sammanslagning av %s: %s"
 msgid "error reading %s"
 msgstr "fel vid läsning av %s"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "fel vid uppdatering av databaserna"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "fel vid återställning av %s: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "fel vid uppdatering av paketinstallations anledning till %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "uttryckligen"
 
@@ -585,27 +649,27 @@ msgstr "uttryckligen"
 msgid "failed to create directory '%s': %s"
 msgstr "misslyckades med att skapa katalog '%s': %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "misslyckades med att öppna konfigurationsfilen '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "misslyckades med att tolka %s -- hoppar över: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "misslyckades med att tolka %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "misslyckades med att tolka .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "misslyckades med att läsa konfigurationsfilen '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "misslyckades med att hämta aur Cache"
 
@@ -617,7 +681,7 @@ msgstr "ignorerar paket devel uppgradering (ingen AUR info hittades):"
 msgid "input too long"
 msgstr "för lång indata"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "ogiltigt nummer: %s"
 
@@ -625,7 +689,7 @@ msgstr "ogiltigt nummer: %s"
 msgid "invalid option '%s'"
 msgstr "ogiltig växel '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "ogiltigt alternativ: '--deps' och '--explicit' kan inte användas tillsammans"
@@ -634,11 +698,11 @@ msgstr ""
 msgid "invalid repository"
 msgstr "ogiltig centralkatalog"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "ogiltigt värde: %d är inte mellan %d och %d"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "inga nycklar att importera"
 
@@ -646,15 +710,15 @@ msgstr "inga nycklar att importera"
 msgid "no query was executed"
 msgstr "ingen fråga utfördes"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "inga målkataloger specificerade"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "nej"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "inget att installera för %s"
 
@@ -662,7 +726,11 @@ msgstr "inget att installera för %s"
 msgid "only one operation may be used at a time"
 msgstr "bara en operation går att utföra åt gången"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "paketet '%s' kunde inte hittas"
 
@@ -674,29 +742,29 @@ msgstr "paketet hittades inte i AUR"
 msgid "package not found in repos"
 msgstr "paketet hittades inte i centralkatalogerna"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "paket"
 msgstr[1] "paket"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "ett problem uppstod vid nyckelimporten"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "tar bort AUR-paket från cachen..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "tar bort ospårade AUR-filer från cachen..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "den PKGDEST för %s som står med i makepkg finns ej: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "det finns ingenting att göra"
 
@@ -704,14 +772,14 @@ msgstr "det finns ingenting att göra"
 msgid "unable to CreateHandle: %s"
 msgstr "misslyckades med att skapa handtag (CreateHandle): %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "okänd operation"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "okänd-version"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "ja"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,71 +1,67 @@
-# 
+#
 # Translators:
 # Ahmet Arda Kavakcı, 2022
 # Mehmet Özgür Bayhan <mozgurbayhan@gmail.com>, 2023
 # can avar, 2023
 # yiğit yeten, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: yiğit yeten, 2023\n"
 "Language-Team: Turkish (https://app.transifex.com/yay-1/teams/123732/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr "(Kurulum Dosyaları Var)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr "(Kuruldu)"
 
-#: pkg/dep/depCheck.go:310
-msgid " (Target"
-msgstr "(Hedef"
-
-#: pkg/dep/depCheck.go:312
-msgid " (Wanted by: "
-msgstr "(Tarafından isteniyor:"
-
-#: cmd.go:472
+#: cmd.go:463
 msgid " [Installed]"
 msgstr "[Kuruldu]"
 
-#: cmd.go:425 install.go:172 install.go:206 vote.go:34
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "yapılacak bir şey yok"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
-msgstr ""
-"%s [A]Hepsi [Ab]İptal [I]Kurulmuş [No]Kurulmamış veya (1 2 3, 1-3, ^4)"
+msgstr "%s [A]Hepsi [Ab]İptal [I]Kurulmuş [No]Kurulmamış veya (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:274 install.go:741
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s çoktan yapıldı -- yapılandırma atlanıyor"
 
-#: pkg/menus/edit_menu.go:58
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "%s belirlenmiş değil"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s hâlihazırda bulunuyor."
 
-#: pkg/dep/dep_graph.go:385 aur_install.go:271 install.go:727
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s güncel -- atlanıyor"
 
-#: install.go:642
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s sağlanmamış, indirme kuyruğu boşaltılıyor"
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
+msgstr "Yükseltilecek/yüklenecek paketler."
 
-#: pkg/pgp/keys.go:127
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
+
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, ihtiyaç duyan: %s"
 
@@ -81,59 +77,115 @@ msgstr "%s: hedef --aur seçeneği ile kullanılamaz -- atlanıyor"
 msgid "%s: can't use target with option --repo -- skipping"
 msgstr "%s: hedef --repo seçeneği ile kullanılamaz -- atlanıyor"
 
-#: pkg/upgrade/sources.go:60
+#: pkg/upgrade/sources.go:57
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: paket güncellemesi göz ardı ediliyor (%s => %s)"
 
-#: upgrade.go:165
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: yerel (%s) AUR'dan (%s) daha güncel"
 
-#: vote.go:49
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr ""
 "Oy verebilmek için AUR_USERNAME ve AUR_PASSWORD ortam değişkenlerini "
 "ayarlayın"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD, ABS'den indirildi: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) PKGBUILD indirildi: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) PKGBUILD indirildi: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) SRCINFO çözümleniyor: %s"
 
-#: pkg/query/types.go:70 pkg/query/types.go:101
+#: pkg/query/types.go:72 pkg/query/types.go:103
 msgid "(Installed)"
 msgstr "(Kuruldu)"
 
-#: pkg/query/types.go:68 pkg/query/types.go:99
+#: pkg/query/types.go:70 pkg/query/types.go:101
 msgid "(Installed: %s)"
 msgstr "(Kuruldu: %s)"
 
-#: pkg/query/types.go:59
+#: pkg/query/types.go:61
 msgid "(Orphaned)"
 msgstr "(Öksüz bırakıldı)"
 
-#: pkg/query/types.go:63
+#: pkg/query/types.go:65
 msgid "(Out-of-date: %s)"
 msgstr "(Güncel değil: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR URL"
 
-#: pkg/dep/dep_graph.go:74
+#: pkg/dep/dep_graph.go:75
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:59
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Ortam değişkenlerinize %s veya %s seçeneklerini ekleyin"
 
@@ -141,55 +193,43 @@ msgstr "Ortam değişkenlerinize %s veya %s seçeneklerini ekleyin"
 msgid "Avoid running yay as root/sudo."
 msgstr "Yay'ı root/sudo olarak çalıştırmaktan kaçının"
 
-#: pkg/dep/dep_graph.go:62
+#: pkg/dep/dep_graph.go:63
 msgid "Check Dependency"
 msgstr "Bağımlılık Kontrolü"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "Bağımlıkları Kontrol Et"
 
-#: pkg/upgrade/service.go:78 upgrade.go:95
+#: pkg/upgrade/service.go:90
 msgid "Checking development packages..."
 msgstr "Geliştirme paketleri kontrol ediliyor..."
 
-#: pkg/dep/depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "Çakışmalar kontrol ediliyor..."
-
-#: pkg/dep/depCheck.go:145
-msgid "Checking for inner conflicts..."
-msgstr "İç çakışmalar kontrol ediliyor..."
-
-#: clean.go:214
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Temizleniyor (%d/%d): %s"
 
-#: pkg/dep/depCheck.go:200
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr "Çakışan paketlerin elle onaylanması gerekecek"
-
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Çakışıyor:"
 
-#: pkg/menus/clean_menu.go:61 pkg/menus/clean_menu.go:108
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Siliniyor (%d/%d): %s"
 
-#: pkg/dep/dep_graph.go:60
+#: pkg/dep/dep_graph.go:61
 msgid "Dependency"
 msgstr "Bağımlılık"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "Bağımlı:"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "Açıklama"
 
-#: pkg/menus/diff_menu.go:161 pkg/menus/diff_menu.go:194
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Gösterilecek olan değişiklikler (diff)?"
 
@@ -197,19 +237,19 @@ msgstr "Gösterilecek olan değişiklikler (diff)?"
 msgid "Disable 'provides' setting by default"
 msgstr "Varsayılan olarak 'provides' ayarını geçersiz kıl"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "AUR paketlerinin TÜMÜNÜ önbellekten silmek istiyor musun?"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "İzlenmemiş AUR paketlerinin TÜM dosyalarını silmek istiyor musun?"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Tüm diğer AUR paketlerini önbellekten silmek istiyor musun?"
 
-#: pkg/menus/edit_menu.go:62
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "PKGBUILD'i neyle düzenleyeceksin?"
 
@@ -217,315 +257,295 @@ msgstr "PKGBUILD'i neyle düzenleyeceksin?"
 msgid "Error during AUR search: %s\n"
 msgstr "AUR araması yaparken hata: %s\n"
 
-#: pkg/upgrade/service.go:256
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr ""
 "Paketlerin dışlanması, kısmi yükseltmelere ve sistemlerin bozulmasına neden "
 "olabilir"
 
-#: pkg/dep/dep_graph.go:59
+#: pkg/dep/dep_graph.go:60
 msgid "Explicit"
 msgstr "Açık"
 
-#: print.go:84
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Doğrudan kurulan paketler: %s"
 
-#: pkg/dep/dep_graph.go:365 pkg/dep/dep_graph.go:454
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "Şunun için AUR paketi bulunamadı:"
 
-#: aur_install.go:104
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "Katman yüklenemedi, sonraki katmana geçiliyor."
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "İstenen paketler yüklenemedi. Manüel müdahale gerekli:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "İlk İletilen"
 
-#: pkg/query/aur_warnings.go:43
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Eski Olarak İşaretlenmiş AUR Paketleri:"
 
-#: print.go:83
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Yabancı kurulan paketler: %s"
 
-#: pkg/vcs/vcs.go:142
+#: pkg/vcs/vcs.go:144
 msgid "Found git repo: %s"
 msgstr "Git deposu bulundu: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB tamamlandı. Hiçbir paket kurulmadı"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "Gruplar"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "İçe Aktar?"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "GPG anahtarları içe aktarılıyor..."
 
-#: pkg/dep/depCheck.go:155
-msgid "Inner conflicts found:"
-msgstr "İç çakışmalar bulundu:"
-
-#: pkg/dep/depCheck.go:173
-msgid "Installing %s will remove:"
-msgstr "%s paketini kurmak şunları kaldıracak:"
-
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "Anahtar Kelimeler"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "Son Değiştirme"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "Lisanslar"
 
-#: pkg/dep/dep_graph.go:76
+#: pkg/dep/dep_graph.go:77
 msgid "Local"
 msgstr "Yerel"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "Bakımcı:"
 
-#: pkg/dep/dep_graph.go:61
+#: pkg/dep/dep_graph.go:62
 msgid "Make Dependency"
 msgstr "Make Bağımlılığı"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "Make Bağımlılıkları"
 
-#: pkg/query/aur_warnings.go:33
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Eksik AUR Hata Ayıklama Paketleri:"
 
-#: pkg/dep/dep_graph.go:78
+#: pkg/dep/dep_graph.go:79
 msgid "Missing"
 msgstr "Kayıp"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "İsim"
 
-#: pkg/dep/dep_graph.go:370 pkg/dep/dep_graph.go:467
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "Şunun için AUR paketi bulunamadı: "
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "Şunun için AUR paketi bulunamadı: "
+
+#: print.go:225
 msgid "None"
 msgstr "Yok"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "İsteğe Bağlı Bağımlılıklar"
 
-#: pkg/query/aur_warnings.go:38
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Orphan (bakımsız) AUR Paketleri:"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Eski"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "İçe aktarılması gereken PGP anahtarları:"
 
-#: install.go:265 vcs.go:46
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
-msgstr "PKGBUILD güncel, Atlanıyor (%d/%d): %s"
-
-#: preparer.go:226
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD güncel, indirme geçiliyor: %s"
 
-#: pkg/menus/edit_menu.go:132 pkg/menus/edit_menu.go:164
+#: pkg/menus/edit_menu.go:130
 msgid "PKGBUILDs to edit?"
 msgstr "Düzenlenecek PKGBUILD'ler?"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "Paket Temel Kimliği (ID):"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "Paket Temeli"
 
-#: pkg/dep/depCheck.go:170
-msgid "Package conflicts found:"
-msgstr "Paket çakışmaları bulundu:"
-
-#: pkg/query/aur_warnings.go:28
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "AUR'da bulunmayan paketler:"
 
-#: pkg/menus/clean_menu.go:53 pkg/menus/clean_menu.go:100
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "cleanBuild yapılacak paketler?"
 
-#: pkg/dep/dep_graph.go:215 upgrade.go:213
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "Dışlanacak paketler"
 
-#: pkg/upgrade/service.go:255
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr "Dışlanacak paketler: (ör. \"1 2 3\", \"1-3\", \"^4\" veya depo ismi)"
 
-#: cmd.go:406
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Kurulacak paketler (ör. 1 2 3, 1-3 veya ^4)"
 
-#: upgrade.go:210
-msgid "Packages to upgrade."
-msgstr "Yükseltilecek paketler."
-
-#: pkg/upgrade/service.go:252
-msgid "Packages to upgrade/install."
-msgstr "Yükseltilecek/yüklenecek paketler."
-
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "Popülerlik"
 
-#: pkg/menus/diff_menu.go:173 pkg/menus/diff_menu.go:206
-#: pkg/menus/edit_menu.go:143 pkg/menus/edit_menu.go:177
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Kurmaya devam et?"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "Sağlar:"
 
-#: pkg/query/aur_info.go:89
-msgid "Querying AUR..."
-msgstr "AUR sorgulanıyor..."
-
-#: install.go:236 preparer.go:108
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Make bağımlılıkları kurulum sonrası silinsin mi?"
 
-#: pkg/dep/depPool.go:503 pkg/dep/dep_graph.go:631
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "AUR Deposu"
 
-#: pkg/db/ialpm/alpm.go:191 print.go:25
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Depo"
 
-#: pkg/dep/dep_graph.go:77
+#: pkg/dep/dep_graph.go:78
 msgid "SRCINFO"
 msgstr "SRCINFO"
 
-#: pkg/upgrade/service.go:63 upgrade.go:73
+#: pkg/upgrade/service.go:72
 msgid "Searching AUR for updates..."
 msgstr "AUR güncellemeleri aranıyor..."
 
-#: pkg/upgrade/service.go:142 upgrade.go:62
+#: pkg/upgrade/service.go:160
 msgid "Searching databases for updates..."
 msgstr "Veritabanlarında güncellemeler aranıyor..."
 
-#: pkg/query/query_builder.go:191
+#: pkg/query/query_builder.go:214
 msgid "Showing repo packages only"
 msgstr "Sadece depo paketleri gösteriliyor"
 
-#: print.go:88
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "pacman önbelleğinin boyutu: %s: %s"
 
-#: print.go:91
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "yay önbelleğinin boyutu: %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "Anlık görüntü URL'si"
 
-#: pkg/dep/dep_graph.go:75
+#: pkg/dep/dep_graph.go:76
 msgid "Sync"
 msgstr "Senkronize"
 
-#: print.go:93
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "En büyük 10 paket:"
 
-#: install.go:495 sync.go:183
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Aşağıdaki paketler sistem mimarin ile uyumlu değil:"
 
-#: pkg/db/ialpm/alpm.go:179 pkg/dep/depPool.go:499 pkg/dep/dep_graph.go:627
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "%s için %d sağlayıcı bulunuyor:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Başka bir Pacman talebi çalışıyor olabilir. Bekleniyor..."
 
-#: print.go:85
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Paketlerin tuttuğu Toplam Boyut: %s"
 
-#: print.go:82
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "İndirilen toplam paketler: %s"
 
-#: install.go:503 sync.go:191
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Yine de yapılandırmaya çalış?"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:192 pkg/menus/clean_menu.go:64 pkg/menus/clean_menu.go:70
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Temizlenemiyor:"
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Aşağıdaki paketler bulunamadı:"
 
-#: vote.go:21
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "Şunlar için paket oylaması işlenemiyor:%s. hata: %s"
 
-#: clean.go:169
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "Kaldırılamıyor %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "Sürüm"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "Oylar"
 
-#: print.go:80
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay sürümü v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]Hiçbiri"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -533,7 +553,7 @@ msgstr ""
 "\n"
 "Yapım dizini:"
 
-#: pkg/db/ialpm/alpm.go:201 pkg/dep/depPool.go:513 pkg/dep/dep_graph.go:641
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -549,15 +569,15 @@ msgstr "kullanıcı nedeniyle iptal ediliyor"
 msgid "argument '-' specified without input on stdin"
 msgstr "stdin üzerinde girdi olmadan '-' argümanı kullanıldı"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "dizin içerisinde PKGBUILD ve .SRCINFO bulunamadı"
 
-#: install.go:532
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "paket ismi bulunamadı: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "PKGDEST dizini bulunamadı: %s"
 
@@ -565,31 +585,23 @@ msgstr "PKGDEST dizini bulunamadı: %s"
 msgid "could not find all required packages"
 msgstr "tüm gereken paketler bulunamadı"
 
-#: pkg/dep/depCheck.go:303
-msgid "could not find all required packages:"
-msgstr "tüm gereken paketler bulunamadı:"
-
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "arşivde listelenmiş paketler bulunamadı %s"
 
-#: install.go:788
-msgid "could not find srcinfo for: %s"
-msgstr "%s : İçin scrinfo bulunamadı"
-
-#: errors.go:26
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "bağımlılık"
 
-#: pkg/vcs/vcs.go:94 pkg/vcs/vcs.go:98
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "Paket gelişim kontrolü başarısız: '%s' hatayla karşılaştı"
 
-#: pkg/menus/edit_menu.go:111
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "düzenleyici başarılı bir şekilde çıkış yapmadı, iptal ediliyor: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "kaynaklar indirilirken hata: %s"
 
@@ -597,20 +609,19 @@ msgstr "kaynaklar indirilirken hata: %s"
 msgid "error fetching %s: %s"
 msgstr "%s getirilirken hata: %s"
 
-#: install.go:321 install.go:455 local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "depo paketleri indirilirken hata"
 
-#: aur_install.go:236 aur_install.go:240
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "kurarken hata:"
 
-#: aur_install.go:204 aur_install.go:208 install.go:683 install.go:724
-#: install.go:738 install.go:752
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "yapılırken hata: %s"
 
-#: install.go:588
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "%s birleştirilirken hata: %s"
 
@@ -618,19 +629,19 @@ msgstr "%s birleştirilirken hata: %s"
 msgid "error reading %s"
 msgstr "%s okunurken hata"
 
-#: install.go:110 sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "veritabanlarını yenilenirken hata"
 
-#: clean.go:220 install.go:581
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "%s yenilenirken hata: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "paket yükleme nedeni güncellenirken hata oluştu %s"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "açık"
 
@@ -638,31 +649,31 @@ msgstr "açık"
 msgid "failed to create directory '%s': %s"
 msgstr "'%s' dizini oluşturulamadı: %s"
 
-#: pkg/settings/config.go:286
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "'%s' yapılandırma dosyası açılamadı: %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "%s çözümlenirken hata -- atlanıyor: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "%s çözümlenirken hata: %s"
 
-#: local_install.go:82
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr " .SRCINFO ayrıştırılamadı"
 
-#: pkg/settings/config.go:296
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "'%s' yapılandırma dosyası okunurken hata: %s"
 
-#: pkg/settings/runtime.go:74
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "aur Cache alınamadı"
 
-#: pkg/upgrade/sources.go:30
+#: pkg/upgrade/sources.go:27
 msgid "ignoring package devel upgrade (no AUR info found):"
 msgstr "devel paketi yükseltmesi yok sayılıyor (AUR bilgisi bulunamadı):"
 
@@ -670,7 +681,7 @@ msgstr "devel paketi yükseltmesi yok sayılıyor (AUR bilgisi bulunamadı):"
 msgid "input too long"
 msgstr "girdi çok uzun"
 
-#: pkg/db/ialpm/alpm.go:222 pkg/dep/depPool.go:533 pkg/dep/dep_graph.go:662
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "geçersiz sayı: %s"
 
@@ -678,19 +689,19 @@ msgstr "geçersiz sayı: %s"
 msgid "invalid option '%s'"
 msgstr "geçersiz seçenek '%s'"
 
-#: cmd.go:208
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr "geçersiz seçenek: '--deps' ve '--explicit' beraber kullanılamaz"
 
-#: pkg/download/abs.go:21
+#: pkg/download/abs.go:22
 msgid "invalid repository"
 msgstr "geçersiz depo"
 
-#: pkg/db/ialpm/alpm.go:227 pkg/dep/depPool.go:538 pkg/dep/dep_graph.go:668
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "geçersiz değer: %d, %d ile %d arasında değil."
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "aktarılacak anahtar yok"
 
@@ -698,15 +709,15 @@ msgstr "aktarılacak anahtar yok"
 msgid "no query was executed"
 msgstr "hiçbir sorgu çalıştırılmadı"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "hiç bir hedef dizin belirtilmedi"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "hayır"
 
-#: aur_install.go:213
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "indirelecek bir şey yok %s"
 
@@ -714,39 +725,46 @@ msgstr "indirelecek bir şey yok %s"
 msgid "only one operation may be used at a time"
 msgstr "bir seferde sadece bir işlem kullanılabilir"
 
-#: print.go:158
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "'%s' paketi bulunamadı"
-
-#: pkg/dep/depCheck.go:197
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr "paket çakışmaları noconfirm ile çözümlenemedi, iptal ediliyor"
 
 #: pkg/download/errors.go:15
 msgid "package not found in AUR"
 msgstr "paket AUR'da bulunamadı"
 
-#: pkg/download/abs.go:22
+#: pkg/download/abs.go:23
 msgid "package not found in repos"
 msgstr "paket depolarda bulunamadı"
 
-#: pkg/pgp/keys.go:103
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "Paket Temeli"
+msgstr[1] "Paket Temeli"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "anahtarları aktarırken sorun"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "AUR paketleri önbellekten siliniyor..."
 
-#: clean.go:177 clean.go:210
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "izlenmemiş AUR paketleri önbellekten siliniyor..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "%s için olan PKGDEST, makepkg'da listelenmiş ancak bulunmuyor: %s"
 
-#: sync.go:110
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "yapılacak bir şey yok"
 
@@ -754,14 +772,59 @@ msgstr "yapılacak bir şey yok"
 msgid "unable to CreateHandle: %s"
 msgstr "CreateHandle yapılamıyor: %s"
 
-#: cmd.go:197
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "beklenmeyen işlem"
 
-#: cmd.go:469
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "bilinmeyen sürüm"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "evet"
+
+#~ msgid " (Target"
+#~ msgstr "(Hedef"
+
+#~ msgid " (Wanted by: "
+#~ msgstr "(Tarafından isteniyor:"
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s sağlanmamış, indirme kuyruğu boşaltılıyor"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "Çakışmalar kontrol ediliyor..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "İç çakışmalar kontrol ediliyor..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr "Çakışan paketlerin elle onaylanması gerekecek"
+
+#~ msgid "Inner conflicts found:"
+#~ msgstr "İç çakışmalar bulundu:"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "%s paketini kurmak şunları kaldıracak:"
+
+#~ msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
+#~ msgstr "PKGBUILD güncel, Atlanıyor (%d/%d): %s"
+
+#~ msgid "Package conflicts found:"
+#~ msgstr "Paket çakışmaları bulundu:"
+
+#~ msgid "Packages to upgrade."
+#~ msgstr "Yükseltilecek paketler."
+
+#~ msgid "Querying AUR..."
+#~ msgstr "AUR sorgulanıyor..."
+
+#~ msgid "could not find all required packages:"
+#~ msgstr "tüm gereken paketler bulunamadı:"
+
+#~ msgid "could not find srcinfo for: %s"
+#~ msgstr "%s : İçin scrinfo bulunamadı"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr "paket çakışmaları noconfirm ile çözümlenemedi, iptal ediliyor"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,49 +1,44 @@
-# 
+#
 # Translators:
 # Volodymyr Markiv <vov4uk21@gmail.com>, 2021
 # Andrii Lytvyn, 2022
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Andrii Lytvyn, 2022\n"
 "Language-Team: Ukrainian (https://www.transifex.com/yay-1/teams/123732/uk/)\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uk\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 "X-Generator: xgotext\n"
 
 #: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr "(Файли Збірки Існують)"
 
-#: pkg/menus/menu.go:28
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr "(Встановлено)"
 
-#: pkg/dep/depCheck.go:312
-msgid " (Target"
-msgstr "(Ціль"
-
-#: pkg/dep/depCheck.go:314
-msgid " (Wanted by: "
-msgstr "(Треба пакунку:"
-
-#: cmd.go:427
+#: cmd.go:463
 msgid " [Installed]"
 msgstr "[Встановлено]"
 
-#: cmd.go:386 install.go:158 install.go:192
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr "тут нічого робити"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr ""
 "%s [A]Всі [Ab]Скасувати [I]Встановлені [No]Невстановлені чи (1 2 3, 1-3, ^4)"
 
-#: install.go:729
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s вже зроблено -- пропуск збірки"
 
@@ -51,139 +46,209 @@ msgstr "%s вже зроблено -- пропуск збірки"
 msgid "%s is not set"
 msgstr "%s не задано"
 
-#: pkg/settings/exe/cmd_builder.go:198
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s вже існує."
 
-#: install.go:715
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s є актуальним -- пропуск"
 
-#: install.go:640
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s не задоволено, очищення черги встановлення"
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
+msgstr "Пакунки для оновлення."
 
-#: pkg/pgp/keys.go:128
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
+
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s потребується для: %s"
 
-#: pkg/menus/diff_menu.go:50
+#: pkg/menus/diff_menu.go:49
 msgid "%s: No changes -- skipping"
 msgstr "%s:  Нема змін -- пропуск"
 
-#: pkg/query/filter.go:52
+#: pkg/query/filter.go:22
 msgid "%s: can't use target with option --aur -- skipping"
 msgstr "%s: не вдалося застосувати ціль з параметром --aur -- пропуск"
 
-#: pkg/query/filter.go:47
+#: pkg/query/filter.go:17
 msgid "%s: can't use target with option --repo -- skipping"
 msgstr "%s: не вдалося застосувати ціль з параметром --repo -- пропуск"
 
-#: pkg/upgrade/sources.go:82
+#: pkg/upgrade/sources.go:57
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: ігнорування оновлення пакета ( %s => %s)"
 
-#: upgrade.go:138
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: встановлений пакунок (%s) новіший ніж у AUR (%s)"
 
-#: pkg/download/unified.go:187
+#: vote.go:51
+msgid ""
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
+msgstr ""
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
+
+#: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) PKGBUILD завантажено з ABS: %s"
 
-#: pkg/download/aur.go:83 pkg/download/unified.go:183
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) Завантажено PKGBUILD: %s"
 
-#: install.go:517
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) Завантажено PKGBUILD: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) Аналіз SRCINFO: %s"
 
-#: pkg/query/types.go:145 pkg/query/types.go:199
+#: pkg/query/types.go:72 pkg/query/types.go:103
 msgid "(Installed)"
 msgstr "(Встановлено)"
 
-#: pkg/query/types.go:143 pkg/query/types.go:197
+#: pkg/query/types.go:70 pkg/query/types.go:101
 msgid "(Installed: %s)"
 msgstr "(Встановлено: %s)"
 
-#: pkg/query/types.go:134
+#: pkg/query/types.go:61
 msgid "(Orphaned)"
 msgstr "(Осиротілий)"
 
-#: pkg/query/types.go:138
+#: pkg/query/types.go:65
 msgid "(Out-of-date: %s)"
 msgstr "(Застарілий: %s)"
 
-#: print.go:28
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR URL"
+
+#: pkg/dep/dep_graph.go:75
+#, fuzzy
+msgid "AUR"
+msgstr "URL"
 
 #: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "Додайте %s або %s до змінних середовища"
 
-#: main.go:103
+#: main.go:60
 msgid "Avoid running yay as root/sudo."
 msgstr "Не запускайте yay як root/sudo."
 
-#: print.go:34
+#: pkg/dep/dep_graph.go:63
+#, fuzzy
+msgid "Check Dependency"
+msgstr "Залежності Перевірки"
+
+#: print.go:41
 msgid "Check Deps"
 msgstr "Залежності Перевірки"
 
-#: upgrade.go:88
+#: pkg/upgrade/service.go:90
 msgid "Checking development packages..."
 msgstr "Перевірка пакетів розробки..."
 
-#: pkg/dep/depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "Перевірка на наявність конфліктів..."
-
-#: pkg/dep/depCheck.go:145
-msgid "Checking for inner conflicts..."
-msgstr "Перевірка на внутрішні конфлікти..."
-
-#: clean.go:206
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "Очистка (%d/%d): %s"
 
-#: pkg/dep/depCheck.go:200
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr "Конфліктні пакети потрібно буде підтвердити вручну"
-
-#: print.go:36
+#: print.go:42
 msgid "Conflicts With"
 msgstr "Конфліктує з"
 
-#: pkg/dep/depCheck.go:305
-msgid "Could not find all required packages:"
-msgstr "Не вдалося знайти всі необхідні пакунки:"
-
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "Видалення (%d/%d): %s"
 
-#: print.go:32
+#: pkg/dep/dep_graph.go:61
+#, fuzzy
+msgid "Dependency"
+msgstr "Залежить Від"
+
+#: print.go:38
 msgid "Depends On"
 msgstr "Залежить Від"
 
-#: print.go:26
+#: print.go:33
 msgid "Description"
 msgstr "Опис"
 
-#: pkg/menus/diff_menu.go:157
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "Показати зміни?"
 
-#: clean.go:72
+#: pkg/settings/migrations.go:25
+msgid "Disable 'provides' setting by default"
+msgstr ""
+
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "Ви бажаєте видалити ВСІ пакунки AUR з кешу?"
 
-#: clean.go:89
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "Ви бажаєте видалити ВСІ невідстежувані файли AUR?"
 
-#: clean.go:74
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "Ви бажаєте видалити всі інші пакунки AUR з кешу?"
 
@@ -195,249 +260,303 @@ msgstr "Редагувати PKGBUILD за допомогою?"
 msgid "Error during AUR search: %s\n"
 msgstr "Помилка під час пошуку у AUR: %s\n"
 
-#: print.go:85
+#: pkg/upgrade/service.go:296
+msgid "Excluding packages may cause partial upgrades and break systems"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:60
+msgid "Explicit"
+msgstr ""
+
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "Явно встановлені пакунки: %s"
 
-#: print.go:40
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
+#, fuzzy
+msgid "Failed to find AUR package for"
+msgstr "Пакунки з AUR, що позначені як застарілі:"
+
+#: pkg/sync/build/installer.go:120
+msgid "Failed to install layer, rolling up to next layer."
+msgstr ""
+
+#: pkg/sync/build/errors.go:16
+msgid ""
+"Failed to install the following packages. Manual intervention is required:"
+msgstr ""
+
+#: print.go:45
 msgid "First Submitted"
 msgstr "Вперше Завантажений"
 
-#: pkg/query/aur_warnings.go:43
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "Пакунки з AUR, що позначені як застарілі:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "Сторонні встановлені пакети: %s"
 
-#: pkg/vcs/vcs.go:119
+#: pkg/vcs/vcs.go:144
 msgid "Found git repo: %s"
 msgstr "Знайдено git-репозиторій: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB завершено. Пакунки не встановлено"
 
-#: print.go:29
+#: print.go:36
 msgid "Groups"
 msgstr "Групи"
 
-#: pkg/pgp/keys.go:88
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "Імпортувати?"
 
-#: pkg/pgp/keys.go:101
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "Імпортування ключів за допомогою gpg..."
 
-#: pkg/dep/depCheck.go:155
-msgid "Inner conflicts found:"
-msgstr "Виявлено внутрішні конфлікти:"
-
-#: pkg/dep/depCheck.go:173
-msgid "Installing %s will remove:"
-msgstr "Встановлення %s видалить:"
-
-#: print.go:24
+#: print.go:46
 msgid "Keywords"
 msgstr "Ключові слова"
 
-#: print.go:41
+#: print.go:47
 msgid "Last Modified"
 msgstr "Остання зміна"
 
-#: print.go:30
+#: print.go:35
 msgid "Licenses"
 msgstr "Ліцензії"
 
-#: print.go:37
+#: pkg/dep/dep_graph.go:77
+msgid "Local"
+msgstr ""
+
+#: print.go:48
 msgid "Maintainer"
 msgstr "Супроводжувач"
 
-#: print.go:33
+#: pkg/dep/dep_graph.go:62
+#, fuzzy
+msgid "Make Dependency"
+msgstr "Залежності Збірки"
+
+#: print.go:40
 msgid "Make Deps"
 msgstr "Залежності Збірки"
 
-#: pkg/query/aur_warnings.go:33
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "Відсутні пакети налагодження AUR:"
 
-#: pkg/query/aur_warnings.go:28
-msgid "Missing AUR Packages:"
-msgstr "Відсутні пакунки з AUR:"
+#: pkg/dep/dep_graph.go:79
+msgid "Missing"
+msgstr ""
 
-#: print.go:23
+#: print.go:31
 msgid "Name"
 msgstr "Ім'я"
 
-#: pkg/text/print.go:95
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
+#, fuzzy
+msgid "No AUR package found for"
+msgstr "пакунок не знайдено в репозиторіях"
+
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "пакунок не знайдено в репозиторіях"
+
+#: print.go:225
 msgid "None"
 msgstr "Ні"
 
-#: print.go:35
+#: print.go:39
 msgid "Optional Deps"
 msgstr "Необов'язкові Залежності"
 
-#: pkg/query/aur_warnings.go:38
-msgid "Orphaned AUR Packages:"
+#: pkg/query/aur_warnings.go:75
+#, fuzzy
+msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "Осиротілі пакунки AUR:"
 
-#: print.go:44 print.go:46
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "Застарілий"
 
-#: pkg/pgp/keys.go:119
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "Необхідно імпортувати ключі PGP:"
 
-#: install.go:242 vcs.go:50
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
+#: pkg/sync/workdir/preparer.go:252
+#, fuzzy
+msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD актуальний, пропуск (%d/%d): %s"
 
-#: pkg/menus/edit_menu.go:123
+#: pkg/menus/edit_menu.go:130
 msgid "PKGBUILDs to edit?"
 msgstr "Редагувати PKGBUILDs?"
 
-#: print.go:51
+#: print.go:60
 msgid "Package Base ID"
 msgstr "ID Групи Пакунків"
 
-#: print.go:52
+#: print.go:61
 msgid "Package Base"
 msgstr "Група Пакунків"
 
-#: pkg/dep/depCheck.go:170
-msgid "Package conflicts found:"
-msgstr "Виявлено конфлікти пакунків:"
+#: pkg/query/aur_warnings.go:67
+#, fuzzy
+msgid "Packages not in AUR:"
+msgstr "пакунок не знайдено в AUR"
 
-#: pkg/menus/clean_menu.go:44
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "Пакети для чистої збірки?"
 
-#: upgrade.go:186
+#: pkg/dep/dep_graph.go:202
+#, fuzzy
+msgid "Packages to exclude"
+msgstr "Пакунки для оновлення."
+
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr ""
 "Пакети, які потрібно виключити: (наприклад, \"1 2 3\", \"1-3\", \"^4\" або "
 "назва репозиторію)"
 
-#: cmd.go:368
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "Пакунки для встановлення (наприклад: 1 2 3, 1-3 або ^4)"
 
-#: upgrade.go:183
-msgid "Packages to upgrade."
-msgstr "Пакунки для оновлення."
-
-#: print.go:39
+#: print.go:49
 msgid "Popularity"
 msgstr "Популярність"
 
-#: pkg/menus/diff_menu.go:169 pkg/menus/edit_menu.go:134
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "Продовжити встановлення?"
 
-#: print.go:31
+#: print.go:37
 msgid "Provides"
 msgstr "Забезпечує"
 
-#: pkg/query/aur_info.go:88
-msgid "Querying AUR..."
-msgstr "Запит AUR..."
-
-#: install.go:213
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "Видалити залежності збірки після встановлення?"
 
-#: pkg/dep/depPool.go:546
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "Репозиторій AUR"
 
-#: print.go:22 pkg/db/ialpm/alpm.go:175
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "Репозиторій"
 
-#: upgrade.go:68
+#: pkg/dep/dep_graph.go:78
+msgid "SRCINFO"
+msgstr ""
+
+#: pkg/upgrade/service.go:72
 msgid "Searching AUR for updates..."
 msgstr "Пошук оновлень у AUR..."
 
-#: upgrade.go:57
+#: pkg/upgrade/service.go:160
 msgid "Searching databases for updates..."
 msgstr "Пошук оновлень у базах даних..."
 
-#: pkg/query/mixed_sources.go:200 pkg/query/source.go:79
+#: pkg/query/query_builder.go:214
 msgid "Showing repo packages only"
 msgstr "Показано лише пакунки з репозиторіїв"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "Розмір кешу pacman %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "Розмір кешу yay %s: %s"
 
-#: print.go:53
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "URL знімка"
 
-#: print.go:94
+#: pkg/dep/dep_graph.go:76
+msgid "Sync"
+msgstr ""
+
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "Десять найбільших пакетів:"
 
-#: install.go:461
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "Наступні пакети не сумісні з вашою архітектурою:"
 
-#: pkg/db/ialpm/alpm.go:163 pkg/dep/depPool.go:541
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "Існує %d постачальників для %s:"
 
-#: pkg/settings/exe/cmd_builder.go:199
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "Можливо, запущено інший екземпляр Pacman. Очікування..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "Загальний розмір, зайнятий пакетами: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "Загальна кількість встановлених пакетів: %s"
 
-#: install.go:469
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "Все одно спробувати їх побудувати?"
 
-#: print.go:27
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:182
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "Неможливо очистити:"
 
-#: get.go:42 get.go:73
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "Не вдалося знайти такі пакети:"
 
-#: print.go:25
+#: vote.go:20
+msgid "Unable to handle package vote for: %s. err: %s"
+msgstr ""
+
+#: clean.go:170
+#, fuzzy
+msgid "Unable to remove %s: %s"
+msgstr "не вдалося проаналізувати %s: %s"
+
+#: print.go:32
 msgid "Version"
 msgstr "Версія"
 
-#: print.go:38
+#: print.go:50
 msgid "Votes"
 msgstr "Голоси"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Версія Yay v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]Ні"
 
-#: clean.go:77
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -445,7 +564,7 @@ msgstr ""
 "\n"
 "Каталог збірки:"
 
-#: pkg/db/ialpm/alpm.go:185 pkg/dep/depPool.go:556
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -457,23 +576,45 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "зупинка через користувача"
 
-#: install.go:496
+#: pkg/settings/parser/parser.go:620
+msgid "argument '-' specified without input on stdin"
+msgstr ""
+
+#: local_install.go:26
+msgid "cannot find PKGBUILD and .SRCINFO in directory"
+msgstr ""
+
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "не вдається знайти пакунок: %v"
 
-#: install.go:688 install.go:821
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "не вдалося знайти PKGDEST для: %s"
 
-#: pkg/vcs/vcs.go:69
+#: errors.go:9
+#, fuzzy
+msgid "could not find all required packages"
+msgstr "Не вдалося знайти всі необхідні пакунки:"
+
+#: pkg/sync/build/errors.go:61
+msgid "could not find any package archives listed in %s"
+msgstr ""
+
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
+#, fuzzy
+msgid "dependency"
+msgstr "Залежить Від"
+
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "розробницька перевірка пакунку не вдалася: '%s' сталася помилка"
 
-#: pkg/menus/edit_menu.go:108
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "вихід з редактора був успішним, переривання: %s"
 
-#: aur_source.go:26
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "помилка завантаження вихідного коду:"
 
@@ -481,63 +622,83 @@ msgstr "помилка завантаження вихідного коду:"
 msgid "error fetching %s: %s"
 msgstr "помилка отримання %s: %s"
 
-#: install.go:299 install.go:405
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "помалка встановлення пакунку з репозиторіїв"
 
-#: install.go:671 install.go:712 install.go:726 install.go:740
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
+#, fuzzy
+msgid "error installing:"
+msgstr "помалка встановлення пакунку з репозиторіїв"
+
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "помилка збірки: %s"
 
-#: install.go:573
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "помилка об'єднання %s: %s"
 
-#: pkg/download/unified.go:56
+#: pkg/download/unified.go:59
 msgid "error reading %s"
 msgstr "помилка читання %s"
 
-#: install.go:88
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "помилка оновлення баз даних"
 
-#: clean.go:212 install.go:566
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "помилка скидання %s: %s"
 
-#: install.go:42
-msgid "error updating package install reason to dependency"
-msgstr "помилка оновлення причини встановлення пакунка на 'залежність'"
-
-#: install.go:60
-msgid "error updating package install reason to explicit"
+#: pkg/sync/build/errors.go:53
+#, fuzzy
+msgid "error updating package install reason to %s"
 msgstr "помилка оновлення причини встановлення пакунка на 'явно встановлено'"
+
+#: pkg/sync/build/errors.go:48
+msgid "explicit"
+msgstr ""
 
 #: pkg/settings/errors.go:23
 msgid "failed to create directory '%s': %s"
 msgstr "не вдалося створити каталог '%s': %s"
 
-#: pkg/settings/config.go:293
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "не вдалося відкрити файл конфігурації '%s': %s"
 
-#: install.go:522
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "не вдалося проаналізувати %s -- пропуск: %s"
 
-#: install.go:526
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "не вдалося проаналізувати %s: %s"
 
-#: pkg/settings/config.go:303
+#: local_install.go:77
+#, fuzzy
+msgid "failed to parse .SRCINFO"
+msgstr "не вдалося проаналізувати %s: %s"
+
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "не вдалося прочитати конфігураційний файл '%s': %s"
+
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
+msgid "failed to retrieve aur Cache"
+msgstr ""
+
+#: pkg/upgrade/sources.go:27
+#, fuzzy
+msgid "ignoring package devel upgrade (no AUR info found):"
+msgstr "%s: ігнорування оновлення пакета ( %s => %s)"
 
 #: pkg/text/errors.go:8
 msgid "input too long"
 msgstr "введення занадто довге"
 
-#: pkg/db/ialpm/alpm.go:206 pkg/dep/depPool.go:576
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "некоректний номер: %s"
 
@@ -545,20 +706,20 @@ msgstr "некоректний номер: %s"
 msgid "invalid option '%s'"
 msgstr "некоректний параметр '%s'"
 
-#: cmd.go:202
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr ""
 "некоректний параметр: '--deps' і '--explicit' не можна використовувати разом"
 
-#: pkg/download/abs.go:21
+#: pkg/download/abs.go:22
 msgid "invalid repository"
 msgstr "недійсний репозиторій"
 
-#: pkg/db/ialpm/alpm.go:211 pkg/dep/depPool.go:581
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "некоректне значення: %d не знаходиться між %d та %d"
 
-#: pkg/pgp/keys.go:114
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "нема ключів для імпорту"
 
@@ -566,59 +727,120 @@ msgstr "нема ключів для імпорту"
 msgid "no query was executed"
 msgstr "запит не виконано"
 
-#: pkg/text/text.go:60
+#: local_install.go:66
+msgid "no target directories specified"
+msgstr ""
+
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "ні"
+
+#: pkg/sync/build/installer.go:242
+msgid "nothing to install for %s"
+msgstr ""
 
 #: pkg/settings/parser/parser.go:164
 msgid "only one operation may be used at a time"
 msgstr "одночасно можна використовувати лише одну операцію"
 
-#: print.go:185
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "пакунок '%s' не знайдено"
-
-#: pkg/dep/depCheck.go:197
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr ""
-"конфлікти пакетів не можна вирішити за допомогою noconfirm, переривання"
 
 #: pkg/download/errors.go:15
 msgid "package not found in AUR"
 msgstr "пакунок не знайдено в AUR"
 
-#: pkg/download/abs.go:22
+#: pkg/download/abs.go:23
 msgid "package not found in repos"
 msgstr "пакунок не знайдено в репозиторіях"
 
-#: pkg/pgp/keys.go:104
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "Група Пакунків"
+msgstr[1] "Група Пакунків"
+msgstr[2] "Група Пакунків"
+msgstr[3] "Група Пакунків"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "проблема імпортування ключів"
 
-#: clean.go:97
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "видалення пакетів AUR з кешу..."
 
-#: clean.go:167 clean.go:198
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "видалення невідстежених файлів AUR з кешу..."
 
-#: install.go:830
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "PKGDEST для %s перераховано makepkg, але не існує: %s"
 
-#: pkg/db/ialpm/alpm.go:231
+#: pkg/sync/sync.go:45
+#, fuzzy
+msgid "there is nothing to do"
+msgstr "тут нічого робити"
+
+#: pkg/db/ialpm/alpm.go:247
 msgid "unable to CreateHandle: %s"
 msgstr "неможливо створити Handle:"
 
-#: cmd.go:191
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "необроблена операція"
 
-#: cmd.go:424
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "невідома версія"
 
-#: pkg/text/text.go:59
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "так"
+
+#~ msgid " (Target"
+#~ msgstr "(Ціль"
+
+#~ msgid " (Wanted by: "
+#~ msgstr "(Треба пакунку:"
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s не задоволено, очищення черги встановлення"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "Перевірка на наявність конфліктів..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "Перевірка на внутрішні конфлікти..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr "Конфліктні пакети потрібно буде підтвердити вручну"
+
+#~ msgid "Inner conflicts found:"
+#~ msgstr "Виявлено внутрішні конфлікти:"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "Встановлення %s видалить:"
+
+#~ msgid "Missing AUR Packages:"
+#~ msgstr "Відсутні пакунки з AUR:"
+
+#~ msgid "Package conflicts found:"
+#~ msgstr "Виявлено конфлікти пакунків:"
+
+#~ msgid "Querying AUR..."
+#~ msgstr "Запит AUR..."
+
+#~ msgid "error updating package install reason to dependency"
+#~ msgstr "помилка оновлення причини встановлення пакунка на 'залежність'"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr ""
+#~ "конфлікти пакетів не можна вирішити за допомогою noconfirm, переривання"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2022
 # lakejason0 <sunliyuan200402@outlook.com>, 2023
@@ -6,63 +6,64 @@
 # kanna 5, 2023
 # Songer Hy, 2023
 # Celestially H., 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Celestially H., 2023\n"
-"Language-Team: Chinese (China) (https://app.transifex.com/yay-1/teams/123732/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://app.transifex.com/yay-1/teams/123732/"
+"zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (构建文件已存在)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (已安装)"
 
-#: cmd.go:461
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [已安装]"
 
-#: cmd.go:418 vote.go:35
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " 今日无事可做"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr "%s [A]全部 [Ab]中止 [I]已安装 [No]未安装 或 (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:304
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s 已生成 -- 跳过构建"
 
-#: pkg/menus/edit_menu.go:56
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "未设置 %s"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s 存在。"
 
-#: pkg/dep/dep_graph.go:431 aur_install.go:301
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s 是最新的 -- 跳过"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "%s to upgrade/install."
 msgstr "%s 个要进行升级/安装的包。"
 
-#: pkg/upgrade/service.go:298
+#: pkg/upgrade/service.go:286
 msgid "%s will also be installed for this operation."
 msgstr "%s 也会为此操作而被安装。"
 
-#: pkg/pgp/keys.go:127
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, 被以下需要: %s"
 
@@ -82,25 +83,81 @@ msgstr "%s: 不能将目标与选项 --repo 一起使用 -- 跳过"
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: 忽略包升级 (%s => %s)"
 
-#: pkg/query/aur_warnings.go:51
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: 本地 (%s) 比 AUR (%s) 更新"
 
-#: vote.go:50
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr "%s: 请设置 AUR_USERNAME 与 AUR_PASSWORD 环境变量以投票"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) 从 ABS 下载了 PKGBUILD: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) 下载了 PKGBUILD: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) 下载了 PKGBUILD: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) 正在解析 SRCINFO: %s"
 
@@ -120,7 +177,7 @@ msgstr "(孤儿包)"
 msgid "(Out-of-date: %s)"
 msgstr "(过时的: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR URL"
 
@@ -128,7 +185,7 @@ msgstr "AUR URL"
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:57
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "将 %s 或 %s 添加到你的环境变量"
 
@@ -140,7 +197,7 @@ msgstr "避免以 root/sudo 运行 yay。"
 msgid "Check Dependency"
 msgstr "作为检查依赖安装"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "检查依赖"
 
@@ -148,15 +205,15 @@ msgstr "检查依赖"
 msgid "Checking development packages..."
 msgstr "正在检查开发包..."
 
-#: clean.go:217
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "正在清理 (%d/%d): %s"
 
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "与它冲突"
 
-#: pkg/menus/clean_menu.go:60
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "正在删除 (%d/%d): %s"
 
@@ -164,15 +221,15 @@ msgstr "正在删除 (%d/%d): %s"
 msgid "Dependency"
 msgstr "作为依赖安装"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "依赖于"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "描述"
 
-#: pkg/menus/diff_menu.go:158
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "显示哪些包的差异？"
 
@@ -180,19 +237,19 @@ msgstr "显示哪些包的差异？"
 msgid "Disable 'provides' setting by default"
 msgstr "默认禁用 'provides' 设置"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "你是否要从缓存中删除所有 AUR 软件包？"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "你是否要删除所有未跟踪的 AUR 文件？"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "你是否要从缓存中删除所有其他 AUR 软件包？"
 
-#: pkg/menus/edit_menu.go:60
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "使用什么来编辑 PKGBUILD？"
 
@@ -200,7 +257,7 @@ msgstr "使用什么来编辑 PKGBUILD？"
 msgid "Error during AUR search: %s\n"
 msgstr "搜索 AUR 时出错: %s\n"
 
-#: pkg/upgrade/service.go:308
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr "排除软件包可能会导致不完整的升级并破坏系统"
 
@@ -208,32 +265,32 @@ msgstr "排除软件包可能会导致不完整的升级并破坏系统"
 msgid "Explicit"
 msgstr "单独指定安装"
 
-#: print.go:85
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "单独指定安装的软件包: %s"
 
-#: pkg/dep/dep_graph.go:408 pkg/dep/dep_graph.go:506
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "查找 AUR 软件包失败："
 
-#: aur_install.go:120
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "层级安装失败，正在合并到下一个层级。"
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "无法安装以下软件包, 需要手动介入处理:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "首次提交"
 
-#: pkg/query/aur_warnings.go:84
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "标记为过时的 AUR 软件包:"
 
-#: print.go:84
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "已安装的外部软件包: %s"
 
@@ -241,31 +298,31 @@ msgstr "已安装的外部软件包: %s"
 msgid "Found git repo: %s"
 msgstr "已找到 git 仓库: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB 完成。 没有安装任何软件包"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "组"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "导入？"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "正在用 gpg 导入密钥..."
 
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "关键字"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "最后修改"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "许可证"
 
@@ -273,7 +330,7 @@ msgstr "许可证"
 msgid "Local"
 msgstr "本地"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "维护者"
 
@@ -281,11 +338,11 @@ msgstr "维护者"
 msgid "Make Dependency"
 msgstr "作为生成依赖安装"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "生成依赖"
 
-#: pkg/query/aur_warnings.go:76
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "缺少 AUR 调试包:"
 
@@ -293,35 +350,40 @@ msgstr "缺少 AUR 调试包:"
 msgid "Missing"
 msgstr "缺少"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "名称"
 
-#: pkg/dep/dep_graph.go:413 pkg/dep/dep_graph.go:519
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "未找到 AUR 软件包"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "未找到 AUR 软件包"
+
+#: print.go:225
 msgid "None"
 msgstr "没有"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "可选依赖"
 
-#: pkg/query/aur_warnings.go:80
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "孤儿 (无人维护) 的 AUR 软件包："
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "过时"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "需要导入的 PGP 密钥:"
 
-#: preparer.go:242
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD 是最新的，跳过下载: %s"
 
@@ -329,55 +391,59 @@ msgstr "PKGBUILD 是最新的，跳过下载: %s"
 msgid "PKGBUILDs to edit?"
 msgstr "要编辑哪些 PKGBUILD？"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "包基础 ID"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "包基础"
 
-#: pkg/query/aur_warnings.go:72
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "不在 AUR 中的软件包："
 
-#: pkg/menus/clean_menu.go:52
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "清理哪些软件包的构建文件？"
 
-#: pkg/dep/dep_graph.go:216
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "要排除的软件包"
 
-#: pkg/upgrade/service.go:307
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr "要排除的包: (示例: \"1 2 3\", \"1-3\", \"^4\" 或软件库名称)"
 
-#: cmd.go:400
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "要安装的包 (示例: 1 2 3, 1-3 或 ^4)"
 
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "受欢迎度"
 
-#: pkg/menus/diff_menu.go:170 pkg/menus/edit_menu.go:143
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "继续安装？"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "提供"
 
-#: preparer.go:119
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "安装后删除生成依赖？"
 
-#: pkg/dep/dep_graph.go:701
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "AUR 软件库"
 
-#: print.go:25 pkg/db/ialpm/alpm.go:191
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "软件库"
 
@@ -397,15 +463,15 @@ msgstr "正在搜索数据库以获取更新..."
 msgid "Showing repo packages only"
 msgstr "仅显示软件库软件包"
 
-#: print.go:89
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "pacman 缓存大小 %s: %s"
 
-#: print.go:92
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "yay 缓存大小 %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "快照 URL"
 
@@ -413,71 +479,71 @@ msgstr "快照 URL"
 msgid "Sync"
 msgstr "同步"
 
-#: print.go:94
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "十个最大的软件包:"
 
-#: sync.go:190
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "下列软件包与你的系统架构不兼容:"
 
-#: pkg/dep/dep_graph.go:697 pkg/db/ialpm/alpm.go:179
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "有 %d 个提供者可用于 %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "可能还有另一个 Pacman 实例正在运行。等待中..."
 
-#: print.go:86
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "包占用的总大小: %s"
 
-#: print.go:83
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "已安装的软件包总数:  %s"
 
-#: sync.go:198
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "依然尝试构建吗？"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "URL"
 
-#: clean.go:195 pkg/menus/clean_menu.go:63 pkg/menus/clean_menu.go:69
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "无法清理："
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "找不到下列软件包："
 
-#: vote.go:19
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "无法处理软件包的投票: %s。错误: %s"
 
-#: clean.go:171
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "无法删除 %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "版本"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "得票"
 
-#: print.go:81
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay 版本 v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]没有"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -485,7 +551,7 @@ msgstr ""
 "\n"
 "构建目录:"
 
-#: pkg/dep/dep_graph.go:711 pkg/db/ialpm/alpm.go:201
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -497,19 +563,19 @@ msgstr ""
 msgid "aborting due to user"
 msgstr "由于用户而中止"
 
-#: pkg/settings/parser/parser.go:619
+#: pkg/settings/parser/parser.go:620
 msgid "argument '-' specified without input on stdin"
 msgstr "指定了参数“-”，但未在 stdin 输入任何内容"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "在目录中找不到 PKGBUILD 和 .SRCINFO 文件"
 
-#: install.go:130
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "找不到包名: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "找不到 PKGDEST: %s"
 
@@ -517,11 +583,11 @@ msgstr "找不到 PKGDEST: %s"
 msgid "could not find all required packages"
 msgstr "无法找到所有必需的软件包"
 
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "在 %s 中无法找到任何软件包存档"
 
-#: errors.go:26 pkg/upgrade/service.go:299
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "作为依赖安装"
 
@@ -529,11 +595,11 @@ msgstr "作为依赖安装"
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "软件包的开发检查失败: '%s' 遇到了错误"
 
-#: pkg/menus/edit_menu.go:109
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "编辑器未成功退出，正在中止: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "下载源文件时出错: %s"
 
@@ -541,19 +607,19 @@ msgstr "下载源文件时出错: %s"
 msgid "error fetching %s: %s"
 msgstr "获取 %s 时出错: %s"
 
-#: local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "安装软件库软件包时出错"
 
-#: aur_install.go:266 aur_install.go:270
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "安装时出错: "
 
-#: aur_install.go:233 aur_install.go:237
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "生成时出错: %s"
 
-#: install.go:160
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "合并 %s 时出错: %s"
 
@@ -561,19 +627,19 @@ msgstr "合并 %s 时出错: %s"
 msgid "error reading %s"
 msgstr "读取 %s 时出错"
 
-#: sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "刷新数据库时出错"
 
-#: clean.go:223 install.go:153
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "重置 %s 时出错: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "更新软件包安装原因至 %s 时出错"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "单独指定安装"
 
@@ -581,27 +647,27 @@ msgstr "单独指定安装"
 msgid "failed to create directory '%s': %s"
 msgstr "无法创建目录 '%s': %s"
 
-#: pkg/settings/config.go:284
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "无法打开配置文件 '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "无法解析 %s -- 跳过: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "无法解析 %s: %s"
 
-#: local_install.go:79
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "无法解析 .SRCINFO"
 
-#: pkg/settings/config.go:294
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "无法读取配置文件 '%s': %s"
 
-#: pkg/settings/runtime.go:73
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "无法获取 AUR 缓存"
 
@@ -613,7 +679,7 @@ msgstr "忽略软件包开发更新（未找到 AUR 信息）："
 msgid "input too long"
 msgstr "输入过长"
 
-#: pkg/dep/dep_graph.go:732 pkg/db/ialpm/alpm.go:222
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "无效数字: %s"
 
@@ -621,7 +687,7 @@ msgstr "无效数字: %s"
 msgid "invalid option '%s'"
 msgstr "无效选项 '%s'"
 
-#: cmd.go:206
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr "无效选项: '--deps' 和 '--explicit' 不能同时指定"
 
@@ -629,11 +695,11 @@ msgstr "无效选项: '--deps' 和 '--explicit' 不能同时指定"
 msgid "invalid repository"
 msgstr "无效软件库"
 
-#: pkg/dep/dep_graph.go:738 pkg/db/ialpm/alpm.go:227
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "无效值: %d 不在 %d 和 %d 之间"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "没有要导入的密钥"
 
@@ -641,15 +707,15 @@ msgstr "没有要导入的密钥"
 msgid "no query was executed"
 msgstr "没有查询被执行"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "未指定目标目录"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "no"
 
-#: aur_install.go:242
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "%s 没有需要安装的依赖软件包"
 
@@ -657,7 +723,11 @@ msgstr "%s 没有需要安装的依赖软件包"
 msgid "only one operation may be used at a time"
 msgstr "一次只能使用一项操作"
 
-#: print.go:181
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "找不到软件包 '%s'"
 
@@ -669,28 +739,28 @@ msgstr "AUR 中找不到软件包"
 msgid "package not found in repos"
 msgstr "软件库中找不到软件包"
 
-#: pkg/upgrade/service.go:304
+#: pkg/upgrade/service.go:292
 msgid "package"
 msgid_plural "packages"
 msgstr[0] "软件包"
 
-#: pkg/pgp/keys.go:103
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "导入密钥时出现问题"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "正在从缓存中删除 AUR 软件包..."
 
-#: clean.go:179 clean.go:213
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "正在从缓存中删除未跟踪的 AUR 文件..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "%s 的 PKGDEST 由 makepkg 列出，但不存在: %s"
 
-#: sync.go:113
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "今日无事可做"
 
@@ -698,14 +768,14 @@ msgstr "今日无事可做"
 msgid "unable to CreateHandle: %s"
 msgstr "无法创建句柄: %s"
 
-#: cmd.go:195
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "未处理的操作"
 
-#: cmd.go:458
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "未知版本"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "yes"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,69 +1,67 @@
-# 
+#
 # Translators:
 # J G, 2022
 # lakejason0 <sunliyuan200402@outlook.com>, 2023
 # 如月飛羽 <flyingfeather1501@gmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: 如月飛羽 <flyingfeather1501@gmail.com>, 2023\n"
-"Language-Team: Chinese (Taiwan) (https://app.transifex.com/yay-1/teams/123732/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://app.transifex.com/yay-1/"
+"teams/123732/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: xgotext\n"
 
-#: pkg/menus/menu.go:31
+#: pkg/menus/menu.go:32
 msgid " (Build Files Exist)"
 msgstr " (編譯檔案已存在)"
 
-#: pkg/menus/menu.go:26
+#: pkg/menus/menu.go:27
 msgid " (Installed)"
 msgstr " (已安裝)"
 
-#: pkg/dep/depCheck.go:310
-msgid " (Target"
-msgstr " (目標"
-
-#: pkg/dep/depCheck.go:312
-msgid " (Wanted by: "
-msgstr " (被這些軟體包依賴: "
-
-#: cmd.go:472
+#: cmd.go:463
 msgid " [Installed]"
 msgstr " [已安裝]"
 
-#: cmd.go:425 install.go:172 install.go:206 vote.go:34
+#: cmd.go:420 vote.go:36
 msgid " there is nothing to do"
 msgstr " 無事可做"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "%s [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)"
 msgstr "%s [A]全部 [Ab]中止 [I]已安裝 [No]未安裝 或 (1 2 3, 1-3, ^4)"
 
-#: aur_install.go:274 install.go:741
+#: pkg/sync/build/installer.go:308
 msgid "%s already made -- skipping build"
 msgstr "%s 已編譯 -- 跳過編譯"
 
-#: pkg/menus/edit_menu.go:58
+#: pkg/menus/edit_menu.go:57
 msgid "%s is not set"
 msgstr "未設定 %s"
 
-#: pkg/settings/exe/cmd_builder.go:238
+#: pkg/settings/exe/cmd_builder.go:257
 msgid "%s is present."
 msgstr "%s 存在。"
 
-#: pkg/dep/dep_graph.go:385 aur_install.go:271 install.go:727
+#: pkg/dep/dep_graph.go:460 pkg/sync/build/installer.go:305
 msgid "%s is up to date -- skipping"
 msgstr "%s 是最新的 -- 跳過"
 
-#: install.go:642
-msgid "%s not satisfied, flushing install queue"
-msgstr "%s 未滿足，正在重新整理安裝序列"
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "%s to upgrade/install."
+msgstr "個要升級/安裝的軟體包。"
 
-#: pkg/pgp/keys.go:127
+#: pkg/upgrade/service.go:286
+msgid "%s will also be installed for this operation."
+msgstr ""
+
+#: pkg/sync/srcinfo/pgp/keys.go:124
 msgid "%s, required by: %s"
 msgstr "%s, 需要: %s"
 
@@ -79,57 +77,113 @@ msgstr "%s: 不能將目標與選項 --aur 一起使用 -- 跳過"
 msgid "%s: can't use target with option --repo -- skipping"
 msgstr "%s: 不能將目標與選項 --repo 一起使用 -- 跳過"
 
-#: pkg/upgrade/sources.go:60
+#: pkg/upgrade/sources.go:57
 msgid "%s: ignoring package upgrade (%s => %s)"
 msgstr "%s: 忽略軟體包升級 (%s => %s)"
 
-#: upgrade.go:165
+#: pkg/query/aur_warnings.go:46
 msgid "%s: local (%s) is newer than AUR (%s)"
 msgstr "%s: 本機 (%s) 比 AUR (%s) 更新"
 
-#: vote.go:49
+#: vote.go:51
 msgid ""
-"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for "
-"voting"
+"%s: please set AUR_USERNAME and AUR_PASSWORD environment variables for voting"
 msgstr "%s: 請設定 AUR_USERNAME 與 AUR_PASSWORD 環境變數以進行投票"
+
+#: pkg/settings/args.go:118
+msgid "'--%s' is deprecated. Use '--batchinstall=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:63
+msgid "'--%s' is deprecated. Use '--cleanafter=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:187
+msgid "'--%s' is deprecated. Use '--cleanmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:207
+msgid "'--%s' is deprecated. Use '--combinedupgrade=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:73
+msgid "'--%s' is deprecated. Use '--devel=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:192
+msgid "'--%s' is deprecated. Use '--diffmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:197
+msgid "'--%s' is deprecated. Use '--editmenu=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:182
+msgid "'--%s' is deprecated. Use '--pgpfetch=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:177
+msgid "'--%s' is deprecated. Use '--provides=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:224
+msgid "'--%s' is deprecated. Use '--separatesources=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:172
+msgid "'--%s' is deprecated. Use '--sudoloop=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:78
+msgid "'--%s' is deprecated. Use '--timeupdate=false' instead"
+msgstr ""
+
+#: pkg/settings/args.go:202
+msgid "'--%s' is deprecated. Use '--useask=false' instead"
+msgstr ""
 
 #: pkg/download/unified.go:192
 msgid "(%d/%d) Downloaded PKGBUILD from ABS: %s"
 msgstr "(%d/%d) 從 ABS 下載了 PKGBUILD: %s"
 
-#: pkg/download/aur.go:84 pkg/download/unified.go:188
+#: pkg/download/aur.go:92 pkg/download/unified.go:188
 msgid "(%d/%d) Downloaded PKGBUILD: %s"
 msgstr "(%d/%d) 下載了 PKGBUILD: %s"
 
-#: pkg/srcinfo/service.go:108
+#: pkg/download/aur.go:82
+#, fuzzy
+msgid "(%d/%d) Failed to download PKGBUILD: %s"
+msgstr "(%d/%d) 下載了 PKGBUILD: %s"
+
+#: pkg/sync/srcinfo/service.go:109
 msgid "(%d/%d) Parsing SRCINFO: %s"
 msgstr "(%d/%d) 正在解析 SRCINFO: %s"
 
-#: pkg/query/types.go:70 pkg/query/types.go:101
+#: pkg/query/types.go:72 pkg/query/types.go:103
 msgid "(Installed)"
 msgstr "(已安裝)"
 
-#: pkg/query/types.go:68 pkg/query/types.go:99
+#: pkg/query/types.go:70 pkg/query/types.go:101
 msgid "(Installed: %s)"
 msgstr "(已安裝: %s)"
 
-#: pkg/query/types.go:59
+#: pkg/query/types.go:61
 msgid "(Orphaned)"
 msgstr "(棄置)"
 
-#: pkg/query/types.go:63
+#: pkg/query/types.go:65
 msgid "(Out-of-date: %s)"
 msgstr "(過期的: %s)"
 
-#: print.go:31
+#: print.go:44
 msgid "AUR URL"
 msgstr "AUR 網址"
 
-#: pkg/dep/dep_graph.go:74
+#: pkg/dep/dep_graph.go:75
 msgid "AUR"
 msgstr "AUR"
 
-#: pkg/menus/edit_menu.go:59
+#: pkg/menus/edit_menu.go:58
 msgid "Add %s or %s to your environment variables"
 msgstr "將 %s 或 %s 添加到你的環境變數"
 
@@ -137,55 +191,43 @@ msgstr "將 %s 或 %s 添加到你的環境變數"
 msgid "Avoid running yay as root/sudo."
 msgstr "避免以 root/sudo 執行 yay。"
 
-#: pkg/dep/dep_graph.go:62
+#: pkg/dep/dep_graph.go:63
 msgid "Check Dependency"
 msgstr "作為檢查依賴安裝"
 
-#: print.go:37
+#: print.go:41
 msgid "Check Deps"
 msgstr "檢查依賴"
 
-#: pkg/upgrade/service.go:78 upgrade.go:95
+#: pkg/upgrade/service.go:90
 msgid "Checking development packages..."
 msgstr "正在檢查開發軟體包..."
 
-#: pkg/dep/depCheck.go:137
-msgid "Checking for conflicts..."
-msgstr "正在檢查衝突..."
-
-#: pkg/dep/depCheck.go:145
-msgid "Checking for inner conflicts..."
-msgstr "正在檢查內部衝突..."
-
-#: clean.go:214
+#: pkg/sync/workdir/clean.go:45
 msgid "Cleaning (%d/%d): %s"
 msgstr "正在清理 (%d/%d): %s"
 
-#: pkg/dep/depCheck.go:200
-msgid "Conflicting packages will have to be confirmed manually"
-msgstr "必須手動確認衝突的軟體包"
-
-#: print.go:39
+#: print.go:42
 msgid "Conflicts With"
 msgstr "與它衝突"
 
-#: pkg/menus/clean_menu.go:61 pkg/menus/clean_menu.go:108
+#: pkg/menus/clean_menu.go:62
 msgid "Deleting (%d/%d): %s"
 msgstr "正在刪除 (%d/%d): %s"
 
-#: pkg/dep/dep_graph.go:60
+#: pkg/dep/dep_graph.go:61
 msgid "Dependency"
 msgstr "作為依賴安裝"
 
-#: print.go:35
+#: print.go:38
 msgid "Depends On"
 msgstr "依賴於"
 
-#: print.go:29
+#: print.go:33
 msgid "Description"
 msgstr "描述"
 
-#: pkg/menus/diff_menu.go:161 pkg/menus/diff_menu.go:194
+#: pkg/menus/diff_menu.go:160
 msgid "Diffs to show?"
 msgstr "顯示差異？"
 
@@ -193,19 +235,19 @@ msgstr "顯示差異？"
 msgid "Disable 'provides' setting by default"
 msgstr "預設停用「provides」設定"
 
-#: clean.go:79
+#: clean.go:78
 msgid "Do you want to remove ALL AUR packages from cache?"
 msgstr "您是否要從快取中刪除所有 AUR 軟體包？"
 
-#: clean.go:96
+#: clean.go:95
 msgid "Do you want to remove ALL untracked AUR files?"
 msgstr "您是否要刪除所有未使用的 AUR 檔案？"
 
-#: clean.go:81
+#: clean.go:80
 msgid "Do you want to remove all other AUR packages from cache?"
 msgstr "您是否要從快取中刪除所有其他 AUR 軟體包？"
 
-#: pkg/menus/edit_menu.go:62
+#: pkg/menus/edit_menu.go:61
 msgid "Edit PKGBUILD with?"
 msgstr "使用什麼來編輯 PKGBUILD？"
 
@@ -213,313 +255,293 @@ msgstr "使用什麼來編輯 PKGBUILD？"
 msgid "Error during AUR search: %s\n"
 msgstr "搜尋 AUR 時出錯: %s\n"
 
-#: pkg/upgrade/service.go:256
+#: pkg/upgrade/service.go:296
 msgid "Excluding packages may cause partial upgrades and break systems"
 msgstr "排除軟體包可能會造成部分更新而使系統無法正常運作"
 
-#: pkg/dep/dep_graph.go:59
+#: pkg/dep/dep_graph.go:60
 msgid "Explicit"
 msgstr "單獨指定安裝"
 
-#: print.go:84
+#: print.go:91
 msgid "Explicitly installed packages: %s"
 msgstr "單獨指定安装的軟體包: %s"
 
-#: pkg/dep/dep_graph.go:365 pkg/dep/dep_graph.go:454
+#: pkg/dep/dep_graph.go:437 pkg/dep/dep_graph.go:535
 msgid "Failed to find AUR package for"
 msgstr "尋找 AUR 軟體包時失敗"
 
-#: aur_install.go:104
+#: pkg/sync/build/installer.go:120
 msgid "Failed to install layer, rolling up to next layer."
 msgstr "層級安裝失敗，將合併到下一個層級。"
 
-#: errors.go:55
+#: pkg/sync/build/errors.go:16
 msgid ""
 "Failed to install the following packages. Manual intervention is required:"
 msgstr "無法安裝以下軟體包。需要手動處理:"
 
-#: print.go:43
+#: print.go:45
 msgid "First Submitted"
 msgstr "首次提交"
 
-#: pkg/query/aur_warnings.go:43
+#: pkg/query/aur_warnings.go:79
 msgid "Flagged Out Of Date AUR Packages:"
 msgstr "標記為過期的 AUR 軟體包:"
 
-#: print.go:83
+#: print.go:90
 msgid "Foreign installed packages: %s"
 msgstr "已安裝的外部軟體包: %s"
 
-#: pkg/vcs/vcs.go:142
+#: pkg/vcs/vcs.go:144
 msgid "Found git repo: %s"
 msgstr "已找到 git 軟體源: %s"
 
-#: vcs.go:73
+#: vcs.go:72
 msgid "GenDB finished. No packages were installed"
 msgstr "GenDB 完成。沒有安裝任何軟體包"
 
-#: print.go:32
+#: print.go:36
 msgid "Groups"
 msgstr "組別"
 
-#: pkg/pgp/keys.go:91
+#: pkg/sync/srcinfo/pgp/keys.go:88
 msgid "Import?"
 msgstr "匯入？"
 
-#: pkg/pgp/keys.go:100
+#: pkg/sync/srcinfo/pgp/keys.go:97
 msgid "Importing keys with gpg..."
 msgstr "正在匯入 gpg 金鑰..."
 
-#: pkg/dep/depCheck.go:155
-msgid "Inner conflicts found:"
-msgstr "發現內部衝突:"
-
-#: pkg/dep/depCheck.go:173
-msgid "Installing %s will remove:"
-msgstr "安裝 %s 將刪除:"
-
-#: print.go:27
+#: print.go:46
 msgid "Keywords"
 msgstr "關鍵字"
 
-#: print.go:44
+#: print.go:47
 msgid "Last Modified"
 msgstr "最後修改"
 
-#: print.go:33
+#: print.go:35
 msgid "Licenses"
 msgstr "授權條款"
 
-#: pkg/dep/dep_graph.go:76
+#: pkg/dep/dep_graph.go:77
 msgid "Local"
 msgstr "本機"
 
-#: print.go:40
+#: print.go:48
 msgid "Maintainer"
 msgstr "維護者"
 
-#: pkg/dep/dep_graph.go:61
+#: pkg/dep/dep_graph.go:62
 msgid "Make Dependency"
 msgstr "作為編譯依賴安裝"
 
-#: print.go:36
+#: print.go:40
 msgid "Make Deps"
 msgstr "編譯依賴"
 
-#: pkg/query/aur_warnings.go:33
+#: pkg/query/aur_warnings.go:71
 msgid "Missing AUR Debug Packages:"
 msgstr "缺少 AUR 除錯軟體包:"
 
-#: pkg/dep/dep_graph.go:78
+#: pkg/dep/dep_graph.go:79
 msgid "Missing"
 msgstr "缺少"
 
-#: print.go:26
+#: print.go:31
 msgid "Name"
 msgstr "名稱"
 
-#: pkg/dep/dep_graph.go:370 pkg/dep/dep_graph.go:467
+#: pkg/dep/dep_graph.go:442 pkg/dep/dep_graph.go:548
 msgid "No AUR package found for"
 msgstr "沒有找到 AUR 軟體包"
 
-#: pkg/text/print.go:117
+#: pkg/dep/dep_graph.go:182
+#, fuzzy
+msgid "No package found for"
+msgstr "沒有找到 AUR 軟體包"
+
+#: print.go:225
 msgid "None"
 msgstr "沒有"
 
-#: print.go:38
+#: print.go:39
 msgid "Optional Deps"
 msgstr "可選依賴"
 
-#: pkg/query/aur_warnings.go:38
+#: pkg/query/aur_warnings.go:75
 msgid "Orphan (unmaintained) AUR Packages:"
 msgstr "孤立 (不受維護) 的 AUR 軟體包:"
 
-#: print.go:47 print.go:49
+#: print.go:53 print.go:55
 msgid "Out-of-date"
 msgstr "過期"
 
-#: pkg/pgp/keys.go:118
+#: pkg/sync/srcinfo/pgp/keys.go:115
 msgid "PGP keys need importing:"
 msgstr "需要匯入的 PGP 金鑰:"
 
-#: install.go:265 vcs.go:46
-msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
-msgstr "PKGBUILD 是最新的，跳過 (%d/%d): %s"
-
-#: preparer.go:226
+#: pkg/sync/workdir/preparer.go:252
 msgid "PKGBUILD up to date, skipping download: %s"
 msgstr "PKGBUILD 是最新的，跳過下載: %s"
 
-#: pkg/menus/edit_menu.go:132 pkg/menus/edit_menu.go:164
+#: pkg/menus/edit_menu.go:130
 msgid "PKGBUILDs to edit?"
 msgstr "要編輯哪些 PKGBUILD 檔案？"
 
-#: print.go:54
+#: print.go:60
 msgid "Package Base ID"
 msgstr "軟體包構造編號"
 
-#: print.go:55
+#: print.go:61
 msgid "Package Base"
 msgstr "軟體包構造"
 
-#: pkg/dep/depCheck.go:170
-msgid "Package conflicts found:"
-msgstr "發現軟體包衝突:"
-
-#: pkg/query/aur_warnings.go:28
+#: pkg/query/aur_warnings.go:67
 msgid "Packages not in AUR:"
 msgstr "不在 AUR 裡的軟體包："
 
-#: pkg/menus/clean_menu.go:53 pkg/menus/clean_menu.go:100
+#: pkg/menus/clean_menu.go:54
 msgid "Packages to cleanBuild?"
 msgstr "清理哪些軟體包的編譯檔案？"
 
-#: pkg/dep/dep_graph.go:215 upgrade.go:213
+#: pkg/dep/dep_graph.go:202
 msgid "Packages to exclude"
 msgstr "要排除的軟體包"
 
-#: pkg/upgrade/service.go:255
+#: pkg/upgrade/service.go:295
 msgid "Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"
 msgstr "要排除的軟體包: (例如: \"1 2 3\", \"1-3\", \"^4\" 或軟體源名稱)"
 
-#: cmd.go:406
+#: cmd.go:402
 msgid "Packages to install (eg: 1 2 3, 1-3 or ^4)"
 msgstr "要安裝的軟體包 (例如: 1 2 3, 1-3 或 ^4)"
 
-#: upgrade.go:210
-msgid "Packages to upgrade."
-msgstr "個要升級的軟體包。"
-
-#: pkg/upgrade/service.go:252
-msgid "Packages to upgrade/install."
-msgstr "個要升級/安裝的軟體包。"
-
-#: print.go:42
+#: print.go:49
 msgid "Popularity"
 msgstr "熱門度"
 
-#: pkg/menus/diff_menu.go:173 pkg/menus/diff_menu.go:206
-#: pkg/menus/edit_menu.go:143 pkg/menus/edit_menu.go:177
+#: pkg/menus/diff_menu.go:172 pkg/menus/edit_menu.go:143
 msgid "Proceed with install?"
 msgstr "繼續安裝？"
 
-#: print.go:34
+#: print.go:37
 msgid "Provides"
 msgstr "提供"
 
-#: pkg/query/aur_info.go:89
-msgid "Querying AUR..."
-msgstr "正在查詢 AUR..."
-
-#: install.go:236 preparer.go:108
+#: pkg/sync/workdir/preparer.go:125
 msgid "Remove make dependencies after install?"
 msgstr "安裝後刪除編譯依賴？"
 
-#: pkg/dep/depPool.go:503 pkg/dep/dep_graph.go:631
+#: print.go:43
+msgid "Replaces"
+msgstr ""
+
+#: pkg/dep/dep_graph.go:730
 msgid "Repository AUR"
 msgstr "AUR 軟體源"
 
-#: pkg/db/ialpm/alpm.go:191 print.go:25
+#: print.go:30 pkg/db/ialpm/alpm.go:191
 msgid "Repository"
 msgstr "軟體源"
 
-#: pkg/dep/dep_graph.go:77
+#: pkg/dep/dep_graph.go:78
 msgid "SRCINFO"
 msgstr "SRCINFO"
 
-#: pkg/upgrade/service.go:63 upgrade.go:73
+#: pkg/upgrade/service.go:72
 msgid "Searching AUR for updates..."
 msgstr "搜尋 AUR 來獲取更新..."
 
-#: pkg/upgrade/service.go:142 upgrade.go:62
+#: pkg/upgrade/service.go:160
 msgid "Searching databases for updates..."
 msgstr "搜尋資料庫來獲取更新..."
 
-#: pkg/query/query_builder.go:191
+#: pkg/query/query_builder.go:214
 msgid "Showing repo packages only"
 msgstr "僅顯示軟體源中的軟體包"
 
-#: print.go:88
+#: print.go:95
 msgid "Size of pacman cache %s: %s"
 msgstr "pacman 快取大小 %s: %s"
 
-#: print.go:91
+#: print.go:98
 msgid "Size of yay cache %s: %s"
 msgstr "yay 快取大小 %s: %s"
 
-#: print.go:56
+#: print.go:62
 msgid "Snapshot URL"
 msgstr "快照網址"
 
-#: pkg/dep/dep_graph.go:75
+#: pkg/dep/dep_graph.go:76
 msgid "Sync"
 msgstr "同步"
 
-#: print.go:93
+#: print.go:100
 msgid "Ten biggest packages:"
 msgstr "前十大的軟體包:"
 
-#: install.go:495 sync.go:183
+#: pkg/sync/sync.go:124
 msgid "The following packages are not compatible with your architecture:"
 msgstr "以下軟體包不支援您的系統架構:"
 
-#: pkg/db/ialpm/alpm.go:179 pkg/dep/depPool.go:499 pkg/dep/dep_graph.go:627
+#: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 msgid "There are %d providers available for %s:"
 msgstr "有 %d 個提供者可用於 %s:"
 
-#: pkg/settings/exe/cmd_builder.go:239
+#: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."
 msgstr "可能還有另一個 Pacman 正在執行。等待中..."
 
-#: print.go:85
+#: print.go:92
 msgid "Total Size occupied by packages: %s"
 msgstr "軟體包佔用的空間: %s"
 
-#: print.go:82
+#: print.go:89
 msgid "Total installed packages: %s"
 msgstr "已安裝的軟體包總數:  %s"
 
-#: install.go:503 sync.go:191
+#: pkg/sync/sync.go:132
 msgid "Try to build them anyway?"
 msgstr "依然嘗試編譯它們？"
 
-#: print.go:30
+#: print.go:34
 msgid "URL"
 msgstr "網址"
 
-#: clean.go:192 pkg/menus/clean_menu.go:64 pkg/menus/clean_menu.go:70
+#: clean.go:194 pkg/menus/clean_menu.go:65 pkg/menus/clean_menu.go:71
 msgid "Unable to clean:"
 msgstr "無法清理："
 
-#: get.go:44 get.go:76
+#: get.go:42 get.go:74
 msgid "Unable to find the following packages:"
 msgstr "找不到下列軟體包:"
 
-#: vote.go:21
+#: vote.go:20
 msgid "Unable to handle package vote for: %s. err: %s"
 msgstr "無法處理軟體包的投票: %s。錯誤: %s"
 
-#: clean.go:169
+#: clean.go:170
 msgid "Unable to remove %s: %s"
 msgstr "無法移除 %s: %s"
 
-#: print.go:28
+#: print.go:32
 msgid "Version"
 msgstr "版本"
 
-#: print.go:41
+#: print.go:50
 msgid "Votes"
 msgstr "得票"
 
-#: print.go:80
+#: print.go:87
 msgid "Yay version v%s"
 msgstr "Yay 版本 v%s"
 
-#: pkg/menus/menu.go:48
+#: pkg/menus/menu.go:49
 msgid "[N]one"
 msgstr "[N]沒有"
 
-#: clean.go:84
+#: clean.go:83
 msgid ""
 "\n"
 "Build directory:"
@@ -527,7 +549,7 @@ msgstr ""
 "\n"
 "編譯資料夾:"
 
-#: pkg/db/ialpm/alpm.go:201 pkg/dep/depPool.go:513 pkg/dep/dep_graph.go:641
+#: pkg/db/ialpm/alpm.go:201 pkg/dep/dep_graph.go:740
 msgid ""
 "\n"
 "Enter a number (default=1): "
@@ -543,15 +565,15 @@ msgstr "由於使用者而中止"
 msgid "argument '-' specified without input on stdin"
 msgstr "指定了引數 '-' 但標準輸入沒有輸入值"
 
-#: local_install.go:27
+#: local_install.go:26
 msgid "cannot find PKGBUILD and .SRCINFO in directory"
 msgstr "目錄內找不到 PKGBUILD 與 .SRCINFO 檔案"
 
-#: install.go:532
+#: pkg/sync/build/pkg_archive.go:148
 msgid "cannot find package name: %v"
 msgstr "找不到軟體包名稱: %v"
 
-#: errors.go:47
+#: pkg/sync/build/errors.go:30
 msgid "could not find PKGDEST for: %s"
 msgstr "找不到 PKGDEST: %s"
 
@@ -559,31 +581,23 @@ msgstr "找不到 PKGDEST: %s"
 msgid "could not find all required packages"
 msgstr "找不到所有需要的軟體包"
 
-#: pkg/dep/depCheck.go:303
-msgid "could not find all required packages:"
-msgstr "找不到所有需要的軟體包:"
-
-#: errors.go:16
+#: pkg/sync/build/errors.go:61
 msgid "could not find any package archives listed in %s"
 msgstr "找不到任何 %s 中列舉的軟體包封存檔"
 
-#: install.go:788
-msgid "could not find srcinfo for: %s"
-msgstr "找不到 srcinfo: %s"
-
-#: errors.go:26
+#: pkg/sync/build/errors.go:50 pkg/upgrade/service.go:287
 msgid "dependency"
 msgstr "作為依賴安裝"
 
-#: pkg/vcs/vcs.go:94 pkg/vcs/vcs.go:98
+#: pkg/vcs/vcs.go:96 pkg/vcs/vcs.go:100
 msgid "devel check for package failed: '%s' encountered an error"
 msgstr "軟體包開發檢查失敗: '%s' 遇到了錯誤"
 
-#: pkg/menus/edit_menu.go:111
+#: pkg/menus/edit_menu.go:110
 msgid "editor did not exit successfully, aborting: %s"
 msgstr "編輯器未成功退出，正在中止: %s"
 
-#: aur_source.go:24
+#: pkg/sync/workdir/aur_source.go:24
 msgid "error downloading sources: %s"
 msgstr "下載套件檔案時出錯: %s"
 
@@ -591,20 +605,19 @@ msgstr "下載套件檔案時出錯: %s"
 msgid "error fetching %s: %s"
 msgstr "取得 %s 時出錯: %s"
 
-#: install.go:321 install.go:455 local_install.go:26
+#: pkg/sync/build/errors.go:9
 msgid "error installing repo packages"
 msgstr "安裝軟體包時出錯"
 
-#: aur_install.go:236 aur_install.go:240
+#: pkg/sync/build/installer.go:266 pkg/sync/build/installer.go:270
 msgid "error installing:"
 msgstr "安裝時出錯："
 
-#: aur_install.go:204 aur_install.go:208 install.go:683 install.go:724
-#: install.go:738 install.go:752
+#: pkg/sync/build/installer.go:233 pkg/sync/build/installer.go:237
 msgid "error making: %s"
 msgstr "編譯時出錯: %s"
 
-#: install.go:588
+#: pkg/sync/workdir/merge.go:24
 msgid "error merging %s: %s"
 msgstr "合併 %s 時出錯: %s"
 
@@ -612,19 +625,19 @@ msgstr "合併 %s 時出錯: %s"
 msgid "error reading %s"
 msgstr "讀取 %s 時出錯"
 
-#: install.go:110 sync.go:37
+#: sync.go:36
 msgid "error refreshing databases"
 msgstr "重新整理資料庫時出錯"
 
-#: clean.go:220 install.go:581
+#: pkg/sync/workdir/clean.go:51 pkg/sync/workdir/merge.go:17
 msgid "error resetting %s: %s"
 msgstr "重置 %s 時出錯: %s"
 
-#: errors.go:29
+#: pkg/sync/build/errors.go:53
 msgid "error updating package install reason to %s"
 msgstr "更新軟體包安裝原因至 %s 時出錯"
 
-#: errors.go:24
+#: pkg/sync/build/errors.go:48
 msgid "explicit"
 msgstr "單獨指定安裝"
 
@@ -632,31 +645,31 @@ msgstr "單獨指定安裝"
 msgid "failed to create directory '%s': %s"
 msgstr "無法建立資料夾 '%s': %s"
 
-#: pkg/settings/config.go:286
+#: pkg/settings/config.go:281
 msgid "failed to open config file '%s': %s"
 msgstr "無法開啟設定檔案 '%s': %s"
 
-#: pkg/srcinfo/service.go:113
+#: pkg/sync/srcinfo/service.go:114
 msgid "failed to parse %s -- skipping: %s"
 msgstr "無法解析 %s -- 跳過: %s"
 
-#: pkg/srcinfo/service.go:117
+#: pkg/sync/srcinfo/service.go:118
 msgid "failed to parse %s: %s"
 msgstr "無法解析 %s: %s"
 
-#: local_install.go:82
+#: local_install.go:77
 msgid "failed to parse .SRCINFO"
 msgstr "無法解析 .SRCINFO"
 
-#: pkg/settings/config.go:296
+#: pkg/settings/config.go:291
 msgid "failed to read config file '%s': %s"
 msgstr "無法讀取設定檔案 '%s': %s"
 
-#: pkg/settings/runtime.go:74
+#: pkg/cmd/graph/main.go:46 pkg/runtime/runtime.go:73
 msgid "failed to retrieve aur Cache"
 msgstr "無法取得 AUR 快取"
 
-#: pkg/upgrade/sources.go:30
+#: pkg/upgrade/sources.go:27
 msgid "ignoring package devel upgrade (no AUR info found):"
 msgstr "忽略軟體包開發更新 (未找到 AUR 資訊):"
 
@@ -664,7 +677,7 @@ msgstr "忽略軟體包開發更新 (未找到 AUR 資訊):"
 msgid "input too long"
 msgstr "輸入太長"
 
-#: pkg/db/ialpm/alpm.go:222 pkg/dep/depPool.go:533 pkg/dep/dep_graph.go:662
+#: pkg/db/ialpm/alpm.go:222 pkg/dep/dep_graph.go:761
 msgid "invalid number: %s"
 msgstr "無效數字: %s"
 
@@ -672,19 +685,19 @@ msgstr "無效數字: %s"
 msgid "invalid option '%s'"
 msgstr "無效選項 '%s'"
 
-#: cmd.go:208
+#: cmd.go:207
 msgid "invalid option: '--deps' and '--explicit' may not be used together"
 msgstr "無效選項: '--deps' 與 '--explicit' 不能同時指定"
 
-#: pkg/download/abs.go:21
+#: pkg/download/abs.go:22
 msgid "invalid repository"
 msgstr "無效軟體源"
 
-#: pkg/db/ialpm/alpm.go:227 pkg/dep/depPool.go:538 pkg/dep/dep_graph.go:668
+#: pkg/db/ialpm/alpm.go:227 pkg/dep/dep_graph.go:767
 msgid "invalid value: %d is not between %d and %d"
 msgstr "無效值: %d 不在 %d 和 %d 之間"
 
-#: pkg/pgp/keys.go:113
+#: pkg/sync/srcinfo/pgp/keys.go:110
 msgid "no keys to import"
 msgstr "沒有要匯入的金鑰"
 
@@ -692,15 +705,15 @@ msgstr "沒有要匯入的金鑰"
 msgid "no query was executed"
 msgstr "沒有查詢被執行"
 
-#: local_install.go:68
+#: local_install.go:66
 msgid "no target directories specified"
 msgstr "沒有指定目標目錄"
 
-#: pkg/text/text.go:69
+#: pkg/text/input.go:48
 msgid "no"
 msgstr "否"
 
-#: aur_install.go:213
+#: pkg/sync/build/installer.go:242
 msgid "nothing to install for %s"
 msgstr "沒有要為 %s 安裝的東西"
 
@@ -708,39 +721,45 @@ msgstr "沒有要為 %s 安裝的東西"
 msgid "only one operation may be used at a time"
 msgstr "一次只能使用一項操作"
 
-#: print.go:158
+#: pkg/cmd/graph/main.go:70
+msgid "only one target is allowed"
+msgstr ""
+
+#: print.go:187
 msgid "package '%s' was not found"
 msgstr "找不到軟體包 '%s'"
-
-#: pkg/dep/depCheck.go:197
-msgid "package conflicts can not be resolved with noconfirm, aborting"
-msgstr "軟體包衝突無法透過 noconfirm 解決，正在中止"
 
 #: pkg/download/errors.go:15
 msgid "package not found in AUR"
 msgstr "AUR 中找不到軟體包"
 
-#: pkg/download/abs.go:22
+#: pkg/download/abs.go:23
 msgid "package not found in repos"
 msgstr "軟體源中找不到軟體包"
 
-#: pkg/pgp/keys.go:103
+#: pkg/upgrade/service.go:292
+#, fuzzy
+msgid "package"
+msgid_plural "packages"
+msgstr[0] "軟體包構造"
+
+#: pkg/sync/srcinfo/pgp/keys.go:100
 msgid "problem importing keys"
 msgstr "匯入金鑰時出錯"
 
-#: clean.go:106
+#: clean.go:105
 msgid "removing AUR packages from cache..."
 msgstr "正在從快取中刪除 AUR 軟體包..."
 
-#: clean.go:177 clean.go:210
+#: clean.go:178 pkg/sync/workdir/clean.go:41
 msgid "removing untracked AUR files from cache..."
 msgstr "正在從暫存中刪除未追蹤的 AUR 檔案..."
 
-#: errors.go:37
+#: pkg/sync/build/errors.go:38
 msgid "the PKGDEST for %s is listed by makepkg but does not exist: %s"
 msgstr "%s 的 PKGDEST 由 makepkg 列出，但不存在: %s"
 
-#: sync.go:110
+#: pkg/sync/sync.go:45
 msgid "there is nothing to do"
 msgstr "無事可做"
 
@@ -748,14 +767,59 @@ msgstr "無事可做"
 msgid "unable to CreateHandle: %s"
 msgstr "無法  CreateHandle: %s"
 
-#: cmd.go:197
+#: cmd.go:196
 msgid "unhandled operation"
 msgstr "未處理的操作"
 
-#: cmd.go:469
+#: cmd.go:460
 msgid "unknown-version"
 msgstr "未知版本"
 
-#: pkg/text/text.go:68
+#: pkg/text/input.go:47
 msgid "yes"
 msgstr "是"
+
+#~ msgid " (Target"
+#~ msgstr " (目標"
+
+#~ msgid " (Wanted by: "
+#~ msgstr " (被這些軟體包依賴: "
+
+#~ msgid "%s not satisfied, flushing install queue"
+#~ msgstr "%s 未滿足，正在重新整理安裝序列"
+
+#~ msgid "Checking for conflicts..."
+#~ msgstr "正在檢查衝突..."
+
+#~ msgid "Checking for inner conflicts..."
+#~ msgstr "正在檢查內部衝突..."
+
+#~ msgid "Conflicting packages will have to be confirmed manually"
+#~ msgstr "必須手動確認衝突的軟體包"
+
+#~ msgid "Inner conflicts found:"
+#~ msgstr "發現內部衝突:"
+
+#~ msgid "Installing %s will remove:"
+#~ msgstr "安裝 %s 將刪除:"
+
+#~ msgid "PKGBUILD up to date, Skipping (%d/%d): %s"
+#~ msgstr "PKGBUILD 是最新的，跳過 (%d/%d): %s"
+
+#~ msgid "Package conflicts found:"
+#~ msgstr "發現軟體包衝突:"
+
+#~ msgid "Packages to upgrade."
+#~ msgstr "個要升級的軟體包。"
+
+#~ msgid "Querying AUR..."
+#~ msgstr "正在查詢 AUR..."
+
+#~ msgid "could not find all required packages:"
+#~ msgstr "找不到所有需要的軟體包:"
+
+#~ msgid "could not find srcinfo for: %s"
+#~ msgstr "找不到 srcinfo: %s"
+
+#~ msgid "package conflicts can not be resolved with noconfirm, aborting"
+#~ msgstr "軟體包衝突無法透過 noconfirm 解決，正在中止"


### PR DESCRIPTION
This PR fixes issue https://github.com/Jguer/yay/issues/2305, refactors the `AURPKGBUILDRepos` function for improved concurrency management, and fixes a critical bug in the Makefile that prevented the `make locale` command from executing properly. The fix involved correcting the `msginit` invocation with the `--no-translator` flag and adding a missing semicolon, which now allows for the proper generation and update of `.po` files. The successful execution of the updated command is reflected in the regenerated localization files included in this PR.