### PR TITLE
socks5 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/leonelquinteros/gotext v1.5.2
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	golang.org/x/sys v0.18.0
 	golang.org/x/term v0.18.0
 	gopkg.in/h2non/gock.v1 v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,7 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/runtime/pacman_test.go
+++ b/pkg/runtime/pacman_test.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Morganamilo/go-pacmanconf"
@@ -21,13 +22,19 @@ func TestPacmanConf(t *testing.T) {
 	absPath, err := filepath.Abs(path)
 	require.NoError(t, err)
 
+	// detect the architecture of the system
+	expectedArch := []string{"x86_64"}
+	if runtime.GOARCH == "arm64" {
+		expectedArch = []string{"aarch64"}
+	}
+
 	expectedPacmanConf := &pacmanconf.Config{
 		RootDir: "/", DBPath: "/var/lib/pacman/",
 		CacheDir: []string{"/var/cache/pacman/pkg/"},
 		HookDir:  []string{"/etc/pacman.d/hooks/"},
 		GPGDir:   "/etc/pacman.d/gnupg/", LogFile: "/var/log/pacman.log",
 		HoldPkg: []string{"pacman", "glibc"}, IgnorePkg: []string{"xorm"},
-		IgnoreGroup: []string{"yorm"}, Architecture: []string{"x86_64"},
+		IgnoreGroup: []string{"yorm"}, Architecture: expectedArch,
 		XferCommand: "/usr/bin/wget --passive-ftp -c -O %o %u",
 		NoUpgrade:   []string(nil), NoExtract: []string(nil), CleanMethod: []string{"KeepInstalled"},
 		SigLevel:           []string{"PackageRequired", "PackageTrustedOnly", "DatabaseOptional", "DatabaseTrustedOnly"},

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -41,7 +41,7 @@ func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version 
 	logger := text.NewLogger(os.Stdout, os.Stderr, os.Stdin, cfg.Debug, "runtime")
 	runner := exe.NewOSRunner(logger.Child("runner"))
 
-	var transport = &http.Transport{}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if socks5_proxy := os.Getenv("SOCKS5_PROXY"); socks5_proxy != "" {
 		dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
 		if err != nil {


### PR DESCRIPTION
Golang implementation of `http.Client` does not handle socks5 support via LD_PRELOAD (a.k.a. tsocks/proxychains). Proposed patch adds explicit socks5 support via environment variable, e.g. `SOCKS5_PROXY=localhost:1080 yay -Ss vivado`.