### PR TITLE
Remove deprecated flags in favor of boolean flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ pacman -S --needed git base-devel yay
 
 - **Yay is not asking me to edit PKGBUILDS, and I don't like the diff menu! What can I do?**
 
-  `yay --editmenu --nodiffmenu --save`
+  `yay --editmenu --diffmenu=false --save`
 
 - **How can I tell Yay to act only on AUR packages, or only on repo packages?**
 

--- a/cmd.go
+++ b/cmd.go
@@ -92,16 +92,12 @@ Permanent configuration options:
     --cleanmenu           Give the option to clean build PKGBUILDS
     --diffmenu            Give the option to show diffs for build files
     --editmenu            Give the option to edit/view PKGBUILDS
-    --nocleanmenu         Don't clean build PKGBUILDS
-    --nodiffmenu          Don't show diffs for build files
-    --noeditmenu          Don't edit/view PKGBUILDS
     --askremovemake       Ask to remove makedepends after install
     --askyesremovemake    Ask to remove makedepends after install("Y" as default)
     --removemake          Remove makedepends after install
     --noremovemake        Don't remove makedepends after install
 
     --cleanafter          Remove package sources after successful install
-    --nocleanafter        Do not remove package sources after successful build
     --keepsrc             Keep pkg/ and src/ after building packages
     --bottomup            Shows AUR's packages first and then repository's
     --topdown             Shows repository's packages first and then AUR's
@@ -109,7 +105,6 @@ Permanent configuration options:
     --doublelineresults   List each search result on two lines, like pacman
 
     --devel               Check development packages during sysupgrade
-    --nodevel             Do not check development packages
     --rebuild             Always build target packages
     --rebuildall          Always build all AUR packages
     --norebuild           Skip package build if in cache and up to date
@@ -118,19 +113,14 @@ Permanent configuration options:
     --noredownload        Skip pkgbuild download if in cache and up to date
     --redownloadall       Always download pkgbuilds of all AUR packages
     --provides            Look for matching providers when searching for packages
-    --noprovides          Just look for packages by pkgname
     --pgpfetch            Prompt to import PGP keys from PKGBUILDs
-    --nopgpfetch          Don't prompt to import PGP keys
     --useask              Automatically resolve conflicts using pacman's ask flag
-    --nouseask            Confirm conflicts manually during the install
 
     --sudo                <file>  sudo command to use
     --sudoflags           <flags> Pass arguments to sudo
     --sudoloop            Loop sudo calls in the background to avoid timeout
-    --nosudoloop          Do not loop sudo calls in the background
 
     --timeupdate          Check packages' AUR page for changes during sysupgrade
-    --notimeupdate        Do not check packages' AUR page for changes
 
 show specific options:
     -c --complete         Used for completions

--- a/completions/bash
+++ b/completions/bash
@@ -69,14 +69,14 @@ _yay() {
   ##yay stuff
   common=('arch cachedir color config confirm dbpath debug gpgdir help hookdir logfile
           noconfirm noprogressbar noscriptlet quiet root verbose
-          makepkg pacman git gpg gpgflags config requestsplitn sudoloop nosudoloop
+          makepkg pacman git gpg gpgflags config requestsplitn sudoloop
           redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild sortby
           singlelineresults doublelineresults answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
-          noansweredit noanswerupgrade cleanmenu diffmenu editmenu cleanafter nocleanafter keepsrc
-          nocleanmenu nodiffmenu provides noprovides pgpfetch nopgpfetch
-          useask nouseask combinedupgrade nocombinedupgrade aur repo makepkgconf
+          noansweredit noanswerupgrade cleanmenu diffmenu editmenu cleanafter keepsrc
+          provides pgpfetch
+          useask combinedupgrade aur repo makepkgconf
           nomakepkgconf askremovemake askyesremovemake removemake noremovemake completioninterval aururl aurrpcurl
-          searchby batchinstall nobatchinstall'
+          searchby batchinstall'
     'b d h q r v')
   yays=('clean gendb' 'c')
   show=('complete defaultconfig currentconfig stats news' 'c d g s w')

--- a/completions/fish
+++ b/completions/fish
@@ -216,9 +216,6 @@ complete -c $progname -n "not $noopt" -l noanswerupgrade -d 'Unset the answer fo
 complete -c $progname -n "not $noopt" -l cleanmenu -d 'Give the option to clean build PKGBUILDS' -f
 complete -c $progname -n "not $noopt" -l diffmenu -d 'Give the option to show diffs for build files' -f
 complete -c $progname -n "not $noopt" -l editmenu -d 'Give the option to edit/view PKGBUILDS' -f
-complete -c $progname -n "not $noopt" -l nocleanmenu -d 'Do not clean build PKGBUILDS' -f
-complete -c $progname -n "not $noopt" -l nodiffmenu -d 'Do not show diffs for build files' -f
-complete -c $progname -n "not $noopt" -l noeditmenu -d 'Do not edit/view PKGBUILDS' -f
 complete -c $progname -n "not $noopt" -l askremovemake -d 'Ask to remove make deps after install' -f
 complete -c $progname -n "not $noopt" -l askyesremovemake -d 'Ask to remove make deps after install(with "Y" as default)' -f
 complete -c $progname -n "not $noopt" -l removemake -d 'Remove make deps after install' -f
@@ -228,25 +225,17 @@ complete -c $progname -n "not $noopt" -l bottomup -d 'Shows aur packages first a
 complete -c $progname -n "not $noopt" -l singlelineresults -d 'List each search result on its own line' -f
 complete -c $progname -n "not $noopt" -l doublelineresults -d 'List each search result on two lines, like pacman' -f
 complete -c $progname -n "not $noopt" -l devel -d 'Check -git/-svn/-hg development version' -f
-complete -c $progname -n "not $noopt" -l nodevel -d 'Disable development version checking' -f
 complete -c $progname -n "not $noopt" -l cleanafter -d 'Clean package sources after successful build' -f
-complete -c $progname -n "not $noopt" -l nocleanafter -d 'Disable package sources cleaning' -f
 complete -c $progname -n "not $noopt" -l keepsrc -d 'Keep pkg/ and src/ after building packages' -f
 complete -c $progname -n "not $noopt" -l timeupdate -d 'Check package modification date and version' -f
-complete -c $progname -n "not $noopt" -l notimeupdate -d 'Check only package version change' -f
 complete -c $progname -n "not $noopt" -l redownload -d 'Redownload PKGBUILD of package even if up-to-date' -f
 complete -c $progname -n "not $noopt" -l redownloadall -d 'Redownload PKGBUILD of package and deps even if up-to-date' -f
 complete -c $progname -n "not $noopt" -l noredownload -d 'Do not redownload up-to-date PKGBUILDs' -f
 complete -c $progname -n "not $noopt" -l provides -d 'Look for matching providers when searching for packages' -f
-complete -c $progname -n "not $noopt" -l noprovides -d 'Just look for packages by pkgname' -f
 complete -c $progname -n "not $noopt" -l pgpfetch -d 'Prompt to import PGP keys from PKGBUILDs' -f
-complete -c $progname -n "not $noopt" -l nopgpfetch -d 'Do not prompt to import PGP keys' -f
 complete -c $progname -n "not $noopt" -l useask -d 'Automatically resolve conflicts using pacmans ask flag' -f
-complete -c $progname -n "not $noopt" -l nouseask -d 'Confirm conflicts manually during the install' -f
 complete -c $progname -n "not $noopt" -l combinedupgrade -d 'Refresh then perform the repo and AUR upgrade together' -f
-complete -c $progname -n "not $noopt" -l nocombinedupgrade -d 'Perform the repo upgrade and AUR upgrade separately' -f
 complete -c $progname -n "not $noopt" -l batchinstall -d 'Build multiple AUR packages then install them together' -f
-complete -c $progname -n "not $noopt" -l nobatchinstall -d 'Build and install each AUR package one by one' -f
 complete -c $progname -n "not $noopt" -l rebuild -d 'Always build target packages' -f
 complete -c $progname -n "not $noopt" -l rebuildall -d 'Always build all AUR packages' -f
 complete -c $progname -n "not $noopt" -l rebuildtree -d 'Always build all AUR packages even if installed' -f
@@ -254,4 +243,3 @@ complete -c $progname -n "not $noopt" -l norebuild -d 'Skip package build if in 
 complete -c $progname -n "not $noopt" -l mflags -d 'Pass the following options to makepkg' -f
 complete -c $progname -n "not $noopt" -l gpgflags -d 'Pass the following options to gpg' -f
 complete -c $progname -n "not $noopt" -l sudoloop -d 'Loop sudo calls in the background to avoid timeout' -f
-complete -c $progname -n "not $noopt" -l nosudoloop -d 'Do not loop sudo calls in the background' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -70,9 +70,6 @@ _pacman_opts_common=(
 	'--cleanmenu[Give the option to clean build PKGBUILDS]'
 	'--diffmenu[Give the option to show diffs for build files]'
 	'--editmenu[Give the option to edit/view PKGBUILDS]'
-	"--nocleanmenu[Don't clean build PKGBUILDS]"
-	"--nodiffmenu[Don't show diffs for build files]"
-	"--noeditmenu[Don't edit/view PKGBUILDS]"
 	"--askremovemake[Ask to remove makedepends after install]"
 	"--askyesremovemake[Ask to remove makedepends after install(with "Y" as default)]"
 	"--removemake[Remove makedepends after install]"
@@ -83,35 +80,26 @@ _pacman_opts_common=(
 	'--singlelineresults[List each search result on its own line]'
 	'--doublelineresults[List each search result on two lines, like pacman]'
 	'--devel[Check -git/-svn/-hg development version]'
-	'--nodevel[Disable development version checking]'
 	'--cleanafter[Clean package sources after successful build]'
-	'--nocleanafter[Disable package sources cleaning after successful build]'
 	'--keepsrc[Keep pkg/ and src/ after building packages]'
 	'--timeupdate[Check packages modification date and version]'
-	'--notimeupdate[Check only package version change]'
 	'--redownload[Always download pkgbuilds of targets]'
 	'--redownloadall[Always download pkgbuilds of all AUR packages]'
 	'--noredownload[Skip pkgbuild download if in cache and up to date]'
 	'--rebuild[Always build target packages]'
 	'--rebuildall[Always build all AUR packages]'
 	'--provides[Look for matching providers when searching for packages]'
-	'--noprovides[Just look for packages by pkgname]'
 	'--pgpfetch[Prompt to import PGP keys from PKGBUILDs]'
-	"--nopgpfetch[Don't prompt to import PGP keys]"
 	"--useask[Automatically resolve conflicts using pacman's ask flag]"
-	'--nouseask[Confirm conflicts manually during the install]'
 	'--combinedupgrade[Refresh then perform the repo and AUR upgrade together]'
-	'--nocombinedupgrade[Perform the repo upgrade and AUR upgrade separately]'
 	'--rebuildtree[Always build all AUR packages even if installed]'
 	'--norebuild[Skip package build if in cache and up to date]'
 	'--mflags[Pass arguments to makepkg]:mflags'
 	'--gpgflags[Pass arguments to gpg]:gpgflags'
 	'--sudoloop[Loop sudo calls in the background to avoid timeout]'
-	'--nosudoloop[Do not loop sudo calls in the background]'
 	'--searchby[Search for packages using a specified field]'
 	'--sortby[Sort AUR results by a specific field during search]'
 	'--batchinstall[Build multiple AUR packages then install them together]'
-	'--nobatchinstall[Build and install each AUR package one by one]'
 )
 
 # options for passing to _arguments: options for --upgrade commands

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -314,18 +314,6 @@ before building.
 recommended to edit pkgbuild variables unless you know what you are doing.
 
 .TP
-.B \-\-nocleanmenu *Deprecated*
-Do not show the clean menu.
-
-.TP
-.B \-\-nodiffmenu *Deprecated*
-Do not show the diff menu.
-
-.TP
-.B \-\-noeditmenu *Deprecated*
-Do not show the edit menu.
-
-.TP
 .B \-\-askremovemake
 Ask to remove makedepends after installing packages.
 
@@ -375,20 +363,12 @@ If 'devel' is enabled in the configuration file, you can temporarily disable it 
 using '--devel=false' on the command line
 
 .TP
-.B \-\-nodevel *Deprecated*
-Do not check for development packages updates during sysupgrade.
-
-.TP
 .B \-\-cleanafter
 Remove untracked files after installation.
 
 Untracked files are removed with the exception of directories.
 This allows VCS packages to easily pull an update
 instead of having to reclone the entire repo.
-
-.TP
-.B \-\-nocleanafter *Deprecated*
-Do not remove package sources after successful Install.
 
 .TP
 .B \-\-keepsrc
@@ -400,16 +380,8 @@ During sysupgrade also compare the build time of installed packages against
 the last modification time of each package's AUR page.
 
 .TP
-.B \-\-notimeupdate *Deprecated*
-Do not consider build times during sysupgrade.
-
-.TP
 .B \-\-separatesources
 Separate query results by source, AUR and sync
-
-.TP
-.B \-\-noseparatesources *Deprecated*
-Do not separate query results by source for searching
 
 .TP
 .B \-\-redownload
@@ -432,21 +404,9 @@ providers are found a menu will appear prompting you to pick one. This
 increases dependency resolve time although this should not be noticeable.
 
 .TP
-.B \-\-noprovides *Deprecated*
-Do not look for matching providers when searching for AUR packages.
-Yay will never show its provider menu but Pacman will still show its
-provider menu for repo packages.
-
-.TP
 .B \-\-pgpfetch
 Prompt to import unknown PGP keys from the \fBvalidpgpkeys\fR field of each
 PKGBUILD.
-
-.TP
-.B \-\-nopgpfetch *Deprecated*
-Do not prompt to import unknown PGP keys. This is likely to cause a build
-failure unless using options such as \fB\-\-skippgpcheck\fR or a customized
-gpg config\%.
 
 .TP
 .B \-\-useask
@@ -454,11 +414,6 @@ Use pacman's --ask flag to automatically confirm package conflicts. Yay lists
 conflicts ahead of time. It is possible that Yay does not detect
 a conflict, causing a package to be removed without the user's confirmation.
 However, this is very unlikely.
-
-.TP
-.B \-\-nouseask *Deprecated*
-Manually resolve package conflicts during the install. Packages which do not
-conflict will not need to be confined manually.
 
 .TP
 .B \-\-combinedupgrade
@@ -472,21 +427,11 @@ the user's responsibility to either resolve the reason Yay exited or run
 a sysupgrade through pacman directly.
 
 .TP
-.B \-\-nocombinedupgrade *Deprecated*
-During sysupgrade, Pacman \-Syu will be called, then the AUR upgrade will
-start. This means the upgrade menu and pkgbuild review will be performed
-after the sysupgrade has finished.
-
-.TP
 .B \-\-batchinstall
 When building and installing AUR packages instead of installing each package
 after building, queue each package for install. Then once either all packages
 are built or a package in the build queue is needed as a dependency to build
 another package, install all the packages in the install queue.
-
-.TP
-.B \-\-nobatchinstall *Deprecated*
-Always install AUR packages immediately after building them.
 
 .TP
 .B \-\-rebuild
@@ -540,10 +485,6 @@ separated list that is quoted by the shell.
 .B \-\-sudoloop
 Loop sudo calls in the background to prevent sudo from timing out during long
 builds.
-
-.TP
-.B \-\-nosudoloop *Deprecated*
-Do not loop sudo calls in the background.
 
 .SH EXAMPLES
 .TP

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	cmdArgs := parser.MakeArguments()
 
 	// Parse command line
-	if err = cfg.ParseCommandLine(cmdArgs, fallbackLog); err != nil {
+	if err = cfg.ParseCommandLine(cmdArgs); err != nil {
 		if str := err.Error(); str != "" {
 			fallbackLog.Errorln(str)
 		}

--- a/pkg/cmd/graph/main.go
+++ b/pkg/cmd/graph/main.go
@@ -25,7 +25,7 @@ func handleCmd(logger *text.Logger) error {
 	}
 
 	cmdArgs := parser.MakeArguments()
-	if errP := cfg.ParseCommandLine(cmdArgs, logger); errP != nil {
+	if errP := cfg.ParseCommandLine(cmdArgs); errP != nil {
 		return errP
 	}
 

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -5,24 +5,21 @@ import (
 	"strings"
 
 	"github.com/Jguer/yay/v12/pkg/settings/parser"
-	"github.com/Jguer/yay/v12/pkg/text"
-
-	"github.com/leonelquinteros/gotext"
 )
 
-func (c *Configuration) ParseCommandLine(a *parser.Arguments, logger *text.Logger) error {
+func (c *Configuration) ParseCommandLine(a *parser.Arguments) error {
 	if err := a.Parse(); err != nil {
 		return err
 	}
 
-	c.extractYayOptions(a, logger)
+	c.extractYayOptions(a)
 
 	return nil
 }
 
-func (c *Configuration) extractYayOptions(a *parser.Arguments, logger *text.Logger) {
+func (c *Configuration) extractYayOptions(a *parser.Arguments) {
 	for option, value := range a.Options {
-		if c.handleOption(option, value.First(), logger) {
+		if c.handleOption(option, value.First()) {
 			a.DelArg(option)
 		}
 	}
@@ -44,7 +41,7 @@ func (c *Configuration) extractYayOptions(a *parser.Arguments, logger *text.Logg
 	}
 }
 
-func (c *Configuration) handleOption(option, value string, logger *text.Logger) bool {
+func (c *Configuration) handleOption(option, value string) bool {
 	boolValue, err := strconv.ParseBool(value)
 	if err != nil {
 		boolValue = true
@@ -59,9 +56,6 @@ func (c *Configuration) handleOption(option, value string, logger *text.Logger) 
 		c.SaveConfig = boolValue
 	case "afterclean", "cleanafter":
 		c.CleanAfter = boolValue
-	case "noafterclean", "nocleanafter":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--cleanafter=false' instead", option))
-		c.CleanAfter = !boolValue
 	case "keepsrc":
 		c.KeepSrc = boolValue
 	case "debug":
@@ -69,14 +63,8 @@ func (c *Configuration) handleOption(option, value string, logger *text.Logger) 
 		return !boolValue
 	case "devel":
 		c.Devel = boolValue
-	case "nodevel":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--devel=false' instead", option))
-		c.Devel = !boolValue
 	case "timeupdate":
 		c.TimeUpdate = boolValue
-	case "notimeupdate":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--timeupdate=false' instead", option))
-		c.TimeUpdate = !boolValue
 	case "topdown":
 		c.BottomUp = false
 	case "bottomup":
@@ -114,9 +102,6 @@ func (c *Configuration) handleOption(option, value string, logger *text.Logger) 
 		c.ReBuild = parser.RebuildModeNo
 	case "batchinstall":
 		c.BatchInstall = boolValue
-	case "nobatchinstall":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--batchinstall=false' instead", option))
-		c.BatchInstall = !boolValue
 	case "answerclean":
 		c.AnswerClean = value
 	case "noanswerclean":
@@ -168,44 +153,20 @@ func (c *Configuration) handleOption(option, value string, logger *text.Logger) 
 		}
 	case "sudoloop":
 		c.SudoLoop = boolValue
-	case "nosudoloop":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--sudoloop=false' instead", option))
-		c.SudoLoop = !boolValue
 	case "provides":
 		c.Provides = boolValue
-	case "noprovides":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--provides=false' instead", option))
-		c.Provides = !boolValue
 	case "pgpfetch":
 		c.PGPFetch = boolValue
-	case "nopgpfetch":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--pgpfetch=false' instead", option))
-		c.PGPFetch = !boolValue
 	case "cleanmenu":
 		c.CleanMenu = boolValue
-	case "nocleanmenu":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--cleanmenu=false' instead", option))
-		c.CleanMenu = !boolValue
 	case "diffmenu":
 		c.DiffMenu = boolValue
-	case "nodiffmenu":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--diffmenu=false' instead", option))
-		c.DiffMenu = !boolValue
 	case "editmenu":
 		c.EditMenu = boolValue
-	case "noeditmenu":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--editmenu=false' instead", option))
-		c.EditMenu = !boolValue
 	case "useask":
 		c.UseAsk = boolValue
-	case "nouseask":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--useask=false' instead", option))
-		c.UseAsk = !boolValue
 	case "combinedupgrade":
 		c.CombinedUpgrade = boolValue
-	case "nocombinedupgrade":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--combinedupgrade=false' instead", option))
-		c.CombinedUpgrade = !boolValue
 	case "a", "aur":
 		c.Mode = parser.ModeAUR
 	case "repo":
@@ -220,9 +181,6 @@ func (c *Configuration) handleOption(option, value string, logger *text.Logger) 
 		c.RemoveMake = "askyes"
 	case "separatesources":
 		c.SeparateSources = boolValue
-	case "noseparatesources":
-		logger.Warnln(gotext.Get("'--%s' is deprecated. Use '--separatesources=false' instead", option))
-		c.SeparateSources = !boolValue
 	default:
 		return false
 	}

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -377,12 +377,9 @@ func isArg(arg string) bool {
 	case "aurrpcurl":
 	case "save":
 	case "afterclean", "cleanafter":
-	case "noafterclean", "nocleanafter":
 	case "keepsrc":
 	case "devel":
-	case "nodevel":
 	case "timeupdate":
-	case "notimeupdate":
 	case "topdown":
 	case "bottomup":
 	case "completioninterval":
@@ -396,7 +393,6 @@ func isArg(arg string) bool {
 	case "rebuildtree":
 	case "norebuild":
 	case "batchinstall":
-	case "nobatchinstall":
 	case "answerclean":
 	case "noanswerclean":
 	case "answerdiff":
@@ -421,21 +417,13 @@ func isArg(arg string) bool {
 	case "sudoflags":
 	case "requestsplitn":
 	case "sudoloop":
-	case "nosudoloop":
 	case "provides":
-	case "noprovides":
 	case "pgpfetch":
-	case "nopgpfetch":
 	case "cleanmenu":
-	case "nocleanmenu":
 	case "diffmenu":
-	case "nodiffmenu":
 	case "editmenu":
-	case "noeditmenu":
 	case "useask":
-	case "nouseask":
 	case "combinedupgrade":
-	case "nocombinedupgrade":
 	case "a", "aur":
 	case "repo":
 	case "removemake":
@@ -450,7 +438,7 @@ func isArg(arg string) bool {
 	case "defaultconfig":
 	case "singlelineresults":
 	case "doublelineresults":
-	case "separatesources", "noseparatesources":
+	case "separatesources":
 	default:
 		return false
 	}


### PR DESCRIPTION
This removes the deprecated flags from #2285. The deprecated messages are still in the `*.po` files. I can remove those manually, but is there a better way to do that?