### PR TITLE
fix(installer): Fix the same pkgbase being built multiple times on error

### DIFF
--- a/pkg/sync/build/installer.go
+++ b/pkg/sync/build/installer.go
@@ -240,6 +240,7 @@ func (installer *Installer) installAURPackages(ctx context.Context,
 			installer.log.Debugln("building pkgbase", base, "package", name)
 			pkgdests, errMake = installer.buildPkg(ctx, dir, base,
 				installIncompatible, cmdArgs.ExistsArg("needed"), aurOrigTargetBases.Contains(base))
+			builtPkgDests[base] = pkgdests
 			if errMake != nil {
 				if !lastLayer {
 					return fmt.Errorf("%s - %w", gotext.Get("error making: %s", base), errMake)
@@ -249,8 +250,6 @@ func (installer *Installer) installAURPackages(ctx context.Context,
 				installer.log.Errorln(gotext.Get("error making: %s", base), "-", errMake)
 				continue
 			}
-
-			builtPkgDests[base] = pkgdests
 		}
 
 		if len(pkgdests) == 0 {

--- a/pkg/sync/build/installer_test.go
+++ b/pkg/sync/build/installer_test.go
@@ -612,8 +612,18 @@ func TestInstaller_CompileFailed(t *testing.T) {
 			failed, err := installer.CompileFailedAndIgnored()
 			if tc.wantErrCompile {
 				require.Error(td, err)
-				assert.ErrorContains(td, err, "yay")
-				assert.Len(t, failed, len(tc.targets))
+				for key := range failed {
+					assert.ErrorContains(td, err, key)
+				}
+				uniqueBases := make(map[string]struct{})
+				for _, layer := range tc.targets {
+					for _, info := range layer {
+						if info.AURBase != nil {
+							uniqueBases[*info.AURBase] = struct{}{}
+						}
+					}
+				}
+				require.Len(td, failed, len(uniqueBases))
 			} else {
 				require.NoError(td, err)
 			}


### PR DESCRIPTION
The previous fix commit ec837c8 failed to address the case where the build fails, as packages are only added to builtPkgDests on a successful build. This commit addresses this by adding the package to the map earlier.

Fixes #2560.

The patch seems trivial and initial testing shows it works and I've not run into any issues with this patch yet, but I'll daily drive this for the next week anyway to see if anything comes up.