### PR TITLE
Print an error message when a package isn't found when using -Si

### DIFF
--- a/query.go
+++ b/query.go
@@ -9,6 +9,7 @@ import (
 	aur "github.com/Jguer/aur"
 	alpm "github.com/Jguer/go-alpm/v2"
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/leonelquinteros/gotext"
 
 	"github.com/Jguer/yay/v12/pkg/db"
 	"github.com/Jguer/yay/v12/pkg/query"
@@ -37,9 +38,9 @@ func syncInfo(ctx context.Context, run *runtime.Runtime,
 	cmdArgs *parser.Arguments, pkgS []string, dbExecutor db.Executor,
 ) error {
 	var (
-		info    []aur.Pkg
-		err     error
-		missing = false
+		remoteAurPkgs []aur.Pkg
+		err           error
+		missing       = false
 	)
 
 	pkgS = query.RemoveInvalidTargets(run.Logger, pkgS, run.Cfg.Mode)
@@ -77,14 +78,25 @@ func syncInfo(ctx context.Context, run *runtime.Runtime,
 			noDB = append(noDB, name)
 		}
 
-		info, err = run.AURClient.Get(ctx, &aur.Query{
+		remoteAurPkgs, err = run.AURClient.Get(ctx, &aur.Query{
 			Needles: noDB,
 			By:      aur.Name,
 		})
 		if err != nil {
-			missing = true
-
 			run.Logger.Errorln(err)
+		}
+
+		// Check for any missing packages and print errors for any not found
+		found := mapset.NewThreadUnsafeSet[string]()
+		for i := range remoteAurPkgs {
+			found.Add(remoteAurPkgs[i].Name)
+		}
+
+		for _, name := range noDB {
+			if !found.Contains(name) {
+				missing = true
+				run.Logger.Errorln(gotext.Get("No AUR package found for"), " ", name)
+			}
 		}
 	}
 
@@ -100,12 +112,8 @@ func syncInfo(ctx context.Context, run *runtime.Runtime,
 		}
 	}
 
-	if len(aurS) != len(info) {
-		missing = true
-	}
-
-	for i := range info {
-		printInfo(run.Logger, run.Cfg, &info[i], cmdArgs.ExistsDouble("i"))
+	for i := range remoteAurPkgs {
+		printInfo(run.Logger, run.Cfg, &remoteAurPkgs[i], cmdArgs.ExistsDouble("i"))
 	}
 
 	if missing {


### PR DESCRIPTION
This fixes the second issue discussed in #2472. It uses the same solution to find missing packages as in #2717, so if both of these get merged, I can create a common function to not duplicate this logic.

A couple of notes on how `yay -Si <pkg>` differs from `pacman -Si <pkg>` (not huge deals IMO):
1. The exit code from yay is 1 when a package isn't found, whereas with pacman the exit code is the number of packages not found (mod 256)
2. pacman prints all packages in order of being specified, including errors. E.g specifying `cmatrix`, `nonexistent`, `firefox` will show the cmatrix info, then `'error: package 'nonexistent' not found`, then firefox info. Yay will print all packages not found first, then repo packages, then AUR packages due to the way the implementation is structured.

Both of these are not big deals, but wanted to point them out in case. I did not update/add any tests as this is just for error printing, but can do so if that is desired.