### PR TITLE
fix: correct Docker manifest creation in builder image workflow

### DIFF
--- a/.github/workflows/builder-image.yml
+++ b/.github/workflows/builder-image.yml
@@ -115,25 +115,27 @@ jobs:
             ghcr.io/${{ env.REGISTRY_IMAGE }}
           tags: |
             type=raw,value=latest
-            type=sha,format=long
+            type=sha,format=short
 
       - name: Create and push manifest list
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled
         run: |
-          # Extract tags
-          TAGS=$(echo '${{ steps.meta.outputs.tags }}' | xargs -I {} echo "-t {}")
+          # Extract Docker Hub tags
+          DH_TAGS=$(echo '${{ steps.meta.outputs.tags }}' | grep -v "^ghcr.io" | xargs -I {} echo "-t {}")
+          
+          # Extract GitHub Container Registry tags
+          GHCR_TAGS=$(echo '${{ steps.meta.outputs.tags }}' | grep "^ghcr.io" | xargs -I {} echo "-t {}")
           
           # Create a manifest list using the image digests from /tmp/digests/*
           DIGESTS=$(for file in /tmp/digests/*; do
             echo -n "${{ env.REGISTRY_IMAGE }}@$(cat $file) "
           done)
           
-          # Create the manifest list with the collected tags and digests
-          docker buildx imagetools create $TAGS $DIGESTS
+          # Create the manifest list for Docker Hub
+          docker buildx imagetools create $DH_TAGS $DIGESTS
           
-          # Push to GitHub Container Registry
-          GHCR_TAGS=$(echo '${{ steps.meta.outputs.tags }}' | sed 's|^|ghcr.io/${{ env.REGISTRY_IMAGE }}:|g' | xargs -I {} echo "-t {}")
+          # Create the manifest list for GitHub Container Registry
           docker buildx imagetools create $GHCR_TAGS $DIGESTS
 
       - name: Inspect image

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -4,10 +4,12 @@ LABEL maintainer="Jguer,docker@jguer.space"
 ENV GO111MODULE=on
 WORKDIR /app
 
+RUN sed -i '/^\[community\]/,/^\[/ s/^/#/' /etc/pacman.conf
+
 COPY go.mod .
 
 RUN pacman-key --init && pacman -Sy && pacman -S --overwrite=* --noconfirm archlinux-keyring && \
     pacman -Su --overwrite=* --needed --noconfirm pacman doxygen meson asciidoc go git gcc make sudo base-devel && \
     rm -rfv /var/cache/pacman/* /var/lib/pacman/sync/* && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.61.0 && \
-    go mod download
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.6 && \
+    go mod download 


### PR DESCRIPTION
- Fix "invalid reference format" error by properly separating Docker Hub and GitHub Container Registry tags
- Use short SHA format instead of long format for more manageable tags
- Improve manifest list creation process to handle multiple registries correctly
- Ensure proper handling of ghcr.io prefix for GitHub Container Registry