### PR TITLE
Update packages on builder before building release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ WORKDIR /app
 
 COPY . .
 
+RUN pacman -Syu --overwrite=* --noconfirm
+
 RUN make release VERSION=${VERSION} PREFIX=${PREFIX} ARCH=${ARCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG ARCH
 
 WORKDIR /app
 
-COPY . .
+RUN pacman -Syyu --overwrite=* --noconfirm
 
-RUN pacman -Syu --overwrite=* --noconfirm
+COPY . .
 
 RUN make release VERSION=${VERSION} PREFIX=${PREFIX} ARCH=${ARCH}

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ljmf00/archlinux:devel
+FROM docker.io/ogarcia/archlinux
 LABEL maintainer="Jguer,docker@jguer.space"
 
 ENV GO111MODULE=on

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ogarcia/archlinux
+FROM docker.io/gmanka/archlinuxarm:base-devel
 LABEL maintainer="Jguer,docker@jguer.space"
 
 ENV GO111MODULE=on

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -4,12 +4,15 @@ LABEL maintainer="Jguer,docker@jguer.space"
 ENV GO111MODULE=on
 WORKDIR /app
 
-RUN sed -i '/^\[community\]/,/^\[/ s/^/#/' /etc/pacman.conf
-
 COPY go.mod .
 
-RUN pacman-key --init && pacman -Sy && pacman -S --overwrite=* --noconfirm archlinux-keyring && \
-    pacman -Su --overwrite=* --needed --noconfirm pacman doxygen meson asciidoc go git gcc make sudo base-devel && \
-    rm -rfv /var/cache/pacman/* /var/lib/pacman/sync/* && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.4.0 && \
-    go mod download 
+ARG EXTRA_PKGS=""
+RUN set -eux; \
+    pacman-key --init; \
+    pacman -Syu --noconfirm --needed archlinux-keyring pacman go git gcc make base-devel sudo; \
+    if [ -n "${EXTRA_PKGS}" ]; then pacman -S --noconfirm --needed ${EXTRA_PKGS}; fi; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.4.0; \
+    go mod download; \
+    rm -rf /var/lib/pacman/sync/* /var/cache/pacman/* /tmp/* /var/tmp/*; \
+    rm -rf /usr/share/man/* /usr/share/doc/* || true; \
+    yes | pacman -Scc >/dev/null 2>&1 || true


### PR DESCRIPTION
This pull request introduces a small change to the `Dockerfile` to improve the build process by ensuring all system packages are up to date and compatible.

- Build process improvement:
  * Added a `RUN pacman -Syu --overwrite=* --noconfirm` step before running `make release` to update and synchronize system packages, preventing potential package conflicts during the build.