### PR TITLE
Use Go 1.21's min/max built-ins

### DIFF
--- a/pkg/intrange/intrange.go
+++ b/pkg/intrange/intrange.go
@@ -42,24 +42,6 @@ func (rs IntRanges) Get(n int) bool {
 	return false
 }
 
-// Min returns min value between a and b.
-func Min(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
-// Max returns max value between a and b.
-func Max(a, b int) int {
-	if a < b {
-		return b
-	}
-
-	return a
-}
-
 // ParseNumberMenu parses input for number menus split by spaces or commas
 // supports individual selection: 1 2 3 4
 // supports range selections: 1-4 10-20
@@ -116,8 +98,8 @@ func ParseNumberMenu(input string) (include, exclude IntRanges,
 			num2 = num1
 		}
 
-		mi := Min(num1, num2)
-		ma := Max(num1, num2)
+		mi := min(num1, num2)
+		ma := max(num1, num2)
 
 		if !invert {
 			include = append(include, makeIntRange(mi, ma))

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -3,7 +3,6 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 
@@ -195,7 +194,7 @@ func (u *UpgradeService) graphToUpSlice(graph *topo.Graph[string, *dep.InstallIn
 		parents := graph.ImmediateDependencies(name)
 		extra := ""
 		if len(parents) > 0 && !info.Upgrade && info.Reason == dep.MakeDep {
-			reducedParents := parents.Slice()[:int(math.Min(cutOffExtra, float64(len(parents))))]
+			reducedParents := parents.Slice()[:min(cutOffExtra, len(parents))]
 			if len(parents) > cutOffExtra {
 				reducedParents = append(reducedParents, "...")
 			}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/Jguer/yay/v12/pkg/db"
-	"github.com/Jguer/yay/v12/pkg/intrange"
 	"github.com/Jguer/yay/v12/pkg/query"
 	"github.com/Jguer/yay/v12/pkg/text"
 )
@@ -61,8 +60,8 @@ func (u UpSlice) Print(logger *text.Logger) {
 		packNameLen := len(StylizedNameWithRepository(upgrade))
 		packVersion, _ := query.GetVersionDiff(upgrade.LocalVersion, upgrade.RemoteVersion)
 		packVersionLen := len(packVersion)
-		longestName = intrange.Max(packNameLen, longestName)
-		longestVersion = intrange.Max(packVersionLen, longestVersion)
+		longestName = max(packNameLen, longestName)
+		longestVersion = max(packVersionLen, longestVersion)
 	}
 
 	lenUp := len(u.Up)
@@ -94,8 +93,8 @@ func (u UpSlice) PrintDeps(logger *text.Logger) {
 		packNameLen := len(StylizedNameWithRepository(upgrade))
 		packVersion, _ := query.GetVersionDiff(upgrade.LocalVersion, upgrade.RemoteVersion)
 		packVersionLen := len(packVersion)
-		longestName = intrange.Max(packNameLen, longestName)
-		longestVersion = intrange.Max(packVersionLen, longestVersion)
+		longestName = max(packNameLen, longestName)
+		longestVersion = max(packVersionLen, longestVersion)
 	}
 
 	lenUp := len(u.PulledDeps)


### PR DESCRIPTION
This simplifies the code compared to either rolling our own or awkwardly using math's float functions with integers.