### PR TITLE
Fix ordering of msgfmt flag in Makefile to ensure compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,4 +131,4 @@ locale:
 	done
 
 ${LOCALEDIR}/%.mo: ${LOCALEDIR}/%.po
-	msgfmt $< -o $@
+	msgfmt -o $@ $<


### PR DESCRIPTION
This should fix #2519. I can't reproduce the issue but `msgfmt` expects options to be specified before the po files. This PR ensures the Makefile does this instead of ordering the po file before the output flag.