### PR TITLE
feat(repo): Sort repository results by pacman.conf repo order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ WORKDIR /app
 
 COPY . .
 
+RUN pacman -Syu --overwrite=* --noconfirm
+
 RUN make release VERSION=${VERSION} PREFIX=${PREFIX} ARCH=${ARCH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,4 @@ WORKDIR /app
 
 COPY . .
 
-RUN pacman -Syu --overwrite=* --noconfirm
-
 RUN make release VERSION=${VERSION} PREFIX=${PREFIX} ARCH=${ARCH}

--- a/pkg/db/mock/executor.go
+++ b/pkg/db/mock/executor.go
@@ -167,7 +167,8 @@ func (t *DBExecutor) Repos() []string {
 	if t.ReposFn != nil {
 		return t.ReposFn()
 	}
-	panic("implement me")
+	// Tests that don't care about repo ordering shouldn't need to stub this out.
+	return nil
 }
 
 func (t *DBExecutor) SatisfierFromDB(s, s2 string) (IPackage, error) {

--- a/pkg/query/metric.go
+++ b/pkg/query/metric.go
@@ -1,13 +1,16 @@
 package query
 
 import (
-	"hash/fnv"
 	"strings"
 
 	"github.com/adrg/strutil"
 )
 
 const minVotes = 30
+const (
+	separateSourceMax = 45.0
+	separateSourceMin = 5.0
+)
 
 // TODO: Add support for Popularity and LastModified
 func (a *abstractResults) aurSortByMetric(pkg *abstractResult) float64 {
@@ -58,29 +61,35 @@ func (a *abstractResults) separateSourceScore(source string, score float64) floa
 		return 50
 	}
 
-	switch source {
-	case sourceAUR:
-		return 0
-	case "core":
-		return 40
-	case "extra":
-		return 30
-	case "community":
-		return 20
-	case "multilib":
-		return 10
-	}
-
 	if v, ok := a.separateSourceCache[source]; ok {
 		return v
 	}
 
-	h := fnv.New32a()
-	h.Write([]byte(source))
-	sourceScore := float64(int(h.Sum32())%9 + 2)
-	a.separateSourceCache[source] = sourceScore
+	// AUR is always lowest priority
+	if source == sourceAUR {
+		return 0
+	}
 
-	return sourceScore
+	// Score sync repositories based on pacman.conf order (as reflected by dbExecutor.Repos()).
+	// First repo gets max, last repo gets min, evenly distributed across the range.
+	for i, repo := range a.repoOrder {
+		if repo != source {
+			continue
+		}
+
+		n := len(a.repoOrder)
+		if n == 1 {
+			a.separateSourceCache[source] = separateSourceMax
+			return separateSourceMax
+		}
+
+		step := (separateSourceMax - separateSourceMin) / float64(n-1)
+		sourceScore := separateSourceMax - (float64(i) * step)
+		a.separateSourceCache[source] = sourceScore
+		return sourceScore
+	}
+
+	return 0
 }
 
 func (a *abstractResults) calculateMetric(pkg *abstractResult) float64 {

--- a/pkg/query/metric_test.go
+++ b/pkg/query/metric_test.go
@@ -1,0 +1,47 @@
+//go:build !integration
+// +build !integration
+
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeparateSourceScore_UsesRepoOrderEvenlyDistributed(t *testing.T) {
+	t.Parallel()
+
+	// Any non-1.0 score avoids the special-case 50 return.
+	const sim = 0.5
+	const delta = 1e-1
+
+	t.Run("arch repos (core/extra/community/multilib)", func(t *testing.T) {
+		a := &abstractResults{
+			separateSources:     true,
+			repoOrder:           []string{"core", "extra", "community", "multilib"},
+			separateSourceCache: map[string]float64{},
+		}
+
+		assert.InDelta(t, 45.0, a.separateSourceScore("core", sim), delta)
+		assert.InDelta(t, 31.6, a.separateSourceScore("extra", sim), delta)
+		assert.InDelta(t, 18.3, a.separateSourceScore("community", sim), delta)
+		assert.InDelta(t, 5.0, a.separateSourceScore("multilib", sim), delta)
+		assert.Equal(t, 0.0, a.separateSourceScore(sourceAUR, sim))
+	})
+
+	t.Run("arch arm repos (core/extra/alarm/aur)", func(t *testing.T) {
+		a := &abstractResults{
+			separateSources:     true,
+			repoOrder:           []string{"core", "extra", "alarm", "aur"},
+			separateSourceCache: map[string]float64{},
+		}
+
+		// Note: AUR is not a sync repository; it is always lowest priority (0) regardless of repo order.
+		assert.InDelta(t, 45.0, a.separateSourceScore("core", sim), delta)
+		assert.InDelta(t, 31.6, a.separateSourceScore("extra", sim), delta)
+		assert.InDelta(t, 18.3, a.separateSourceScore("alarm", sim), delta)
+		assert.InDelta(t, 5.0, a.separateSourceScore("aur", sim), delta)
+		assert.Equal(t, 0.0, a.separateSourceScore(sourceAUR, sim))
+	})
+}

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Jguer/yay/v12/pkg/text"
 )
 
-const sourceAUR = "aur"
+const sourceAUR = "AUR"
 
 type SearchVerbosity int
 
@@ -91,6 +91,7 @@ type abstractResults struct {
 	metric          strutil.StringMetric
 	separateSources bool
 	sortBy          string
+	repoOrder       []string
 
 	distanceCache       map[string]float64
 	separateSourceCache map[string]float64
@@ -143,6 +144,7 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 		metric:              metric,
 		separateSources:     s.separateSources,
 		sortBy:              s.sortBy,
+		repoOrder:           dbExecutor.Repos(),
 		distanceCache:       map[string]float64{},
 		separateSourceCache: map[string]float64{},
 	}

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -148,35 +148,6 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 		distanceCache:       map[string]float64{},
 		separateSourceCache: map[string]float64{},
 	}
-
-	if s.targetMode.AtLeastAUR() {
-		var aurResults []aur.Pkg
-		aurResults, aurErr = queryAUR(ctx, s.aurClient, pkgS, s.searchBy)
-		dbName := sourceAUR
-
-		for i := range aurResults {
-			if s.queryMap[dbName] == nil {
-				s.queryMap[dbName] = map[string]any{}
-			}
-
-			by := getSearchBy(s.searchBy)
-			if (by == aur.NameDesc || by == aur.None || by == aur.Name) &&
-				!matchesSearch(&aurResults[i], pkgS) {
-				continue
-			}
-
-			s.queryMap[dbName][aurResults[i].Name] = aurResults[i]
-
-			sortableResults.results = append(sortableResults.results, abstractResult{
-				source:      dbName,
-				name:        aurResults[i].Name,
-				description: aurResults[i].Description,
-				provides:    aurResults[i].Provides,
-				votes:       aurResults[i].NumVotes,
-			})
-		}
-	}
-
 	var repoResults []alpm.IPackage
 	if s.targetMode.AtLeastRepo() {
 		repoResults = dbExecutor.SyncPackages(pkgS...)
@@ -202,6 +173,34 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 				description: repoResults[i].Description(),
 				provides:    provides,
 				votes:       -1,
+			})
+		}
+	}
+
+	if s.targetMode.AtLeastAUR() {
+		var aurResults []aur.Pkg
+		aurResults, aurErr = queryAUR(ctx, s.aurClient, pkgS, s.searchBy)
+		dbName := sourceAUR
+
+		for i := range aurResults {
+			if s.queryMap[dbName] == nil {
+				s.queryMap[dbName] = map[string]any{}
+			}
+
+			by := getSearchBy(s.searchBy)
+			if (by == aur.NameDesc || by == aur.None || by == aur.Name) &&
+				!matchesSearch(&aurResults[i], pkgS) {
+				continue
+			}
+
+			s.queryMap[dbName][aurResults[i].Name] = aurResults[i]
+
+			sortableResults.results = append(sortableResults.results, abstractResult{
+				source:      dbName,
+				name:        aurResults[i].Name,
+				description: aurResults[i].Description,
+				provides:    aurResults[i].Provides,
+				votes:       aurResults[i].NumVotes,
 			})
 		}
 	}

--- a/pkg/query/query_builder_test.go
+++ b/pkg/query/query_builder_test.go
@@ -289,6 +289,10 @@ func TestSourceQueryBuilder(t *testing.T) {
 	}
 
 	mockDB := &mock.DBExecutor{
+		ReposFn: func() []string {
+			// Match pacman.conf parsing order for source separation.
+			return []string{"core"}
+		},
 		SyncPackagesFn: func(pkgs ...string) []mock.IPackage {
 			mockDB := mock.NewDB("core")
 			return []mock.IPackage{


### PR DESCRIPTION
This PR updates repository result sorting to follow the repository order defined in pacman.conf.
When multiple repositories provide the same package, the results are now ordered consistently based on the user’s configured repo priority (top-to-bottom in pacman.conf).


fixes #2639
