### PR TITLE
Fix locale initialization logic

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Build yay Artifact
         run: make
       - name: Upload yay Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: yay
           path: ./yay
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,6 +32,8 @@ jobs:
           chown -R yay:yay /home/yay/go/ &&
             su yay -c "make test-integration"
       - name: Build yay Artifact
+        env:
+          GOFLAGS: -buildvcs=false -tags=next
         run: make
       - name: Upload yay Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,7 @@ jobs:
         run: /app/bin/golangci-lint run -v ./...
       - name: Run Build and Tests
         run: make test
+
       - name: Run Integration Tests
         continue-on-error: true
         run: |
@@ -29,4 +30,11 @@ jobs:
           chown -R yay:yay . &&
           cp -r ~/go/ /home/yay/go/ &&
           chown -R yay:yay /home/yay/go/ &&
-          su yay -c "make test-integration"
+            su yay -c "make test-integration"
+      - name: Build yay Artifact
+        run: make
+      - name: Upload yay Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: yay
+          path: ./yay

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime/debug"
+	"strings"
 
 	"github.com/leonelquinteros/gotext"
 
@@ -27,7 +28,9 @@ func initGotext() {
 	}
 
 	if lc := os.Getenv("LANGUAGE"); lc != "" {
-		gotext.Configure(localePath, lc, "yay")
+		// Split LANGUAGE by ':' and prioritize the first locale
+		locales := strings.Split(lc, ":")
+		gotext.Configure(localePath, locales[0], "yay")
 	} else if lc := os.Getenv("LC_ALL"); lc != "" {
 		gotext.Configure(localePath, lc, "yay")
 	} else if lc := os.Getenv("LC_MESSAGES"); lc != "" {

--- a/main.go
+++ b/main.go
@@ -31,7 +31,9 @@ func initGotext() {
 		// Split LANGUAGE by ':' and prioritize the first locale
 		// Should fix in gotext to support this
 		locales := strings.Split(lc, ":")
-		gotext.Configure(localePath, locales[0], "yay")
+		if len(locales) > 0 && locales[0] != "" {
+			gotext.Configure(localePath, locales[0], "yay")
+		}
 	} else if lc := os.Getenv("LC_ALL"); lc != "" {
 		gotext.Configure(localePath, lc, "yay")
 	} else if lc := os.Getenv("LC_MESSAGES"); lc != "" {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func initGotext() {
 
 	if lc := os.Getenv("LANGUAGE"); lc != "" {
 		// Split LANGUAGE by ':' and prioritize the first locale
+		// Should fix in gotext to support this
 		locales := strings.Split(lc, ":")
 		gotext.Configure(localePath, locales[0], "yay")
 	} else if lc := os.Getenv("LC_ALL"); lc != "" {


### PR DESCRIPTION
This pull request updates the locale configuration logic in `main.go` to better handle the `LANGUAGE` environment variable by prioritizing the first locale in the list. It also includes a minor import addition to support this change.

### Locale configuration improvements:
* Updated the `initGotext` function to split the `LANGUAGE` environment variable by `:` and use the first locale in the list for configuration. This ensures proper handling of multi-locale `LANGUAGE` values. (`[main.goL30-R33](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L30-R33)`)

### Codebase maintenance:
* Added the `strings` package to the import list in `main.go` to support string splitting for the updated locale logic. (`[main.goR9](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R9)`)