### PR TITLE
Fix incompatible Pacman flags when listing packages

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -459,6 +459,10 @@ func syncList(ctx context.Context, run *runtime.Runtime,
 	}
 
 	if run.Cfg.Mode.AtLeastRepo() && (len(cmdArgs.Targets) != 0 || !aur) {
+		// --upgrade in Pacman is incompatible with --list. --refresh is unnecessary
+		// and can be provided by the user if they want to refresh the databases.
+		cmdArgs.DelArg("u", "upgrade", "y", "refresh")
+
 		return run.CmdBuilder.Show(run.CmdBuilder.BuildPacmanCmd(ctx,
 			cmdArgs, run.Cfg.Mode, settings.NoConfirm))
 	}


### PR DESCRIPTION
Fixes #2486.

-u and --upgrade cannot be passed into Pacman when -l or --list are used. Therefore, remove the upgrade arguments before executing the Pacman flag.

Additionally, the refresh flags are removed because it is unnecessary and unexpected for the databases to be refreshed without explicitly passing a refresh flag. A refresh can still be forced by the user by supplying a refresh flag to yay's command line.