### PR TITLE
chore(ci): update golangci-lint to v2.1.5 in ci.Dockerfile

### DIFF
--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -11,5 +11,5 @@ COPY go.mod .
 RUN pacman-key --init && pacman -Sy && pacman -S --overwrite=* --noconfirm archlinux-keyring && \
     pacman -Su --overwrite=* --needed --noconfirm pacman doxygen meson asciidoc go git gcc make sudo base-devel && \
     rm -rfv /var/cache/pacman/* /var/lib/pacman/sync/* && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.6 && \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.1.5 && \
     go mod download 


### PR DESCRIPTION
This pull request updates the `ci.Dockerfile` to use a newer version of `golangci-lint`. The most important change is the upgrade of the `golangci-lint` version from `v1.64.6` to `v2.1.5`.

Dependency update:

* [`ci.Dockerfile`](diffhunk://#diff-cb18d2c2c6d7bb0c60cd0594014c3f908c9439417589c3e17c3200bd916bb734L14-R14): Updated the `golangci-lint` version installed via the `install.sh` script from `v1.64.6` to `v2.1.5` to ensure compatibility with the latest linting features and bug fixes.