### PR TITLE
chore(ci): update golangci lint v2.1.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,9 @@ RUN echo "docker ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/docker
 # Create a non-root user and switch to it
 USER docker
 
+# Add /app/bin to the PATH
+ENV PATH="/app/bin:$PATH"
+
 # Set the working directory
 WORKDIR /workspace
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,10 +16,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      # - name: Lint
-      #   env:
-      #     GOFLAGS: -buildvcs=false -tags=next
-      #   run: /app/bin/golangci-lint run -v ./...
+      - name: Lint
+        env:
+          GOFLAGS: -buildvcs=false -tags=next
+        run: /app/bin/golangci-lint run -v ./...
       - name: Run Build and Tests
         run: make test
       - name: Run Integration Tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,67 +1,18 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 3
-    min-occurrences: 4
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  gocyclo:
-    min-complexity: 15
-  goimports:
-    local-prefixes: github.com/Jguer/yay/v12
-  gomnd:
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-    ignored-numbers:
-      - "0"
-      - "1"
-      - "2"
-      - "3"
-    ignored-functions:
-      - strings.SplitN
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-
+version: "2"
+run:
+  go: "1.20"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
-    - forbidigo
     - bodyclose
     - dogsled
     - dupl
-    - errorlint
     - errcheck
-    # - funlen # TOFIX
+    - errorlint
     - gochecknoinits
-    # - goconst # TOFIX
     - gocritic
-    # - gocyclo # TOFIX
-    - gofmt
-    - goimports
-    # - gomnd # TOFIX
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -70,36 +21,74 @@ linters:
     - noctx
     - nolintlint
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-
-run:
-  go: "1.20"
-  timeout: "10m"
-  forbidigo:
-    forbid:
-      - p: ^fmt\.Print.*$
-        msg: Do not commit print statements.
-
-issues:
-  exclude-rules:
-    - path: (.+)_test.go
-      linters:
-        - lll
-        - revive
-        - wsl
-        - govet
-        - godot
-        - errcheck
-        - stylecheck
-        - dupl
-        - gocritic
-        - gochecknoinits
-        - errorlint
-
-  exclude:
-    - G204
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 3
+      min-occurrences: 4
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: false
+      require-specific: false
+      allow-unused: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - errorlint
+          - gochecknoinits
+          - gocritic
+          - godot
+          - govet
+          - lll
+          - revive
+          - staticcheck
+          - wsl
+        path: (.+)_test.go
+      - path: (.+)\.go$
+        text: G204
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/Jguer/yay/v12
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "go.lintTool": "golangci-lint",
+    "gopls": {
+        "formatting.gofumpt": true,
+        "formatting.local": "github.com/Jguer/yay/v12"
+    }
+}

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -11,5 +11,5 @@ COPY go.mod .
 RUN pacman-key --init && pacman -Sy && pacman -S --overwrite=* --noconfirm archlinux-keyring && \
     pacman -Su --overwrite=* --needed --noconfirm pacman doxygen meson asciidoc go git gcc make sudo base-devel && \
     rm -rfv /var/cache/pacman/* /var/lib/pacman/sync/* && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.6 && \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.1.5 && \
     go mod download 

--- a/clean.go
+++ b/clean.go
@@ -55,9 +55,10 @@ func syncClean(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argume
 	_, removeAll, _ := cmdArgs.GetArg("c", "clean")
 
 	for _, v := range run.PacmanConf.CleanMethod {
-		if v == "KeepInstalled" {
+		switch v {
+		case "KeepInstalled":
 			keepInstalled = true
-		} else if v == "KeepCurrent" {
+		case "KeepCurrent":
 			keepCurrent = true
 		}
 	}

--- a/local_install.go
+++ b/local_install.go
@@ -43,7 +43,7 @@ func srcinfoExists(ctx context.Context,
 			return fmt.Errorf("unable to generate .SRCINFO: %w - %s", err, stderr)
 		}
 
-		if len(srcinfo) == 0 {
+		if srcinfo == "" {
 			return fmt.Errorf("generated .SRCINFO is empty, check your PKGBUILD for errors")
 		}
 

--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -37,7 +37,7 @@ func (i *InstallInfo) String() string {
 }
 
 type (
-	Reason int
+	Reason uint
 	Source int
 )
 
@@ -804,17 +804,17 @@ func makeAURPKGFromSrcinfo(dbExecutor db.Executor, srcInfo *gosrc.Srcinfo) ([]*a
 			Description:   getDesc(pkg),
 			URL:           pkg.URL,
 			Depends: append(archStringToString(alpmArch, pkg.Depends),
-				archStringToString(alpmArch, srcInfo.Package.Depends)...),
-			MakeDepends:  archStringToString(alpmArch, srcInfo.PackageBase.MakeDepends),
-			CheckDepends: archStringToString(alpmArch, srcInfo.PackageBase.CheckDepends),
+				archStringToString(alpmArch, srcInfo.Depends)...),
+			MakeDepends:  archStringToString(alpmArch, srcInfo.MakeDepends),
+			CheckDepends: archStringToString(alpmArch, srcInfo.CheckDepends),
 			Conflicts: append(archStringToString(alpmArch, pkg.Conflicts),
-				archStringToString(alpmArch, srcInfo.Package.Conflicts)...),
+				archStringToString(alpmArch, srcInfo.Conflicts)...),
 			Provides: append(archStringToString(alpmArch, pkg.Provides),
-				archStringToString(alpmArch, srcInfo.Package.Provides)...),
+				archStringToString(alpmArch, srcInfo.Provides)...),
 			Replaces: append(archStringToString(alpmArch, pkg.Replaces),
-				archStringToString(alpmArch, srcInfo.Package.Replaces)...),
+				archStringToString(alpmArch, srcInfo.Replaces)...),
 			OptDepends: append(archStringToString(alpmArch, pkg.OptDepends),
-				archStringToString(alpmArch, srcInfo.Package.OptDepends)...),
+				archStringToString(alpmArch, srcInfo.OptDepends)...),
 			Groups:   pkg.Groups,
 			License:  pkg.License,
 			Keywords: []string{},

--- a/pkg/intrange/intrange.go
+++ b/pkg/intrange/intrange.go
@@ -17,10 +17,10 @@ type IntRange struct {
 // IntRanges is a slice of IntRange.
 type IntRanges []IntRange
 
-func makeIntRange(min, max int) IntRange {
+func makeIntRange(minVal, maxVal int) IntRange {
 	return IntRange{
-		min,
-		max,
+		min: minVal,
+		max: maxVal,
 	}
 }
 

--- a/pkg/intrange/intrange_test.go
+++ b/pkg/intrange/intrange_test.go
@@ -64,9 +64,9 @@ func TestParseNumberMenu(t *testing.T) {
 			},
 			mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string](),
 		},
-		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet[string]("abort", "all", "none"), mapset.NewThreadUnsafeSet[string]()},
-		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet[string]("a-b"), mapset.NewThreadUnsafeSet[string]("abort", "a-b")},
-		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet[string]("-9223372036854775809-9223372036854775809"), mapset.NewThreadUnsafeSet[string]()},
+		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet("abort", "all", "none"), mapset.NewThreadUnsafeSet[string]()},
+		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet("a-b"), mapset.NewThreadUnsafeSet("abort", "a-b")},
+		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet("-9223372036854775809-9223372036854775809"), mapset.NewThreadUnsafeSet[string]()},
 		{IntRanges{
 			makeIntRange(1, 1),
 			makeIntRange(2, 2),
@@ -86,7 +86,7 @@ func TestParseNumberMenu(t *testing.T) {
 		}, IntRanges{}, mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()},
 		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()},
 		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()},
-		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet[string]("a", "b", "c", "d", "e"), mapset.NewThreadUnsafeSet[string]()},
+		{IntRanges{}, IntRanges{}, mapset.NewThreadUnsafeSet("a", "b", "c", "d", "e"), mapset.NewThreadUnsafeSet[string]()},
 	}
 
 	for n, in := range inputs {

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -289,7 +289,7 @@ func matchesSearch(pkg *aur.Pkg, terms []string) bool {
 		desc := strings.ToLower(pkg.Description)
 		targ := strings.ToLower(pkgN)
 
-		if !(strings.Contains(name, targ) || strings.Contains(desc, targ)) {
+		if !strings.Contains(name, targ) && !strings.Contains(desc, targ) {
 			return false
 		}
 	}

--- a/pkg/query/version_diff.go
+++ b/pkg/query/version_diff.go
@@ -37,7 +37,7 @@ func GetVersionDiff(oldVersion, newVersion string) (left, right string) {
 	}
 
 	for index, char := range oldVersion {
-		charIsSpecial := !(unicode.IsLetter(char) || unicode.IsNumber(char))
+		charIsSpecial := !unicode.IsLetter(char) && !unicode.IsNumber(char)
 
 		if (index >= len(newVersion)) || (char != rune(newVersion[index])) {
 			if charIsSpecial {

--- a/pkg/settings/exe/cmd_builder.go
+++ b/pkg/settings/exe/cmd_builder.go
@@ -173,11 +173,12 @@ func (c *CmdBuilder) deElevateCommand(ctx context.Context, cmd *exec.Cmd) *exec.
 
 	if userFound, err := user.Lookup(ogCaller); err == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
-		uid, _ := strconv.Atoi(userFound.Uid)
-		gid, _ := strconv.Atoi(userFound.Gid)
-		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}
-
-		return cmd
+		uid64, errUid := strconv.ParseUint(userFound.Uid, 10, 32)
+		gid64, errGid := strconv.ParseUint(userFound.Gid, 10, 32)
+		if errUid == nil && errGid == nil {
+			cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid64), Gid: uint32(gid64)}
+			return cmd
+		}
 	}
 
 	cmdArgs := []string{

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -25,7 +25,7 @@ func (o *Option) Add(args ...string) {
 }
 
 func (o *Option) First() string {
-	if o.Args == nil || len(o.Args) == 0 {
+	if len(o.Args) == 0 {
 		return ""
 	}
 
@@ -565,7 +565,6 @@ func (a *Arguments) parseShortOption(arg, param string) (usedNext bool, err erro
 			break
 		} else {
 			err = a.AddArg(char)
-
 			if err != nil {
 				return
 			}

--- a/pkg/sync/build/pkg_archive_test.go
+++ b/pkg/sync/build/pkg_archive_test.go
@@ -6,9 +6,10 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/Jguer/yay/v12/pkg/settings/exe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v12/pkg/settings/exe"
 )
 
 func TestParsePackageList(t *testing.T) {

--- a/pkg/sync/workdir/preparer.go
+++ b/pkg/sync/workdir/preparer.go
@@ -194,14 +194,15 @@ func (preper *Preparer) PrepareWorkspace(ctx context.Context,
 
 	for _, layer := range targets {
 		for _, info := range layer {
-			if info.Source == dep.AUR {
+			switch info.Source {
+			case dep.AUR:
 				pkgBase := *info.AURBase
 				pkgBuildDir := filepath.Join(preper.cfg.BuildDir, pkgBase)
 				if preper.needToCloneAURBase(info, pkgBuildDir) {
 					aurBasesToClone.Add(pkgBase)
 				}
 				pkgBuildDirsByBase[pkgBase] = pkgBuildDir
-			} else if info.Source == dep.SrcInfo {
+			case dep.SrcInfo:
 				pkgBase := *info.AURBase
 				pkgBuildDirsByBase[pkgBase] = *info.SrcinfoPath
 			}

--- a/pkg/text/text.go
+++ b/pkg/text/text.go
@@ -23,12 +23,12 @@ func SplitDBFromName(pkg string) (db, name string) {
 
 // LessRunes compares two rune values, and returns true if the first argument is lexicographicaly smaller.
 func LessRunes(iRunes, jRunes []rune) bool {
-	max := len(iRunes)
-	if max > len(jRunes) {
-		max = len(jRunes)
+	maxLen := len(iRunes)
+	if maxLen > len(jRunes) {
+		maxLen = len(jRunes)
 	}
 
-	for idx := 0; idx < max; idx++ {
+	for idx := 0; idx < maxLen; idx++ {
 		ir := iRunes[idx]
 		jr := jRunes[idx]
 

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -201,7 +201,8 @@ func (u *UpgradeService) graphToUpSlice(graph *topo.Graph[string, *dep.InstallIn
 			extra = fmt.Sprintf(" (%s of %s)", dep.ReasonNames[info.Reason], strings.Join(reducedParents, ", "))
 		}
 
-		if info.Source == dep.AUR {
+		switch info.Source {
+		case dep.AUR:
 			aurRepo := "aur"
 			if info.Devel {
 				aurRepo = "devel"
@@ -215,7 +216,7 @@ func (u *UpgradeService) graphToUpSlice(graph *topo.Graph[string, *dep.InstallIn
 				Reason:        alpmReason,
 				Extra:         extra,
 			})
-		} else if info.Source == dep.Sync {
+		case dep.Sync:
 			repoUp.Up = append(repoUp.Up, Upgrade{
 				Name:          name,
 				RemoteVersion: info.Version,

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -38,9 +38,10 @@ func (u UpSlice) Less(i, j int) bool {
 	}
 
 	for _, db := range u.Repos {
-		if db == u.Up[i].Repository {
+		switch db {
+		case u.Up[i].Repository:
 			return true
-		} else if db == u.Up[j].Repository {
+		case u.Up[j].Repository:
 			return false
 		}
 	}
@@ -52,9 +53,7 @@ func (u UpSlice) Less(i, j int) bool {
 }
 
 // calculateFormatting calculates formatting parameters for printing upgrades
-func calculateFormatting(upgrades []Upgrade) (int, int, int) {
-	longestName, longestVersion := 0, 0
-
+func calculateFormatting(upgrades []Upgrade) (longestName, longestVersion, longestNumber int) {
 	for i := range upgrades {
 		upgrade := &upgrades[i]
 		packNameLen := len(StylizedNameWithRepository(upgrade))
@@ -65,9 +64,9 @@ func calculateFormatting(upgrades []Upgrade) (int, int, int) {
 	}
 
 	lenUp := len(upgrades)
-	longestNumber := len(fmt.Sprintf("%v", lenUp))
+	longestNumber = len(fmt.Sprintf("%v", lenUp))
 
-	return longestName, longestVersion, longestNumber
+	return
 }
 
 // Print prints the details of the packages to upgrade.


### PR DESCRIPTION
This pull request introduces a variety of changes, including updates to linting configurations, Dockerfile improvements, code refactoring, and bug fixes. The most significant updates involve enhancing the linting setup, refactoring switch statements for better readability, and improving type safety in the codebase.

### Linting and Configuration Updates:
* Updated `.golangci.yml` to enable a specific set of linters, including `errcheck`, `staticcheck`, and `gocritic`, while removing deprecated configurations and adding exclusions for generated files and specific paths. [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L1-R28) [[2]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L19-R94)
* Added `golangci-lint` as the default linting tool in `.vscode/settings.json` and configured `gopls` for consistent formatting.
* Upgraded `golangci-lint` version from `v1.64.6` to `v2.1.5` in `ci.Dockerfile`.

### Code Refactoring:
* Refactored multiple `if-else` chains into `switch` statements for improved readability, e.g., in `clean.go`, `workdir/preparer.go`, and `upgrade/service.go`. [[1]](diffhunk://#diff-11def9b172ef25e724ddf6042ba3efa508764aeef57c0a8a7ca9d0354909a3a6L58-R61) [[2]](diffhunk://#diff-f827d0329077c9d863c5c2c91918d6bbe7e57e9d87ac5e626eca76a0e2fc1161L197-R205) [[3]](diffhunk://#diff-f31ba4ebace00e7b6af6c98d2e9d3cff36e7d2ea1254a314b8611c2da61a9312L204-R205)
* Renamed variables for clarity and consistency, such as `min` to `minVal` and `max` to `maxVal` in `pkg/intrange/intrange.go`.

### Bug Fixes:
* Fixed logical errors in conditional expressions, such as replacing `!(A || B)` with `!A && !B` in `query_builder.go`.
* Resolved incorrect type usage by changing `Reason int` to `Reason uint` in `pkg/dep/dep_graph.go`.

### Dockerfile and Workflow Enhancements:
* Added `/app/bin` to `PATH` in `.devcontainer/Dockerfile` to ensure binaries are accessible during development.
* Uncommented and re-enabled the linting step in `.github/workflows/testing.yml` to integrate lint checks into the CI pipeline.

### Miscellaneous Improvements:
* Simplified redundant checks, such as removing unnecessary `nil` checks for slices in `parser.go`.
* Improved test cases in `intrange_test.go` by using more concise syntax for `mapset` initialization. [[1]](diffhunk://#diff-45d6e747adc1183529d8ae7e94e709089ceab6a9da2eea8a5dab2050b930ae36L67-R69) [[2]](diffhunk://#diff-45d6e747adc1183529d8ae7e94e709089ceab6a9da2eea8a5dab2050b930ae36L89-R89)