### PR TITLE
Remove deprecated warning when using -yc together

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,10 +131,6 @@ func main() {
 	if err = handleCmd(ctx, run, cmdArgs, dbExecutor); err != nil {
 		if str := err.Error(); str != "" {
 			fallbackLog.Errorln(str)
-			if cmdArgs.ExistsArg("c") && cmdArgs.ExistsArg("y") && cmdArgs.Op == "S" {
-				// Remove after 2023-10-01
-				fallbackLog.Errorln("Did you mean 'yay -Yc'?")
-			}
 		}
 
 		exitError := &exec.ExitError{}


### PR DESCRIPTION
This PR removes the deprecation warning that users got when using `-yc` instead of `-Yc`. More information found on #2181.