### PR TITLE
Fix building packages with incompatible architectures in makepkg 7.1.0+

### DIFF
--- a/pkg/sync/build/pkg_archive.go
+++ b/pkg/sync/build/pkg_archive.go
@@ -127,8 +127,9 @@ func asexp(ctx context.Context,
 func parsePackageList(ctx context.Context, cmdBuilder exe.ICmdBuilder,
 	dir string,
 ) (pkgdests map[string]string, pkgVersion string, err error) {
+	args := []string{"--packagelist", "--ignorearch"}
 	stdout, stderr, err := cmdBuilder.Capture(
-		cmdBuilder.BuildMakepkgCmd(ctx, dir, "--packagelist"))
+		cmdBuilder.BuildMakepkgCmd(ctx, dir, args...))
 	if err != nil {
 		return nil, "", fmt.Errorf("%s %w", stderr, err)
 	}


### PR DESCRIPTION
In pacman 7.1.0+, makepkg was changed to check for a package's architecture compatibility when running `--packagelist` (see https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/307). This broke Yay's ability to ignore a package's architecture when installing it (running the package list command would fail with an incompatible architecture error).

`parsePackageList` is only called from the installer which already checks to make sure the user is okay with building the package on the incompatible architecture. In the future if this were to be called from more places it *could* be an issue to always pass `--ignorearch`, but I can't really think of a situation this would happen. I'm happy to add a parameter to `parsePackageList` so the caller has control over passing `--ignorearch` to makepkg.