### PR TITLE
fix(installer): Fixes the same pkgbase being built multiple times

### DIFF
--- a/local_install_test.go
+++ b/local_install_test.go
@@ -61,8 +61,6 @@ func TestIntegrationLocalInstall(t *testing.T) {
 		"pacman -D -q --asdeps --config /etc/pacman.conf -- dotnet-runtime-6.0 dotnet-sdk-6.0",
 		"makepkg --nobuild -f -C --ignorearch",
 		"makepkg -c --nobuild --noextract --ignorearch",
-		"makepkg --nobuild -f -C --ignorearch",
-		"makepkg -c --nobuild --noextract --ignorearch",
 		"pacman -U --config /etc/pacman.conf -- /testdir/jellyfin-server-10.8.4-1-x86_64.pkg.tar.zst /testdir/jellyfin-web-10.8.4-1-x86_64.pkg.tar.zst",
 		"pacman -D -q --asexplicit --config /etc/pacman.conf -- jellyfin-server jellyfin-web",
 		"makepkg --nobuild -f -C --ignorearch",
@@ -75,7 +73,6 @@ func TestIntegrationLocalInstall(t *testing.T) {
 		"makepkg --packagelist",
 		"git -C testdata/jfin git reset --hard HEAD",
 		"git -C testdata/jfin git merge --no-edit --ff",
-		"makepkg --packagelist",
 		"makepkg --packagelist",
 	}
 
@@ -331,15 +328,12 @@ func TestIntegrationLocalInstallNeeded(t *testing.T) {
 		"makepkg -c --nobuild --noextract --ignorearch",
 		"makepkg --nobuild -f -C --ignorearch",
 		"makepkg -c --nobuild --noextract --ignorearch",
-		"makepkg --nobuild -f -C --ignorearch",
-		"makepkg -c --nobuild --noextract --ignorearch",
 	}
 
 	wantCapture := []string{
 		"makepkg --packagelist",
 		"git -C testdata/jfin git reset --hard HEAD",
 		"git -C testdata/jfin git merge --no-edit --ff",
-		"makepkg --packagelist",
 		"makepkg --packagelist",
 	}
 
@@ -497,8 +491,6 @@ func TestIntegrationLocalInstallGenerateSRCINFO(t *testing.T) {
 		"pacman -D -q --asdeps --config /etc/pacman.conf -- dotnet-runtime-6.0 dotnet-sdk-6.0",
 		"makepkg --nobuild -f -C --ignorearch",
 		"makepkg -c --nobuild --noextract --ignorearch",
-		"makepkg --nobuild -f -C --ignorearch",
-		"makepkg -c --nobuild --noextract --ignorearch",
 		"pacman -U --config /etc/pacman.conf -- /testdir/jellyfin-server-10.8.4-1-x86_64.pkg.tar.zst /testdir/jellyfin-web-10.8.4-1-x86_64.pkg.tar.zst",
 		"pacman -D -q --asexplicit --config /etc/pacman.conf -- jellyfin-server jellyfin-web",
 		"makepkg --nobuild -f -C --ignorearch",
@@ -512,7 +504,6 @@ func TestIntegrationLocalInstallGenerateSRCINFO(t *testing.T) {
 		"makepkg --packagelist",
 		"git -C testdata/jfin git reset --hard HEAD",
 		"git -C testdata/jfin git merge --no-edit --ff",
-		"makepkg --packagelist",
 		"makepkg --packagelist",
 	}
 

--- a/pkg/sync/build/installer.go
+++ b/pkg/sync/build/installer.go
@@ -219,6 +219,7 @@ func (installer *Installer) installAURPackages(ctx context.Context,
 		return nil
 	}
 
+	builtPkgDests := make(map[string]map[string]string)
 	deps, exps := make([]string, 0, aurDepNames.Cardinality()), make([]string, 0, aurExpNames.Cardinality())
 	pkgArchives := make([]string, 0, len(exps)+len(deps))
 
@@ -226,16 +227,25 @@ func (installer *Installer) installAURPackages(ctx context.Context,
 		base := nameToBase[name]
 		dir := pkgBuildDirsByBase[base]
 
-		pkgdests, errMake := installer.buildPkg(ctx, dir, base,
-			installIncompatible, cmdArgs.ExistsArg("needed"), installer.origTargets.Contains(name))
-		if errMake != nil {
-			if !lastLayer {
-				return fmt.Errorf("%s - %w", gotext.Get("error making: %s", base), errMake)
+		pkgdests, ok := builtPkgDests[base]
+		if ok {
+			installer.log.Debugln("skipping built pkgbase", base, "package", name)
+		} else {
+			var errMake error
+			installer.log.Debugln("building pkgbase", base, "package", name)
+			pkgdests, errMake = installer.buildPkg(ctx, dir, base,
+				installIncompatible, cmdArgs.ExistsArg("needed"), installer.origTargets.Contains(name))
+			if errMake != nil {
+				if !lastLayer {
+					return fmt.Errorf("%s - %w", gotext.Get("error making: %s", base), errMake)
+				}
+
+				installer.failedAndIgnored[name] = errMake
+				installer.log.Errorln(gotext.Get("error making: %s", base), "-", errMake)
+				continue
 			}
 
-			installer.failedAndIgnored[name] = errMake
-			installer.log.Errorln(gotext.Get("error making: %s", base), "-", errMake)
-			continue
+			builtPkgDests[base] = pkgdests
 		}
 
 		if len(pkgdests) == 0 {

--- a/pkg/sync/build/installer.go
+++ b/pkg/sync/build/installer.go
@@ -148,13 +148,17 @@ func (installer *Installer) handleLayer(ctx context.Context,
 	nameToBaseMap := make(map[string]string, 0)
 	syncDeps, syncExp, syncGroups := mapset.NewThreadUnsafeSet[string](),
 		mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()
-	aurDeps, aurExp := mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()
+	aurDeps, aurExp, aurOrigTargetBases := mapset.NewThreadUnsafeSet[string](),
+		mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()
 
 	upgradeSync := false
 	for name, info := range layer {
 		switch info.Source {
 		case dep.AUR, dep.SrcInfo:
 			nameToBaseMap[name] = *info.AURBase
+			if installer.origTargets.Contains(name) {
+				aurOrigTargetBases.Add(*info.AURBase)
+			}
 
 			switch info.Reason {
 			case dep.Explicit:
@@ -201,14 +205,15 @@ func (installer *Installer) handleLayer(ctx context.Context,
 	}
 
 	errAur := installer.installAURPackages(ctx, cmdArgs, aurDeps, aurExp,
-		nameToBaseMap, pkgBuildDirs, true, lastLayer, installer.appendNoConfirm())
+		aurOrigTargetBases, nameToBaseMap, pkgBuildDirs, true, lastLayer,
+		installer.appendNoConfirm())
 
 	return errAur
 }
 
 func (installer *Installer) installAURPackages(ctx context.Context,
 	cmdArgs *parser.Arguments,
-	aurDepNames, aurExpNames mapset.Set[string],
+	aurDepNames, aurExpNames, aurOrigTargetBases mapset.Set[string],
 	nameToBase, pkgBuildDirsByBase map[string]string,
 	installIncompatible bool,
 	lastLayer bool,
@@ -234,7 +239,7 @@ func (installer *Installer) installAURPackages(ctx context.Context,
 			var errMake error
 			installer.log.Debugln("building pkgbase", base, "package", name)
 			pkgdests, errMake = installer.buildPkg(ctx, dir, base,
-				installIncompatible, cmdArgs.ExistsArg("needed"), installer.origTargets.Contains(name))
+				installIncompatible, cmdArgs.ExistsArg("needed"), aurOrigTargetBases.Contains(base))
 			if errMake != nil {
 				if !lastLayer {
 					return fmt.Errorf("%s - %w", gotext.Get("error making: %s", base), errMake)

--- a/pkg/sync/build/installer_test.go
+++ b/pkg/sync/build/installer_test.go
@@ -696,8 +696,6 @@ func TestInstaller_InstallSplitPackage(t *testing.T) {
 				"pacman -D -q --asdeps --config /etc/pacman.conf -- dotnet-runtime-6.0 aspnet-runtime dotnet-sdk-6.0",
 				"makepkg --nobuild -f -C --ignorearch",
 				"makepkg -f -c --noconfirm --noextract --noprepare --holdver --ignorearch",
-				"makepkg --nobuild -f -C --ignorearch",
-				"makepkg -c --nobuild --noextract --ignorearch",
 				"pacman -U --config /etc/pacman.conf -- /testdir/jellyfin-web-10.8.4-1-x86_64.pkg.tar.zst /testdir/jellyfin-server-10.8.4-1-x86_64.pkg.tar.zst",
 				"pacman -D -q --asdeps --config /etc/pacman.conf -- jellyfin-server jellyfin-web",
 				"makepkg --nobuild -f -C --ignorearch",
@@ -705,7 +703,7 @@ func TestInstaller_InstallSplitPackage(t *testing.T) {
 				"pacman -U --config /etc/pacman.conf -- /testdir/jellyfin-10.8.4-1-x86_64.pkg.tar.zst",
 				"pacman -D -q --asexplicit --config /etc/pacman.conf -- jellyfin",
 			},
-			wantCapture: []string{"makepkg --packagelist", "makepkg --packagelist", "makepkg --packagelist"},
+			wantCapture: []string{"makepkg --packagelist", "makepkg --packagelist"},
 		},
 	}
 

--- a/sync_test.go
+++ b/sync_test.go
@@ -547,7 +547,7 @@ pkgname = python-vosk
 	wantCapture := []string{
 		"/usr/bin/git -C /testdir/vosk-api reset --hard HEAD",
 		"/usr/bin/git -C /testdir/vosk-api merge --no-edit --ff",
-		"makepkg --packagelist", "makepkg --packagelist",
+		"makepkg --packagelist",
 		"makepkg --packagelist",
 	}
 	wantShow := []string{
@@ -555,7 +555,6 @@ pkgname = python-vosk
 		"makepkg --verifysource --skippgpcheck -f -Cc", "makepkg --nobuild -f -C --ignorearch",
 		"makepkg -c --nobuild --noextract --ignorearch",
 		"pacman -U --config /etc/pacman.conf -- /testdir/vosk-api-0.3.45-1-x86_64.pkg.tar.zst",
-		"makepkg --nobuild -f -C --ignorearch", "makepkg -c --nobuild --noextract --ignorearch",
 		"makepkg --nobuild -f -C --ignorearch", "makepkg -c --nobuild --noextract --ignorearch",
 		"pacman -U --config /etc/pacman.conf -- /testdir/vosk-api-0.3.45-1-x86_64.pkg.tar.zst /testdir/python-vosk-0.3.45-1-x86_64.pkg.tar.zst",
 		"pacman -D -q --asdeps --config /etc/pacman.conf -- vosk-api",


### PR DESCRIPTION
When building a PKGBUILD pkgbase with multiple pkgnames, `installAURPackages()` invokes `buildPkg()` multiple times for the same pkgbase. This causes `prepare()` to be run multiple times for the same pkgbase, since detection of already built packages happens after `prepare()`.

Additionally, detection of already built packages can fail if the split debug packages are enabled and the package does not contain any binaries, causing no `-debug` package to be created by makepkg even though it is listed by `makepkg --packagelist`.

This PR fixes this by keeping track of the pkgdests built by `buildPkg()` and avoiding rebuilds of the same pkgbase in the same yay invocation.

Fixes #2340.