### PR TITLE
fix: use positional argument for "providers available" translation

### DIFF
--- a/pkg/db/ialpm/alpm.go
+++ b/pkg/db/ialpm/alpm.go
@@ -176,7 +176,7 @@ func (ae *AlpmExecutor) questionCallback() func(question alpm.QuestionAny) {
 			return nil
 		})
 
-		str := text.Bold(gotext.Get("There are %d providers available for %s:", size, qp.Dep()))
+		str := text.Bold(gotext.Get("There are %[1]d providers available for %[2]s:", size, qp.Dep()))
 
 		size = 1
 

--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -723,7 +723,7 @@ func (g *Grapher) provideMenu(dep string, options []aur.Pkg) *aur.Pkg {
 		return &options[0]
 	}
 
-	str := text.Bold(gotext.Get("There are %d providers available for %s:", size, dep))
+	str := text.Bold(gotext.Get("There are %[1]d providers available for %[2]s:", size, dep))
 	str += "\n"
 
 	size = 1

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,7 +1,7 @@
-# 
+#
 # Translators:
 # Davidmp <medipas@gmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Davidmp <medipas@gmail.com>, 2023\n"
@@ -434,8 +434,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Els paquets següents no són compatibles amb la vostra arquitectura:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Hi ha %d proveïdors disponibles per a %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Hi ha %[1]d proveïdors disponibles per a %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/ca_ES.po
+++ b/po/ca_ES.po
@@ -1,7 +1,7 @@
-# 
+#
 # Translators:
 # Davidmp <medipas@gmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Davidmp <medipas@gmail.com>, 2024\n"
@@ -434,8 +434,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Els paquets següents no són compatibles amb la vostra arquitectura:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Hi ha %d proveïdors disponibles per a %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Hi ha %[1]d proveïdors disponibles per a %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,10 +1,10 @@
-# 
+#
 # Translators:
 # Fjuro Fjuro, 2022
 # a30a45d5047eb877c4dc397ded846f36_1de9be1, 2023
 # Matyáš Černý, 2023
 # walken, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: walken, 2024\n"
@@ -436,8 +436,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Následující balíčky nejsou kompatibilní s vaší architekturou:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Pro %s je dostupných %d poskytovatelů:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Pro %[2]s je dostupných %[1]d poskytovatelů:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/de.po
+++ b/po/de.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # Julian Neupert <julian.neupert@gmail.com>, 2021
 # Chris Boesch, 2021
@@ -14,7 +14,7 @@
 # Severin Hamader <severin.hamader@yahoo.de>, 2023
 # Manuel Schneider, 2023
 # Marethyu _, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Marethyu _, 2023\n"
@@ -451,8 +451,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Die folgenden Pakete sind mit Ihrer Architektur inkompatibel:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Es sind %d Anbieter für %s verfügbar:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Es sind %[1]d Anbieter für %[2]s verfügbar:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/en.po
+++ b/po/en.po
@@ -444,7 +444,7 @@ msgstr ""
 
 #: pkg/db/ialpm/alpm.go:179
 #: pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
+msgid "There are %[1]d providers available for %[2]s:"
 msgstr ""
 
 #: pkg/settings/exe/cmd_builder.go:258

--- a/po/es.po
+++ b/po/es.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Ivan Garcia, 2021
@@ -10,7 +10,7 @@
 # Angel López, 2023
 # C C, 2023
 # Angel Alderete, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Angel Alderete, 2024\n"
@@ -447,8 +447,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Los siguientes paquetes no son compatibles con su arquitectura:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Existen %d paquetes que proveen %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Existen %[1]d paquetes que proveen %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/eu.po
+++ b/po/eu.po
@@ -449,8 +449,8 @@ msgstr "Ondorengo paketeak ez dira zure arkitekturarekin bateragarriak:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 #, fuzzy
-msgid "There are %d providers available for %s:"
-msgstr "%d hornitzaile eskuragarri %s paketearentzat:\n"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "%[1]d hornitzaile eskuragarri %[2]s paketearentzat:\n"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # Benjamin Chenebault, 2023
 # anthony tonitch <d.tonitch@gmail.com>, 2024
@@ -8,7 +8,7 @@
 # Sylvain Bx, 2024
 # Mathias Brugger, 2024
 # Pierre Grasser, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Pierre Grasser, 2024\n"
@@ -446,8 +446,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Les paquets suivants sont incompatibles avec votre architecture :"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Il y a %d paquets pouvant fournir %s :"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Il y a %[1]d paquets pouvant fournir %[2]s :"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Mr Strik3, 2022
@@ -9,7 +9,7 @@
 # Bertrand Junqua, 2024
 # Barsanuphe, 2024
 # Pierre Grasser, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Pierre Grasser, 2024\n"
@@ -447,8 +447,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Les paquets suivants sont incompatibles avec votre architecture :"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Il y a %d paquets pouvant fournir %s :"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Il y a %[1]d paquets pouvant fournir %[2]s :"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/he.po
+++ b/po/he.po
@@ -1,8 +1,8 @@
-# 
+#
 # Translators:
 # lavi landa, 2024
 # Yaron Shahrabani <sh.yaron@gmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>, 2024\n"
@@ -431,8 +431,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "החבילות הבאות אינן תואמות לארכיטקטורת המעבד שלך:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "יש %d ספקים זמינים עבור %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "יש %[1]d ספקים זמינים עבור %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/he_IL.po
+++ b/po/he_IL.po
@@ -1,8 +1,8 @@
-# 
+#
 # Translators:
 # Yaron Shahrabani <sh.yaron@gmail.com>, 2024
 # lavi landa, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: lavi landa, 2024\n"
@@ -431,8 +431,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "החבילות הבאות אינן תואמות לארכיטקטורת המעבד שלך:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "יש %d ספקים זמינים עבור %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "יש %[1]d ספקים זמינים עבור %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/hu.po
+++ b/po/hu.po
@@ -1,9 +1,9 @@
-# 
+#
 # Translators:
 # Szigeti Péter, 2021
 # Gergő Kasza, 2022
 # summoner, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: summoner, 2024\n"
@@ -456,8 +456,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Az alábbi csomagok nem kompatibilisek a processzor architektúrájával:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "%d szolgáltató áll rendelkezésre ehhez: %s: "
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "%[1]d szolgáltató áll rendelkezésre ehhez: %[2]s: "
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/id.po
+++ b/po/id.po
@@ -1,9 +1,9 @@
-# 
+#
 # Translators:
 # Ludovico, 2022
 # Linerly <linerly@proton.me>, 2024
 # Alif Fathur, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Alif Fathur, 2024\n"
@@ -455,8 +455,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Paket-paket berikut ini tidak kompatibel dengan arsitektur Anda:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Tersedia %d penyedia untuk %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Tersedia %[1]d penyedia untuk %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1,11 +1,11 @@
-# 
+#
 # Translators:
 # Cardellino, 2021
 # Giulio Terigi, 2022
 # Simone Dotto <simonedotto@protonmail.com>, 2022
 # jheitz223, 2023
 # Vincenzo Reale <vinx.reale@gmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Vincenzo Reale <vinx.reale@gmail.com>, 2023\n"
@@ -441,8 +441,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "I seguenti pacchetti non sono compatibili con la tua architettura:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Ci sono %d fornitori disponibili per %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Ci sono %[1]d fornitori disponibili per %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/ja.po
+++ b/po/ja.po
@@ -450,8 +450,8 @@ msgstr ""
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
 #, fuzzy
-msgid "There are %d providers available for %s:"
-msgstr "%d 個のパッケージが %s を提供しています:\n"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "%[1]d 個のパッケージが %[2]s を提供しています:\n"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/ko.po
+++ b/po/ko.po
@@ -431,8 +431,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "다음 패키지는 이 컴퓨터의 아키텍처와 호환되지 않음:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "%s에 사용할 수 있는 %d개 공급자가 있습니다:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "%[2]s에 사용할 수 있는 %[1]d개 공급자가 있습니다:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # Pim van den Berg, 2022
 # Jonathan van der Steege <jonakeys@hotmail.com>, 2023
@@ -6,7 +6,7 @@
 # Luke Rieff, 2023
 # Ariejan de Vroom <ariejan@ariejan.net>, 2024
 # Heimen Stoffels <vistausss@fastmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>, 2024\n"
@@ -444,8 +444,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "De volgende pakketten zijn niet compatibel met uw architectuur:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Er zijn %d bronnen die %s aanbieden:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Er zijn %[1]d bronnen die %[2]s aanbieden:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Oskar <me@medzik.dev>, 2022
@@ -9,7 +9,7 @@
 # Mariusz Bubak, 2024
 # Bartłomiej Konecki, 2024
 # Tadeusz Magura-Witkowski, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Tadeusz Magura-Witkowski, 2024\n"
@@ -462,8 +462,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Te paczki nie są kompatybilne z architekturą Twojego systemu:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Jest %d możliwych źródeł dla %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Jest %[1]d możliwych źródeł dla %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Paweł Bernaciak, 2022
@@ -8,7 +8,7 @@
 # Bartłomiej Konecki, 2023
 # Mariusz Bubak, 2023
 # Tadeusz Magura-Witkowski, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Tadeusz Magura-Witkowski, 2024\n"
@@ -461,8 +461,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Te paczki nie są kompatybilne z architekturą Twojego systemu:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Jest %d możliwych źródeł dla %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Jest %[1]d możliwych źródeł dla %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,9 +1,9 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Eduardo Ervideira, 2023
 # Hugo Carvalho <hugokarvalho@hotmail.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>, 2023\n"
@@ -437,8 +437,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Os seguintes pacotes não são compatíveis com a sua arquitetura:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Existem %d provedores disponíveis para %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Existem %[1]d provedores disponíveis para %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # Otto Micheletti <michelettiotto@gmail.com>, 2021
@@ -7,7 +7,7 @@
 # Fernando Macedo, 2023
 # Felipe Avelar, 2023
 # Lucas Miranda <Liddack@outlook.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Lucas Miranda <Liddack@outlook.com>, 2023\n"
@@ -442,8 +442,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Os seguintes pacotes não são compatíveis com a sua arquitetura:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Existem %d fornecedores disponíveis para %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Existem %[1]d fornecedores disponíveis para %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # Vladislav Zenkov, 2022
 # Kira Malinova, 2023
@@ -7,7 +7,7 @@
 # falixkamishin falixx, 2023
 # Ravenso BlacK, 2023
 # Vladislav Grechannik, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Vladislav Grechannik, 2024\n"
@@ -440,8 +440,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Следующие пакеты несовместимы с вашей архитектурой:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Существует %d пакетов которые удволетворяют %s"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Существует %[1]d пакетов которые удволетворяют %[2]s"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2021
 # makvasm, 2021
@@ -13,7 +13,7 @@
 # Dancheg97 F, 2024
 # Vladislav Grechannik, 2024
 # ratijas, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: ratijas, 2024\n"
@@ -447,8 +447,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Следующие пакеты несовместимы с архитектурой вашего процессора:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Существует %d пакетов которые удволетворяют %s"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Существует %[1]d пакетов которые удволетворяют %[2]s"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,9 +1,9 @@
-# 
+#
 # Translators:
 # Matej Mrenica, 2022
 # Peter Cyprich, 2024
 # Michal Fusatý, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Michal Fusatý, 2024\n"
@@ -456,7 +456,7 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Nasledovné balíčky nie sú kompatibilné s vašou architektúrou: "
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
+msgid "There are %[1]d providers available for %[2]s:"
 msgstr ""
 "Existuje/existujú %d poskytovateľ/poskytovatelia/poskytovateľov pre %s: "
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,9 +1,9 @@
-# 
+#
 # Translators:
 # J G, 2021
 # August Wikerfors, 2023
 # Luna Jernberg <bittin@cafe8bitar.se>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Luna Jernberg <bittin@cafe8bitar.se>, 2023\n"
@@ -438,8 +438,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Följande paket stöds inte av din arkitektur:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Det finns %d tillgängliga tillhandahållare för %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Det finns %[1]d tillgängliga tillhandahållare för %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/tr.po
+++ b/po/tr.po
@@ -438,8 +438,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Aşağıdaki paketler sistem mimarin ile uyumlu değil:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "%s için %d sağlayıcı bulunuyor:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "%[2]s için %[1]d sağlayıcı bulunuyor:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,11 +1,11 @@
-# 
+#
 # Translators:
 # Volodymyr Markiv <vov4uk21@gmail.com>, 2021
 # Igor Lukyanov, 2023
 # Andrii Lytvyn, 2023
 # null null, 2023
 # Andrii Yermak, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: Andrii Yermak, 2024\n"
@@ -455,8 +455,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "Наступні пакунки не сумісні з вашою архітектурою:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "Існує %d постачальників для %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "Існує %[1]d постачальників для %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,4 +1,4 @@
-# 
+#
 # Translators:
 # J G, 2022
 # Moon Xanadu <xmoonox@gmail.com>, 2023
@@ -9,7 +9,7 @@
 # Alex Wang, 2023
 # Xuekai Deng, 2024
 # CloverGit, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Last-Translator: CloverGit, 2024\n"
@@ -453,8 +453,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "下列软件包与你的系统架构不兼容:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "有 %d 个提供者可用于 %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "有 %[1]d 个提供者可用于 %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -435,8 +435,8 @@ msgid "The following packages are not compatible with your architecture:"
 msgstr "以下套件不支援您的系統架構:"
 
 #: pkg/db/ialpm/alpm.go:179 pkg/dep/dep_graph.go:726
-msgid "There are %d providers available for %s:"
-msgstr "有 %d 個提供者可用於 %s:"
+msgid "There are %[1]d providers available for %[2]s:"
+msgstr "有 %[1]d 個提供者可用於 %[2]s:"
 
 #: pkg/settings/exe/cmd_builder.go:258
 msgid "There may be another Pacman instance running. Waiting..."


### PR DESCRIPTION
fixes #2517.

<details><summary>regexes used (for future reference)</summary>
<p>

for go, `en.po`, `sk.po`:
```po
msgid "There are %d providers available for %s:"
```
```po
msgid "There are %1$d providers available for %2$s:"
```
for `cs.po`, `ko.po`, `tr.po`:
```po
msgid "There are %d providers available for %s:"\nmsgstr "(.*)%s(.*)%d(.*)"
```
```po
msgid "There are %1$d providers available for %2$s:"\nmsgstr "$1%2$s$2%1$d$3"
```
everything else:
```po
msgid "There are %d providers available for %s:"\nmsgstr "(.*)%d(.*)%s(.*)"
```
```po
msgid "There are %1$d providers available for %2$s:"\nmsgstr "$1%1$d$2%2$s$3"
```

</p>
</details> 
