### PR TITLE
Respect provided targets when using -Si flag

### DIFF
--- a/query.go
+++ b/query.go
@@ -46,7 +46,13 @@ func syncInfo(ctx context.Context, run *runtime.Runtime,
 	aurS, repoS := packageSlices(pkgS, run.Cfg, dbExecutor)
 
 	if len(repoS) == 0 && len(aurS) == 0 {
-		aurS = dbExecutor.InstalledRemotePackageNames()
+		if run.Cfg.Mode != parser.ModeRepo {
+			aurS = dbExecutor.InstalledRemotePackageNames()
+		}
+
+		if run.Cfg.Mode != parser.ModeAUR {
+			repoS = dbExecutor.InstalledSyncPackageNames()
+		}
 	}
 
 	if len(aurS) != 0 {


### PR DESCRIPTION
This adds more to the fix in #2459 to work with the `-a (--aur)` and `--repo` flags. Checks to make sure each target is specifically (through the `--aur` or `--repo` flags) or implicitly (none of those flags are specified) specified before filling the `aurS` and `repoS` slices.