### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ If you are migrating from another AUR helper, you can simply install Yay with th
 The initial installation of Yay can be done by cloning the PKGBUILD and
 building with makepkg:
 
-We start with updating the package lists and make sure we have the `base-devel` package group installed.
+We make sure we have the `base-devel` package group installed.
 
 ```sh
-pacman -Sy --needed git base-devel
+pacman -S --needed git base-devel
 git clone https://aur.archlinux.org/yay.git
 cd yay
 makepkg -si


### PR DESCRIPTION
Update the README to prevent partial upgrades.

Partial upgrades are dangerous on Arch Linux.
Partial upgrades may occur when a `-y` operation is given without a corresponding `-u` operation.

Quote from the ArchWiki:
> Do not use:
> `pacman -Sy package`
> `pacman -Sy` followed by `pacman -S` package (Note the absence of `-S**u**` in the installation of the package.)
> `pacman -Syuw` (Note that `pacman -Syuw` does imply the same risks like pacman -Sy`, as it will update the pacman sync database without installing the newer packages.)

https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported