### PR TITLE
Replace github.com/pkg/errors with stdlib errors/fmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/ohler55/ojg v1.21.4 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/ohler55/ojg v1.21.4 h1:2iWyz/xExx0XySVIxR9kWFxIdsLNrpWLrKuAcs5aOZU=
 github.com/ohler55/ojg v1.21.4/go.mod h1:gQhDVpQLqrmnd2eqGAvJtn+NfKoYJbe/A4Sj3/Vro4o=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/local_install.go
+++ b/local_install.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,7 +21,6 @@ import (
 
 	gosrc "github.com/Morganamilo/go-srcinfo"
 	"github.com/leonelquinteros/gotext"
-	"github.com/pkg/errors"
 )
 
 var ErrNoBuildFiles = errors.New(gotext.Get("cannot find PKGBUILD and .SRCINFO in directory"))
@@ -74,7 +74,7 @@ func installLocalPKGBUILD(
 
 		pkgbuild, err := gosrc.ParseFile(filepath.Join(targetDir, ".SRCINFO"))
 		if err != nil {
-			return errors.Wrap(err, gotext.Get("failed to parse .SRCINFO"))
+			return fmt.Errorf("%s: %w", gotext.Get("failed to parse .SRCINFO"), err)
 		}
 
 		srcInfos[targetDir] = pkgbuild

--- a/pkg/cmd/graph/main.go
+++ b/pkg/cmd/graph/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +16,6 @@ import (
 
 	"github.com/Jguer/aur/metadata"
 	"github.com/leonelquinteros/gotext"
-	"github.com/pkg/errors"
 )
 
 func handleCmd(logger *text.Logger) error {
@@ -43,7 +43,7 @@ func handleCmd(logger *text.Logger) error {
 		metadata.WithCacheFilePath(
 			filepath.Join(cfg.BuildDir, "aur.json")))
 	if err != nil {
-		return errors.Wrap(err, gotext.Get("failed to retrieve aur Cache"))
+		return fmt.Errorf("%s: %w", gotext.Get("failed to retrieve aur Cache"), err)
 	}
 
 	grapher := dep.NewGrapher(dbExecutor, aurCache, true, settings.NoConfirm,


### PR DESCRIPTION
https://github.com/pkg/errors is archived and effectively sunsetted, see https://github.com/pkg/errors/issues/245 for details. The standard library suffices nowadays.