### PR TITLE
Add missing languages to Makefile LANGS list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LOCALEDIR := po
 SYSTEMLOCALEPATH := $(PREFIX)/share/locale/
 
 # ls -1 po | sed -e 's/\.po$//' | paste -sd " "
-LANGS := ca cs de en es eu fr_FR he id it_IT ja ko pl_PL pt_BR pt ru_RU ru sv tr uk zh_CN zh_TW
+LANGS := ca cs de en es eu fr_FR he hu id it_IT ja ko nl pl_PL pt_BR pt ru_RU ru sk sv tr uk vi vi_VN zh_CN zh_TW
 POTFILE := default.pot
 POFILES := $(addprefix $(LOCALEDIR)/,$(addsuffix .po,$(LANGS)))
 MOFILES := $(POFILES:.po=.mo)


### PR DESCRIPTION
Added hu (Hungarian), nl (Dutch), sk (Slovak), vi, and vi_VN (Vietnamese) to the LANGS variable so they are included in the build process.