### PR TITLE
add short option for --repo

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -54,7 +54,7 @@ If no operation is specified 'yay -Syu' will be performed
 If no operation is specified and targets are provided -Y will be assumed
 
 New options:
-       --repo             Assume targets are from the repositories
+    -N --repo             Assume targets are from the repositories
     -a --aur              Assume targets are from the AUR
 
 Permanent configuration options:

--- a/completions/bash
+++ b/completions/bash
@@ -61,7 +61,7 @@ _yay() {
           search unrequired upgrades' 'c e g i k l m n o p s t u')
   remove=('cascade dbonly nodeps assume-installed nosave print recursive unneeded' 'c n p s u')
   sync=('asdeps asexplicit clean dbonly downloadonly overwrite groups ignore ignoregroup
-         info list needed nodeps assume-installed print refresh recursive search sysupgrade'
+         info list needed nodeps assume-installed print refresh recursive search sysupgrade aur repo'
     'c g i l p s u w y a N')
   upgrade=('asdeps asexplicit overwrite needed nodeps assume-installed print recursive' 'p')
   core=('database files help query remove sync upgrade version' 'D F Q R S U V h')

--- a/completions/bash
+++ b/completions/bash
@@ -62,7 +62,7 @@ _yay() {
   remove=('cascade dbonly nodeps assume-installed nosave print recursive unneeded' 'c n p s u')
   sync=('asdeps asexplicit clean dbonly downloadonly overwrite groups ignore ignoregroup
          info list needed nodeps assume-installed print refresh recursive search sysupgrade'
-    'c g i l p s u w y')
+    'c g i l p s u w y a N')
   upgrade=('asdeps asexplicit overwrite needed nodeps assume-installed print recursive' 'p')
   core=('database files help query remove sync upgrade version' 'D F Q R S U V h')
 

--- a/completions/fish
+++ b/completions/fish
@@ -165,7 +165,7 @@ complete -c $progname -n "$webspecific" -s u -l unvote -d 'Unvote for AUR packag
 complete -c $progname -n "$webspecific" -xa "$listall"
 
 # New options
-complete -c $progname -n "not $noopt" -l repo -d 'Assume targets are from the AUR' -f
+complete -c $progname -n "not $noopt" -s N -l repo -d 'Assume targets are from the AUR' -f
 complete -c $progname -n "not $noopt" -s a -l aur -d 'Assume targets are from the repositories' -f
 
 # Yay options

--- a/completions/zsh
+++ b/completions/zsh
@@ -23,7 +23,7 @@ _pacman_opts_commands=(
 
 # options for passing to _arguments: options common to all commands
 _pacman_opts_common=(
-	'--repo[Assume targets are from the repositories]'
+	{-N,--repo}'[Assume targets are from the repositories]'
 	{-a,--aur}'[Assume targets are from the AUR]'
 	'--aururl[Set an alternative AUR URL]:url'
 	'--aurrpcurl[Set an alternative URL for the AUR /rpc endpoint]:url'

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -63,7 +63,7 @@ Yay will also remove cached data about devel packages.
 
 .SH NEW OPTIONS
 .TP
-.B    \-\-repo
+.B \-N, \-\-repo
 Assume all targets are from the repositories. Additionally Actions such as
 sysupgrade will only act on repository packages.
 

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -169,7 +169,7 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.CombinedUpgrade = boolValue
 	case "a", "aur":
 		c.Mode = parser.ModeAUR
-	case "repo":
+	case "N", "repo":
 		c.Mode = parser.ModeRepo
 	case "removemake":
 		c.RemoveMake = "yes"

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -425,7 +425,7 @@ func isArg(arg string) bool {
 	case "useask":
 	case "combinedupgrade":
 	case "a", "aur":
-	case "repo":
+	case "N", "repo":
 	case "removemake":
 	case "noremovemake":
 	case "askremovemake":


### PR DESCRIPTION
Add short option for the existing `--repo` option.

Decided to go with `-N` for "native" as `-n` is already [taken](https://github.com/Jguer/yay/blob/f7f2169992143d7e6d70fc32a4a2ea0d57fe730b/pkg/settings/parser/parser.go#L358). Open to changing, though.

Closes https://github.com/Jguer/yay/issues/2082