### PR TITLE
Fix cleaning AUR always cleaning all packages

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -52,7 +52,7 @@ func syncClean(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argume
 	keepInstalled := false
 	keepCurrent := false
 
-	removeAll := cmdArgs.ExistsArg("c", "clean")
+	_, removeAll, _ := cmdArgs.GetArg("c", "clean")
 
 	for _, v := range run.PacmanConf.CleanMethod {
 		switch v {

--- a/clean_test.go
+++ b/clean_test.go
@@ -6,11 +6,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Jguer/go-alpm/v2"
+	pacmanconf "github.com/Morganamilo/go-pacmanconf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -111,6 +114,109 @@ func TestCleanHanging(t *testing.T) {
 					strings.Split(tc.wantShow[i], " "),
 					fmt.Sprintf("%d - %s", i, show))
 			}
+		})
+	}
+}
+
+func TestIntegrationCleanAUR(t *testing.T) {
+	buildDir := filepath.Join(t.TempDir(), "build")
+	yayGitDir := filepath.Join(buildDir, "yay-git")
+	zoomDir := filepath.Join(buildDir, "zoom")
+
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		args     []string
+		wantDirs []string
+	}{
+		{
+			name:     "Sync clean AUR",
+			args:     []string{"S", "c", "a"},
+			wantDirs: []string{"zoom"},
+		},
+		{
+			name:     "Sync clean double AUR",
+			args:     []string{"S", "c", "c", "a"},
+			wantDirs: []string{},
+		},
+	}
+
+	dbExc := &mock.DBExecutor{
+		PackageOptionalDependsFn: func(i alpm.IPackage) []alpm.Depend {
+			if i.Name() == "linux" {
+				return []alpm.Depend{
+					{
+						Name: "linux-headers",
+					},
+				}
+			}
+
+			return []alpm.Depend{}
+		},
+		PackageProvidesFn: func(p alpm.IPackage) []alpm.Depend { return []alpm.Depend{} },
+		PackageDependsFn:  func(p alpm.IPackage) []alpm.Depend { return []alpm.Depend{} },
+		InstalledRemotePackagesFn: func() map[string]alpm.IPackage {
+			return map[string]alpm.IPackage{
+				"zoom": &mock.Package{
+					PName:    "zoom",
+					PVersion: "6.5.8-1",
+					PBase:    "zoom",
+					PReason:  alpm.PkgReasonExplicit,
+				},
+			}
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockRunner := &exe.MockRunner{
+				CaptureFn: func(cmd *exec.Cmd) (stdout string, stderr string, err error) {
+					return "", "", nil
+				},
+				ShowFn: func(cmd *exec.Cmd) error { return nil },
+			}
+
+			cfg := &settings.Configuration{
+				BuildDir: buildDir,
+				Mode:     parser.ModeAUR,
+			}
+			pacmanConf := &pacmanconf.Config{
+				// Only testing the keep installed clean method right now
+				CleanMethod: []string{"KeepInstalled"},
+			}
+			run := &runtime.Runtime{
+				Cfg:        cfg,
+				PacmanConf: pacmanConf,
+				Logger:     newTestLogger(),
+			}
+			cmdArgs := parser.MakeArguments()
+			cmdArgs.AddArg(tc.args...)
+
+			// Create the package directories to be cleaned
+			err := os.MkdirAll(yayGitDir, 0755)
+			require.NoError(t, err)
+			err = os.MkdirAll(zoomDir, 0755)
+			require.NoError(t, err)
+
+			err = handleCmd(context.Background(),
+				run, cmdArgs, dbExc,
+			)
+			require.NoError(t, err)
+
+			// This should only test AUR cleaning, so no calls to an external command should be made
+			assert.Len(t, mockRunner.ShowCalls, 0)
+
+			// Make sure the directories left after cleaning are the only ones we expect
+			packageDirs, err := os.ReadDir(buildDir)
+			require.NoError(t, err)
+
+			var packageDirNames []string
+			for _, dir := range packageDirs {
+				packageDirNames = append(packageDirNames, dir.Name())
+			}
+
+			assert.ElementsMatch(t, tc.wantDirs, packageDirNames)
 		})
 	}
 }


### PR DESCRIPTION
Since #2644, specifying the `--clean` or `-c` argument would always clean all packages in the AUR cache, rather than needing to provide `-cc`. This PR reverts that change to restore normal functionality (`yay -Sca` removes non-installed AUR package caches and `yay -Scca` removes all AUR package caches). I also added a regression test to catch this if it happens again.