### PR TITLE
fix(yay) make it obvious when searching very short packages

### DIFF
--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -152,6 +152,11 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 		aurResults, aurErr = queryAUR(ctx, s.aurClient, pkgS, s.searchBy)
 		dbName := sourceAUR
 
+		if aurErr != nil {
+			s.logger.Errorln(ErrAURSearch{inner: aurErr})
+			return
+		}
+
 		for i := range aurResults {
 			if s.queryMap[dbName] == nil {
 				s.queryMap[dbName] = map[string]interface{}{}


### PR DESCRIPTION
Fixes #2544 

When searching for packages with (arguably) silly names like q, yay does not behave in an expected way and does not make it obvious there was an error.

Current Behavior:

```
➜ yay q
 -> Error during AUR search: 1 error occurred:
	* status 200: Query arg too small.



 -> Showing repo packages only
1167 multilib/lib32-libdv 1.0.0-9 (55.0 KiB 126.8 KiB) 
    The Quasar DV codec (libdv) is a software codec for DV video (32-bit)
1166 multilib/lib32-gamemode 1.8.2-1 (10.1 KiB 31.1 KiB) 
    A daemon/lib combo that allows games to request a set of optimisations be temporarily applied to the host OS
...
2 core/sqlite 3.47.1-2 (1.9 MiB 9.8 MiB) (Installed: 3.47.1-1)
    A C library that implements an SQL database engine
1 core/qgpgme-qt6 1.24.1-1 (313.4 KiB 1.4 MiB) (Installed)
    Qt6 bindings for GPGme
==> Packages to install (eg: 1 2 3, 1-3 or ^4)
==> 
```

Fixed Behavior:
```
➜ yay q
 -> Error during AUR search: 1 error occurred:
        * status 200: Query arg too small.
```


The reason I chose to return early was inspired by how `paru` handles this:
Paru's Behavior:
```
➜ paru q
error: Query arg too small.
```

I am not sure if returning early is the right thing to do. Please suggest any changes if any.