### PR TITLE
change chain-command within readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ makepkg -si
 If you want to do all of this at once, we can chain the commands like so:
 
 ```sh
-pacman -S --needed git base-devel && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si
+sudo pacman -S --needed git base-devel && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si
 ```
 
 ### Binary


### PR DESCRIPTION
I propose we change the chain-command within the readme from;

`pacman -S --needed git base-devel && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si`

to

`sudo pacman -S --needed git base-devel && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si`

The only command in this that needs sudo is pacman- and running the full command **as root does not work**;
```
==> ERROR: Running makepkg as root is not allowed as it can cause permanent,
catastrophic damage to your system.
```

This new commands satisfies the usage of sudo (pacman needs root) without overusing it and receiving an error from makepkg. 