### PR TITLE
fix(dep_graph): fix panic on selecting AUR providers

### DIFF
--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -749,7 +749,7 @@ func (g *Grapher) provideMenu(dep string, options []aur.Pkg) *aur.Pkg {
 		if err != nil {
 			g.logger.Errorln(err)
 
-			break
+			return &options[0]
 		}
 
 		if numberBuf == "" {
@@ -772,8 +772,6 @@ func (g *Grapher) provideMenu(dep string, options []aur.Pkg) *aur.Pkg {
 
 		return &options[num-1]
 	}
-
-	return nil
 }
 
 func makeAURPKGFromSrcinfo(dbExecutor db.Executor, srcInfo *gosrc.Srcinfo) ([]*aur.Pkg, error) {


### PR DESCRIPTION
This commit fixes https://github.com/Jguer/yay/issues/2289 by making `provideMenu` returns the first option when it receives an error input from the user (e.g. user sends EOF).

## How to validate

We can validate this fix by trying to install `libmediawiki`. This package has multiple AUR providers.

### Before

Panic on EOF (<kbd>Ctrl</kbd>+<kbd>D</kbd>)

```
yay -S libmediawiki                                                                                                                                                 ✘ INT
:: There are 2 providers available for kcoreaddons:
:: Repository AUR
    1) kcoreaddons-git 2) kf5-transition-dummy 

Enter a number (default=1): 
==>  -> EOF
 -> runtime error: invalid memory address or nil pointer dereferencegoroutine 1 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:24 +0x5e
main.main.func2()
	github.com/Jguer/yay/v12/main.go:125 +0x45
panic({0x55862194a3e0?, 0x558621bf6680?})
	runtime/panic.go:914 +0x21f
github.com/Jguer/yay/v12/pkg/dep.(*Grapher).findDepsFromAUR(0xc000232140, {0x5586219b8c30, 0x558621c6f440}, {0x5586219bcc58, 0xc000279d10})
	github.com/Jguer/yay/v12/pkg/dep/dep_graph.go:556 +0x8ef
github.com/Jguer/yay/v12/pkg/dep.(*Grapher).addNodes(0xc000232140, {0x5586219b8c30, 0x558621c6f440}, 0xc000216210, {0xc0005a7c50, 0x10}, {0xc000232600?, 0x4, 0x55862199a180?}, 0x1)
	github.com/Jguer/yay/v12/pkg/dep/dep_graph.go:678 +0xe25
github.com/Jguer/yay/v12/pkg/dep.(*Grapher).addDepNodes(0xc000232140, {0x5586219b8c30, 0x558621c6f440}, 0xc0001f4700, 0x55862193eee0?)
	github.com/Jguer/yay/v12/pkg/dep/dep_graph.go:308 +0xbc
github.com/Jguer/yay/v12/pkg/dep.(*Grapher).AddDepsForPkgs(...)
	github.com/Jguer/yay/v12/pkg/dep/dep_graph.go:298
github.com/Jguer/yay/v12/pkg/dep.(*Grapher).GraphFromAUR(0xc000232140, {0x5586219b8c30, 0x558621c6f440}, 0x55862145a148?, {0xc000224120, 0x1, 0x1})
	github.com/Jguer/yay/v12/pkg/dep/dep_graph.go:475 +0xbb1
github.com/Jguer/yay/v12/pkg/dep.(*Grapher).GraphFromTargets(0xc000232140, {0x5586219b8c30, 0x558621c6f440}, 0x6?, {0xc000033e70, 0x1, 0x5586214de445?})
	github.com/Jguer/yay/v12/pkg/dep/dep_graph.go:187 +0x626
main.syncInstall({0x5586219b8c30?, 0x558621c6f440}, 0xc00024e070, 0xc0001b18f0, {0x5586219bcf08, 0xc000250000})
	github.com/Jguer/yay/v12/sync.go:49 +0x759
main.handleSync({0x5586219b8c30, 0x558621c6f440}, 0xc00024e070, 0xc0001b18f0, {0x5586219bcf08, 0xc000250000})
	github.com/Jguer/yay/v12/cmd.go:368 +0x8e5
main.handleCmd({0x5586219b8c30, 0x558621c6f440}, 0xc00024e070, 0xc0001b18f0, {0x5586219bcf08?, 0xc000250000?})
	github.com/Jguer/yay/v12/cmd.go:177 +0x345
main.main()
	github.com/Jguer/yay/v12/main.go:131 +0x6c9
```

### After

Install the first option

```
yay -S libmediawiki
:: There are 2 providers available for kcoreaddons:
:: Repository AUR
    1) kcoreaddons-git 2) kf5-transition-dummy 

Enter a number (default=1): 
==>  -> EOF
AUR Dependency (1): kcoreaddons-git-5.240.0_r1871.g9a8845d4-1
AUR Make Dependency (1): extra-cmake-modules-git-5.246.0.r3657.11dd72b0-1
AUR Explicit (1): libmediawiki-git-5.37.0.r16.g8741b29-1
Sync Make Dependency (8): extra-cmake-modules-5.112.0-1, python-pyqt6-6.6.1-1, sip-6.8.0-1, clang-16.0.6-1, doxygen-1.9.8-1, python-requests-2.31.0-1, qt6-tools-6.6.1-1, python-sphinx-7.2.6-1
Sync Dependency (1): cmake-3.28.0-1
Sync Check Dependency (2): reuse-2.1.0-1, qt6-declarative-6.6.1-1
:: PKGBUILD up to date, skipping download: libmediawiki-git
:: PKGBUILD up to date, skipping download: kcoreaddons-git
:: PKGBUILD up to date, skipping download: extra-cmake-modules-git
  3 libmediawiki-git                         (Build Files Exist)
  2 kcoreaddons-git                          (Build Files Exist)
  1 extra-cmake-modules-git                  (Build Files Exist)
==> Packages to cleanBuild?
==> [N]one [A]ll [Ab]ort [I]nstalled [No]tInstalled or (1 2 3, 1-3, ^4)
==> 
```