### PR TITLE
feat(su): add run0 to the list of alternative privilege elevators

### DIFF
--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -179,7 +179,7 @@ func (c *Configuration) setPrivilegeElevator() error {
 	c.SudoFlags = ""
 	c.SudoLoop = false
 
-	for _, bin := range [...]string{"doas", "pkexec", "su"} {
+	for _, bin := range [...]string{"doas", "run0", "pkexec", "su"} {
 		if _, err := exec.LookPath(bin); err == nil {
 			c.SudoBin = bin
 			return nil // command existing


### PR DESCRIPTION
systemd 256 introduces the run0 based on systemd-run, as an alternative to sudo/doas without being a SUID binary.

TODO:
- [ ] Add config tests
- [ ] Add `--background=` flag to prevent red background color