### PR TITLE
Add support for all sortyby options

### DIFF
--- a/completions/fish
+++ b/completions/fish
@@ -203,7 +203,7 @@ complete -c $progname -n "not $noopt" -l makepkgconf -d 'Use custom makepkg.conf
 complete -c $progname -n "not $noopt" -l nomakepkgconf -d 'Use default makepkg.conf' -f
 complete -c $progname -n "not $noopt" -l requestsplitn -d 'Max amount of packages to query per AUR request' -f
 complete -c $progname -n "not $noopt" -l completioninterval -d 'Refresh interval for completion cache' -f
-complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specific field during search' -xa "{votes,popularity,id,baseid,name,base,submitted,modified}"
+complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specific field during search' -xa "{votes,popularity,name,base,submitted,modified}"
 complete -c $progname -n "not $noopt" -l searchby -d 'Search for AUR packages by querying the specified field' -xa "{name,name-desc,maintainer,depends,checkdepends,makedepends,optdepends}"
 complete -c $progname -n "not $noopt" -l answerclean -d 'Set a predetermined answer for the clean build menu' -xa "{All,None,Installed,NotInstalled}"
 complete -c $progname -n "not $noopt" -l answerdiff -d 'Set a predetermined answer for the edit diff menu' -xa "{All,None,Installed,NotInstalled}"

--- a/completions/zsh
+++ b/completions/zsh
@@ -58,7 +58,7 @@ _pacman_opts_common=(
 	'--git[git command to use]:git:_files'
 	'--gpg[gpg command to use]:gpg:_files'
 
-	'--sortby[Sort AUR results by a specific field during search]:sortby options:(votes popularity id baseid name base submitted modified)'
+	'--sortby[Sort AUR results by a specific field during search]:sortby options:(votes popularity name base submitted modified)'
 	'--searchby[Search for packages using a specified field]:query'
 	'(--noanswerclean)--answerclean[Set a predetermined answer for the clean build menu]:answer'
 	'(--noanswerdiff)--answerdiff[Set a predetermined answer for the diff menu]:answer'

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -245,7 +245,7 @@ the cache to be refreshed every time, while setting this to -1 will cause the
 cache to never be refreshed.
 
 .TP
-.B \-\-sortby <votes|popularity|id|baseid|name|base|submitted|modified>
+.B \-\-sortby <votes|popularity|name|base|submitted|modified>
 Sort AUR results by a specific field during search.
 
 .TP

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -84,8 +84,6 @@ type abstractResult struct {
 	name           string
 	description    string
 	packageBase    string
-	packageId      int
-	packageBaseId  int
 	votes          int
 	popularity     float64
 	firstSubmitted int
@@ -123,14 +121,6 @@ func (a *abstractResults) GetSortFunc(sortBy string, bottomUp bool) SortFunc {
 	case "base":
 		sortFunc = func(pkgA, pkgB abstractResult) int {
 			return cmp.Compare(pkgA.packageBase, pkgB.packageBase)
-		}
-	case "baseid":
-		sortFunc = func(pkgA, pkgB abstractResult) int {
-			return cmp.Compare(pkgA.packageBaseId, pkgB.packageBaseId)
-		}
-	case "id":
-		sortFunc = func(pkgA, pkgB abstractResult) int {
-			return cmp.Compare(pkgA.packageId, pkgB.packageId)
 		}
 	case "modified":
 		sortFunc = func(pkgA, pkgB abstractResult) int {
@@ -232,8 +222,6 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 				name:           repoResults[i].Name(),
 				description:    repoResults[i].Description(),
 				packageBase:    repoResults[i].Base(),
-				packageId:      -1,
-				packageBaseId:  -1,
 				votes:          -1,
 				popularity:     -1,
 				firstSubmitted: -1,
@@ -266,8 +254,6 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 				name:           aurResults[i].Name,
 				description:    aurResults[i].Description,
 				packageBase:    aurResults[i].PackageBase,
-				packageId:      aurResults[i].ID,
-				packageBaseId:  aurResults[i].PackageBaseID,
 				votes:          aurResults[i].NumVotes,
 				popularity:     aurResults[i].Popularity,
 				firstSubmitted: aurResults[i].FirstSubmitted,

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -158,29 +158,22 @@ func (a *abstractResults) GetSortFunc(sortBy string, bottomUp bool) SortFunc {
 		}
 	}
 
-	// Secondary sort by metric (tie-breaker)
+	// Sort by metric as a tie-breaker. Also handle separating sources when not a tie
 	{
 		originalSortFunc := sortFunc
 		sortFunc = func(pkgA, pkgB abstractResult) int {
 			if cmpResult := originalSortFunc(pkgA, pkgB); cmpResult != 0 {
+				if a.separateSources {
+					if cmpSources := strings.Compare(pkgA.source, pkgB.source); cmpSources != 0 {
+						return cmpSources
+					}
+				}
 				return cmpResult
 			}
 
 			metricA := a.calculateMetric(&pkgA)
 			metricB := a.calculateMetric(&pkgB)
 			return cmp.Compare(metricA, metricB)
-		}
-	}
-
-	if a.separateSources {
-		// Sort by source first
-		originalSortFunc := sortFunc
-		sortFunc = func(pkgA, pkgB abstractResult) int {
-			cmpSources := strings.Compare(pkgA.source, pkgB.source)
-			if cmpSources == 0 {
-				return originalSortFunc(pkgA, pkgB)
-			}
-			return cmpSources
 		}
 	}
 

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"cmp"
 	"context"
 	"sort"
 	"strconv"
@@ -37,6 +38,8 @@ type Builder interface {
 	Results(dbExecutor db.Executor, verboseSearch SearchVerbosity) error
 	GetTargets(include, exclude intrange.IntRanges, otherExclude mapset.Set[string]) ([]string, error)
 }
+
+type SortFunc func(pkgA, pkgB abstractResult) int
 
 type SourceQueryBuilder struct {
 	results           []abstractResult
@@ -77,20 +80,25 @@ func NewSourceQueryBuilder(
 }
 
 type abstractResult struct {
-	source      string
-	name        string
-	description string
-	votes       int
-	provides    []string
+	source         string
+	name           string
+	description    string
+	packageBase    string
+	packageId      int
+	packageBaseId  int
+	votes          int
+	popularity     float64
+	firstSubmitted int
+	lastModified   int
+	provides       []string
 }
 
 type abstractResults struct {
 	results         []abstractResult
 	search          string
-	bottomUp        bool
 	metric          strutil.StringMetric
 	separateSources bool
-	sortBy          string
+	sortByFunc      SortFunc
 	repoOrder       []string
 
 	distanceCache       map[string]float64
@@ -103,29 +111,88 @@ func (a *abstractResults) Swap(i, j int) { a.results[i], a.results[j] = a.result
 func (a *abstractResults) Less(i, j int) bool {
 	pkgA := a.results[i]
 	pkgB := a.results[j]
+	// Sort in descending order by default
+	return a.sortByFunc(pkgA, pkgB) > 0
+}
 
-	var cmpResult bool
+func (a *abstractResults) GetSortFunc(sortBy string, bottomUp bool) SortFunc {
+	var sortFunc SortFunc
 
-	switch a.sortBy {
+	// Primary sort
+	switch sortBy {
+	case "base":
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.packageBase, pkgB.packageBase)
+		}
+	case "baseid":
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.packageBaseId, pkgB.packageBaseId)
+		}
+	case "id":
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.packageId, pkgB.packageId)
+		}
+	case "modified":
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.lastModified, pkgB.lastModified)
+		}
 	case "name":
-		cmpResult = !text.LessRunes([]rune(pkgA.name), []rune(pkgB.name))
-		if a.separateSources {
-			cmpSources := strings.Compare(pkgA.source, pkgB.source)
-			if cmpSources != 0 {
-				cmpResult = cmpSources > 0
-			}
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.name, pkgB.name)
+		}
+	case "popularity":
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.popularity, pkgB.popularity)
+		}
+	case "submitted":
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.firstSubmitted, pkgB.firstSubmitted)
+		}
+	case "votes":
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return cmp.Compare(pkgA.votes, pkgB.votes)
 		}
 	default:
-		simA := a.calculateMetric(&pkgA)
-		simB := a.calculateMetric(&pkgB)
-		cmpResult = simA > simB
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return 0
+		}
 	}
 
-	if a.bottomUp {
-		cmpResult = !cmpResult
+	// Secondary sort by metric (tie-breaker)
+	{
+		originalSortFunc := sortFunc
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			if cmpResult := originalSortFunc(pkgA, pkgB); cmpResult != 0 {
+				return cmpResult
+			}
+
+			metricA := a.calculateMetric(&pkgA)
+			metricB := a.calculateMetric(&pkgB)
+			return cmp.Compare(metricA, metricB)
+		}
 	}
 
-	return cmpResult
+	if a.separateSources {
+		// Sort by source first
+		originalSortFunc := sortFunc
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			cmpSources := strings.Compare(pkgA.source, pkgB.source)
+			if cmpSources == 0 {
+				return originalSortFunc(pkgA, pkgB)
+			}
+			return cmpSources
+		}
+	}
+
+	if bottomUp {
+		// Invert sort for bottom-up sorting
+		originalSortFunc := sortFunc
+		sortFunc = func(pkgA, pkgB abstractResult) int {
+			return -originalSortFunc(pkgA, pkgB)
+		}
+	}
+
+	return sortFunc
 }
 
 func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor, pkgS []string) {
@@ -140,14 +207,14 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 	sortableResults := &abstractResults{
 		results:             []abstractResult{},
 		search:              strings.Join(pkgS, ""),
-		bottomUp:            s.bottomUp,
 		metric:              metric,
 		separateSources:     s.separateSources,
-		sortBy:              s.sortBy,
 		repoOrder:           dbExecutor.Repos(),
 		distanceCache:       map[string]float64{},
 		separateSourceCache: map[string]float64{},
 	}
+	sortableResults.sortByFunc = sortableResults.GetSortFunc(s.sortBy, s.bottomUp)
+
 	var repoResults []alpm.IPackage
 	if s.targetMode.AtLeastRepo() {
 		repoResults = dbExecutor.SyncPackages(pkgS...)
@@ -168,11 +235,17 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 			}
 
 			sortableResults.results = append(sortableResults.results, abstractResult{
-				source:      repoResults[i].DB().Name(),
-				name:        repoResults[i].Name(),
-				description: repoResults[i].Description(),
-				provides:    provides,
-				votes:       -1,
+				source:         repoResults[i].DB().Name(),
+				name:           repoResults[i].Name(),
+				description:    repoResults[i].Description(),
+				packageBase:    repoResults[i].Base(),
+				packageId:      -1,
+				packageBaseId:  -1,
+				votes:          -1,
+				popularity:     -1,
+				firstSubmitted: -1,
+				lastModified:   -1,
+				provides:       provides,
 			})
 		}
 	}
@@ -196,11 +269,17 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 			s.queryMap[dbName][aurResults[i].Name] = aurResults[i]
 
 			sortableResults.results = append(sortableResults.results, abstractResult{
-				source:      dbName,
-				name:        aurResults[i].Name,
-				description: aurResults[i].Description,
-				provides:    aurResults[i].Provides,
-				votes:       aurResults[i].NumVotes,
+				source:         dbName,
+				name:           aurResults[i].Name,
+				description:    aurResults[i].Description,
+				packageBase:    aurResults[i].PackageBase,
+				packageId:      aurResults[i].ID,
+				packageBaseId:  aurResults[i].PackageBaseID,
+				votes:          aurResults[i].NumVotes,
+				popularity:     aurResults[i].Popularity,
+				firstSubmitted: aurResults[i].FirstSubmitted,
+				lastModified:   aurResults[i].LastModified,
+				provides:       aurResults[i].Provides,
 			})
 		}
 	}

--- a/pkg/query/query_builder_test.go
+++ b/pkg/query/query_builder_test.go
@@ -504,30 +504,6 @@ func TestSourceQueryBuilderSortByFields(t *testing.T) {
 			wantNames: []string{"ruby-yard", "yay", "yay-git"},
 		},
 		{
-			desc:      "sort-by-baseid topdown",
-			sortBy:    "baseid",
-			bottomUp:  false,
-			wantNames: []string{"yay-git", "yay", "ruby-yard"},
-		},
-		{
-			desc:      "sort-by-baseid bottomup",
-			sortBy:    "baseid",
-			bottomUp:  true,
-			wantNames: []string{"ruby-yard", "yay", "yay-git"},
-		},
-		{
-			desc:      "sort-by-id topdown",
-			sortBy:    "id",
-			bottomUp:  false,
-			wantNames: []string{"yay-git", "yay", "ruby-yard"},
-		},
-		{
-			desc:      "sort-by-id bottomup",
-			sortBy:    "id",
-			bottomUp:  true,
-			wantNames: []string{"ruby-yard", "yay", "yay-git"},
-		},
-		{
 			desc:      "sort-by-modified topdown",
 			sortBy:    "modified",
 			bottomUp:  false,

--- a/pkg/query/query_builder_test.go
+++ b/pkg/query/query_builder_test.go
@@ -35,6 +35,8 @@ func TestSourceQueryBuilder(t *testing.T) {
 		wantOutput        []string
 	}
 
+	mockDB, mockAUR := newQueryBuilderMocks()
+
 	testCases := []testCase{
 		{
 			desc:            "sort-by-votes bottomup separatesources",
@@ -71,11 +73,11 @@ func TestSourceQueryBuilder(t *testing.T) {
 			separateSources: false,
 			sortBy:          "votes",
 			verbosity:       Detailed,
-			wantResults:     []string{"linux-zen", "linux-ck", "linux"},
+			wantResults:     []string{"linux-zen", "linux", "linux-ck"},
 			wantOutput: []string{
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
-				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
+				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
 			},
 		},
 		{
@@ -85,67 +87,11 @@ func TestSourceQueryBuilder(t *testing.T) {
 			separateSources: false,
 			sortBy:          "votes",
 			verbosity:       Detailed,
-			wantResults:     []string{"linux", "linux-ck", "linux-zen"},
-			wantOutput: []string{
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
-				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
-			},
-		},
-		{
-			desc:            "sort-by-name bottomup separatesources",
-			search:          []string{"linux"},
-			bottomUp:        true,
-			separateSources: true,
-			sortBy:          "name",
-			verbosity:       Detailed,
 			wantResults:     []string{"linux-ck", "linux", "linux-zen"},
 			wantOutput: []string{
 				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
-			},
-		},
-		{
-			desc:            "sort-by-name topdown separatesources",
-			search:          []string{"linux"},
-			bottomUp:        false,
-			separateSources: true,
-			sortBy:          "name",
-			verbosity:       Detailed,
-			wantResults:     []string{"linux-zen", "linux", "linux-ck"},
-			wantOutput: []string{
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
-				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
-			},
-		},
-		{
-			desc:            "sort-by-name bottomup noseparatesources",
-			search:          []string{"linux"},
-			bottomUp:        true,
-			separateSources: false,
-			sortBy:          "name",
-			verbosity:       Detailed,
-			wantResults:     []string{"linux", "linux-ck", "linux-zen"},
-			wantOutput: []string{
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
-				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
-			},
-		},
-		{
-			desc:            "sort-by-name topdown noseparatesources",
-			search:          []string{"linux"},
-			bottomUp:        false,
-			separateSources: false,
-			sortBy:          "name",
-			verbosity:       Detailed,
-			wantResults:     []string{"linux-zen", "linux-ck", "linux"},
-			wantOutput: []string{
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
-				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
 			},
 		},
 		{
@@ -288,6 +234,173 @@ func TestSourceQueryBuilder(t *testing.T) {
 		},
 	}
 
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &strings.Builder{}
+			queryBuilder := NewSourceQueryBuilder(mockAUR,
+				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
+				tc.sortBy, tc.targetMode, tc.searchBy, tc.bottomUp,
+				tc.singleLineResults, tc.separateSources)
+
+			queryBuilder.Execute(context.Background(), mockDB, tc.search)
+
+			assert.Len(t, queryBuilder.results, len(tc.wantResults))
+			assert.Equal(t, len(tc.wantResults), queryBuilder.Len())
+			for i, name := range tc.wantResults {
+				assert.Equal(t, name, queryBuilder.results[i].name)
+			}
+
+			queryBuilder.Results(mockDB, tc.verbosity)
+
+			assert.Equal(t, strings.Join(tc.wantOutput, ""), w.String())
+		})
+	}
+}
+
+func TestSourceQueryBuilderSortByFields(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		desc      string
+		sortBy    string
+		bottomUp  bool
+		wantNames []string
+	}
+
+	testCases := []testCase{
+		{
+			desc:      "sort-by-base topdown",
+			sortBy:    "base",
+			bottomUp:  false,
+			wantNames: []string{"linux-zen", "linux-ck", "linux"},
+		},
+		{
+			desc:      "sort-by-base bottomup",
+			sortBy:    "base",
+			bottomUp:  true,
+			wantNames: []string{"linux", "linux-ck", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-baseid topdown",
+			sortBy:    "baseid",
+			bottomUp:  false,
+			wantNames: []string{"linux-ck", "linux", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-baseid bottomup",
+			sortBy:    "baseid",
+			bottomUp:  true,
+			wantNames: []string{"linux-zen", "linux", "linux-ck"},
+		},
+		{
+			desc:      "sort-by-id topdown",
+			sortBy:    "id",
+			bottomUp:  false,
+			wantNames: []string{"linux-ck", "linux", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-id bottomup",
+			sortBy:    "id",
+			bottomUp:  true,
+			wantNames: []string{"linux-zen", "linux", "linux-ck"},
+		},
+		{
+			desc:      "sort-by-modified topdown",
+			sortBy:    "modified",
+			bottomUp:  false,
+			wantNames: []string{"linux-ck", "linux", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-modified bottomup",
+			sortBy:    "modified",
+			bottomUp:  true,
+			wantNames: []string{"linux-zen", "linux", "linux-ck"},
+		},
+		{
+			desc:      "sort-by-name topdown",
+			sortBy:    "name",
+			bottomUp:  false,
+			wantNames: []string{"linux-zen", "linux-ck", "linux"},
+		},
+		{
+			desc:      "sort-by-name bottomup",
+			sortBy:    "name",
+			bottomUp:  true,
+			wantNames: []string{"linux", "linux-ck", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-popularity topdown",
+			sortBy:    "popularity",
+			bottomUp:  false,
+			wantNames: []string{"linux-ck", "linux", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-popularity bottomup",
+			sortBy:    "popularity",
+			bottomUp:  true,
+			wantNames: []string{"linux-zen", "linux", "linux-ck"},
+		},
+		{
+			desc:      "sort-by-votes topdown",
+			sortBy:    "votes",
+			bottomUp:  false,
+			wantNames: []string{"linux-ck", "linux", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-votes bottomup",
+			sortBy:    "votes",
+			bottomUp:  true,
+			wantNames: []string{"linux-zen", "linux", "linux-ck"},
+		},
+		{
+			desc:      "sort-by-submitted topdown",
+			sortBy:    "submitted",
+			bottomUp:  false,
+			wantNames: []string{"linux-ck", "linux", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-submitted bottomup",
+			sortBy:    "submitted",
+			bottomUp:  true,
+			wantNames: []string{"linux-zen", "linux", "linux-ck"},
+		},
+		{
+			desc:      "sort-by-default topdown",
+			sortBy:    "",
+			bottomUp:  false,
+			wantNames: []string{"linux", "linux-ck", "linux-zen"},
+		},
+		{
+			desc:      "sort-by-default bottomup",
+			sortBy:    "",
+			bottomUp:  true,
+			wantNames: []string{"linux-zen", "linux-ck", "linux"},
+		},
+	}
+
+	mockDB, mockAUR := newQueryBuilderMocks()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &strings.Builder{}
+			queryBuilder := NewSourceQueryBuilder(mockAUR,
+				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
+				tc.sortBy, parser.ModeAny, "", tc.bottomUp,
+				false, false)
+
+			queryBuilder.Execute(context.Background(), mockDB, []string{"linux"})
+
+			gotNames := make([]string, len(queryBuilder.results))
+			for i, result := range queryBuilder.results {
+				gotNames[i] = result.name
+			}
+
+			assert.Equal(t, tc.wantNames, gotNames)
+		})
+	}
+}
+
+func newQueryBuilderMocks() (*mock.DBExecutor, *mockaur.MockAUR) {
 	mockDB := &mock.DBExecutor{
 		ReposFn: func() []string {
 			// Match pacman.conf parsing order for source separation.
@@ -297,6 +410,7 @@ func TestSourceQueryBuilder(t *testing.T) {
 			mockDB := mock.NewDB("core")
 			return []mock.IPackage{
 				&mock.Package{
+					PBase:         "linux",
 					PName:         "linux",
 					PVersion:      "5.16.0",
 					PDescription:  "The Linux kernel and modules",
@@ -306,6 +420,7 @@ func TestSourceQueryBuilder(t *testing.T) {
 					PArchitecture: "x86_64",
 				},
 				&mock.Package{
+					PBase:         "linux-zen",
 					PName:         "linux-zen",
 					PVersion:      "5.16.0",
 					PDescription:  "The Linux ZEN kernel and modules",
@@ -344,25 +459,5 @@ func TestSourceQueryBuilder(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			w := &strings.Builder{}
-			queryBuilder := NewSourceQueryBuilder(mockAUR,
-				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
-				tc.sortBy, tc.targetMode, tc.searchBy, tc.bottomUp,
-				tc.singleLineResults, tc.separateSources)
-
-			queryBuilder.Execute(context.Background(), mockDB, tc.search)
-
-			assert.Len(t, queryBuilder.results, len(tc.wantResults))
-			assert.Equal(t, len(tc.wantResults), queryBuilder.Len())
-			for i, name := range tc.wantResults {
-				assert.Equal(t, name, queryBuilder.results[i].name)
-			}
-
-			queryBuilder.Results(mockDB, tc.verbosity)
-
-			assert.Equal(t, strings.Join(tc.wantOutput, ""), w.String())
-		})
-	}
+	return mockDB, mockAUR
 }

--- a/pkg/query/query_builder_test.go
+++ b/pkg/query/query_builder_test.go
@@ -35,15 +35,13 @@ func TestSourceQueryBuilder(t *testing.T) {
 		wantOutput        []string
 	}
 
-	mockDB, mockAUR := newQueryBuilderMocks()
-
 	testCases := []testCase{
 		{
-			desc:            "sort-by-votes bottomup separatesources",
+			desc:            "sort-by-metric bottomup separatesources",
 			search:          []string{"linux"},
 			bottomUp:        true,
 			separateSources: true,
-			sortBy:          "votes",
+			sortBy:          "",
 			verbosity:       Detailed,
 			wantResults:     []string{"linux-ck", "linux-zen", "linux"},
 			wantOutput: []string{
@@ -53,11 +51,11 @@ func TestSourceQueryBuilder(t *testing.T) {
 			},
 		},
 		{
-			desc:            "sort-by-votes topdown separatesources",
+			desc:            "sort-by-metric topdown separatesources",
 			search:          []string{"linux"},
 			bottomUp:        false,
 			separateSources: true,
-			sortBy:          "votes",
+			sortBy:          "",
 			verbosity:       Detailed,
 			wantResults:     []string{"linux", "linux-zen", "linux-ck"},
 			wantOutput: []string{
@@ -67,39 +65,39 @@ func TestSourceQueryBuilder(t *testing.T) {
 			},
 		},
 		{
-			desc:            "sort-by-votes bottomup noseparatesources",
+			desc:            "sort-by-metric bottomup noseparatesources",
 			search:          []string{"linux"},
 			bottomUp:        true,
 			separateSources: false,
-			sortBy:          "votes",
+			sortBy:          "",
 			verbosity:       Detailed,
-			wantResults:     []string{"linux-zen", "linux", "linux-ck"},
+			wantResults:     []string{"linux-zen", "linux-ck", "linux"},
 			wantOutput: []string{
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
 				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
+				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
 			},
 		},
 		{
-			desc:            "sort-by-votes topdown noseparatesources",
+			desc:            "sort-by-metric topdown noseparatesources",
 			search:          []string{"linux"},
 			bottomUp:        false,
 			separateSources: false,
-			sortBy:          "votes",
+			sortBy:          "",
 			verbosity:       Detailed,
-			wantResults:     []string{"linux-ck", "linux", "linux-zen"},
+			wantResults:     []string{"linux", "linux-ck", "linux-zen"},
 			wantOutput: []string{
-				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
+				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
 			},
 		},
 		{
-			desc:            "sort-by-votes bottomup separatesources number-menu",
+			desc:            "sort-by-metric bottomup separatesources number-menu",
 			search:          []string{"linux"},
 			bottomUp:        true,
 			separateSources: true,
-			sortBy:          "votes",
+			sortBy:          "",
 			verbosity:       NumberMenu,
 			wantResults:     []string{"linux-ck", "linux-zen", "linux"},
 			wantOutput: []string{
@@ -109,11 +107,11 @@ func TestSourceQueryBuilder(t *testing.T) {
 			},
 		},
 		{
-			desc:            "sort-by-votes topdown separatesources number-menu",
+			desc:            "sort-by-metric topdown separatesources number-menu",
 			search:          []string{"linux"},
 			bottomUp:        false,
 			separateSources: true,
-			sortBy:          "votes",
+			sortBy:          "",
 			verbosity:       NumberMenu,
 			wantResults:     []string{"linux", "linux-zen", "linux-ck"},
 			wantOutput: []string{
@@ -234,173 +232,6 @@ func TestSourceQueryBuilder(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			w := &strings.Builder{}
-			queryBuilder := NewSourceQueryBuilder(mockAUR,
-				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
-				tc.sortBy, tc.targetMode, tc.searchBy, tc.bottomUp,
-				tc.singleLineResults, tc.separateSources)
-
-			queryBuilder.Execute(context.Background(), mockDB, tc.search)
-
-			assert.Len(t, queryBuilder.results, len(tc.wantResults))
-			assert.Equal(t, len(tc.wantResults), queryBuilder.Len())
-			for i, name := range tc.wantResults {
-				assert.Equal(t, name, queryBuilder.results[i].name)
-			}
-
-			queryBuilder.Results(mockDB, tc.verbosity)
-
-			assert.Equal(t, strings.Join(tc.wantOutput, ""), w.String())
-		})
-	}
-}
-
-func TestSourceQueryBuilderSortByFields(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		desc      string
-		sortBy    string
-		bottomUp  bool
-		wantNames []string
-	}
-
-	testCases := []testCase{
-		{
-			desc:      "sort-by-base topdown",
-			sortBy:    "base",
-			bottomUp:  false,
-			wantNames: []string{"linux-zen", "linux-ck", "linux"},
-		},
-		{
-			desc:      "sort-by-base bottomup",
-			sortBy:    "base",
-			bottomUp:  true,
-			wantNames: []string{"linux", "linux-ck", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-baseid topdown",
-			sortBy:    "baseid",
-			bottomUp:  false,
-			wantNames: []string{"linux-ck", "linux", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-baseid bottomup",
-			sortBy:    "baseid",
-			bottomUp:  true,
-			wantNames: []string{"linux-zen", "linux", "linux-ck"},
-		},
-		{
-			desc:      "sort-by-id topdown",
-			sortBy:    "id",
-			bottomUp:  false,
-			wantNames: []string{"linux-ck", "linux", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-id bottomup",
-			sortBy:    "id",
-			bottomUp:  true,
-			wantNames: []string{"linux-zen", "linux", "linux-ck"},
-		},
-		{
-			desc:      "sort-by-modified topdown",
-			sortBy:    "modified",
-			bottomUp:  false,
-			wantNames: []string{"linux-ck", "linux", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-modified bottomup",
-			sortBy:    "modified",
-			bottomUp:  true,
-			wantNames: []string{"linux-zen", "linux", "linux-ck"},
-		},
-		{
-			desc:      "sort-by-name topdown",
-			sortBy:    "name",
-			bottomUp:  false,
-			wantNames: []string{"linux-zen", "linux-ck", "linux"},
-		},
-		{
-			desc:      "sort-by-name bottomup",
-			sortBy:    "name",
-			bottomUp:  true,
-			wantNames: []string{"linux", "linux-ck", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-popularity topdown",
-			sortBy:    "popularity",
-			bottomUp:  false,
-			wantNames: []string{"linux-ck", "linux", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-popularity bottomup",
-			sortBy:    "popularity",
-			bottomUp:  true,
-			wantNames: []string{"linux-zen", "linux", "linux-ck"},
-		},
-		{
-			desc:      "sort-by-votes topdown",
-			sortBy:    "votes",
-			bottomUp:  false,
-			wantNames: []string{"linux-ck", "linux", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-votes bottomup",
-			sortBy:    "votes",
-			bottomUp:  true,
-			wantNames: []string{"linux-zen", "linux", "linux-ck"},
-		},
-		{
-			desc:      "sort-by-submitted topdown",
-			sortBy:    "submitted",
-			bottomUp:  false,
-			wantNames: []string{"linux-ck", "linux", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-submitted bottomup",
-			sortBy:    "submitted",
-			bottomUp:  true,
-			wantNames: []string{"linux-zen", "linux", "linux-ck"},
-		},
-		{
-			desc:      "sort-by-default topdown",
-			sortBy:    "",
-			bottomUp:  false,
-			wantNames: []string{"linux", "linux-ck", "linux-zen"},
-		},
-		{
-			desc:      "sort-by-default bottomup",
-			sortBy:    "",
-			bottomUp:  true,
-			wantNames: []string{"linux-zen", "linux-ck", "linux"},
-		},
-	}
-
-	mockDB, mockAUR := newQueryBuilderMocks()
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			w := &strings.Builder{}
-			queryBuilder := NewSourceQueryBuilder(mockAUR,
-				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
-				tc.sortBy, parser.ModeAny, "", tc.bottomUp,
-				false, false)
-
-			queryBuilder.Execute(context.Background(), mockDB, []string{"linux"})
-
-			gotNames := make([]string, len(queryBuilder.results))
-			for i, result := range queryBuilder.results {
-				gotNames[i] = result.name
-			}
-
-			assert.Equal(t, tc.wantNames, gotNames)
-		})
-	}
-}
-
-func newQueryBuilderMocks() (*mock.DBExecutor, *mockaur.MockAUR) {
 	mockDB := &mock.DBExecutor{
 		ReposFn: func() []string {
 			// Match pacman.conf parsing order for source separation.
@@ -454,6 +285,404 @@ func newQueryBuilderMocks() (*mock.DBExecutor, *mockaur.MockAUR) {
 					URL:            "https://wiki.archlinux.org/index.php/Linux-ck",
 					URLPath:        "/cgit/aur.git/snapshot/linux-ck.tar.gz",
 					Version:        "5.16.12-1",
+				},
+			}, nil
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &strings.Builder{}
+			queryBuilder := NewSourceQueryBuilder(mockAUR,
+				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
+				tc.sortBy, tc.targetMode, tc.searchBy, tc.bottomUp,
+				tc.singleLineResults, tc.separateSources)
+
+			queryBuilder.Execute(context.Background(), mockDB, tc.search)
+
+			assert.Len(t, queryBuilder.results, len(tc.wantResults))
+			assert.Equal(t, len(tc.wantResults), queryBuilder.Len())
+			for i, name := range tc.wantResults {
+				assert.Equal(t, name, queryBuilder.results[i].name)
+			}
+
+			queryBuilder.Results(mockDB, tc.verbosity)
+
+			assert.Equal(t, strings.Join(tc.wantOutput, ""), w.String())
+		})
+	}
+}
+
+func TestSourceQueryBuilderTieSortsByRepoOrder(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		desc      string
+		bottomUp  bool
+		repoOrder []string
+		wantNames []string
+	}
+
+	testCases := []testCase{
+		{
+			desc:      "sort-by-metric topdown repo-order-core-extra",
+			bottomUp:  false,
+			repoOrder: []string{"core", "extra"},
+			wantNames: []string{"systemd", "systemd-libs", "python-systemd", "systemd-git"},
+		},
+		{
+			desc:      "sort-by-metric topdown repo-order-extra-core",
+			bottomUp:  false,
+			repoOrder: []string{"extra", "core"},
+			wantNames: []string{"systemd", "python-systemd", "systemd-libs", "systemd-git"},
+		},
+		{
+			desc:      "sort-by-metric bottomup repo-order-core-extra",
+			bottomUp:  true,
+			repoOrder: []string{"core", "extra"},
+			wantNames: []string{"systemd-git", "python-systemd", "systemd-libs", "systemd"},
+		},
+		{
+			desc:      "sort-by-metric bottomup repo-order-extra-core",
+			bottomUp:  true,
+			repoOrder: []string{"extra", "core"},
+			wantNames: []string{"systemd-git", "systemd-libs", "python-systemd", "systemd"},
+		},
+	}
+
+	mockDB := &mock.DBExecutor{
+		SyncPackagesFn: func(pkgs ...string) []mock.IPackage {
+			return []mock.IPackage{
+				&mock.Package{
+					PBase:         "systemd",
+					PName:         "systemd",
+					PVersion:      "259-1",
+					PDescription:  "system and service manager",
+					PSize:         1,
+					PISize:        1,
+					PDB:           mock.NewDB("core"),
+					PArchitecture: "x86_64",
+				},
+				&mock.Package{
+					PBase:         "systemd",
+					PName:         "systemd-libs",
+					PVersion:      "259-1",
+					PDescription:  "systemd client libraries",
+					PSize:         1,
+					PISize:        1,
+					PDB:           mock.NewDB("core"),
+					PArchitecture: "x86_64",
+				},
+				&mock.Package{
+					PBase:         "python-systemd",
+					PName:         "python-systemd",
+					PVersion:      "235-4",
+					PDescription:  "Python bindings for systemd",
+					PSize:         1,
+					PISize:        1,
+					PDB:           mock.NewDB("extra"),
+					PArchitecture: "x86_64",
+				},
+			}
+		},
+		LocalPackageFn: func(string) mock.IPackage {
+			return nil
+		},
+	}
+
+	mockAUR := &mockaur.MockAUR{
+		GetFn: func(ctx context.Context, query *aur.Query) ([]aur.Pkg, error) {
+			return []aur.Pkg{
+				{
+					Description:    "system and service manager (git version)",
+					FirstSubmitted: 1445633397,
+					ID:             1909597,
+					LastModified:   1765571424,
+					Maintainer:     "Atsutane",
+					Name:           "systemd-git",
+					NumVotes:       11,
+					OutOfDate:      0,
+					PackageBase:    "systemd-git",
+					PackageBaseID:  102323,
+					Popularity:     0.005618,
+					URL:            "https://www.github.com/systemd/systemd",
+					URLPath:        "/cgit/aur.git/snapshot/systemd-git.tar.gz",
+					Version:        "259.rc3.r85286.7524671f74c-1",
+				},
+			}, nil
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &strings.Builder{}
+			mockDB.ReposFn = func() []string {
+				return tc.repoOrder
+			}
+			queryBuilder := NewSourceQueryBuilder(mockAUR,
+				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
+				"", parser.ModeAny, "", tc.bottomUp,
+				false, true)
+
+			queryBuilder.Execute(context.Background(), mockDB, []string{"systemd"})
+
+			gotNames := make([]string, len(queryBuilder.results))
+			for i, result := range queryBuilder.results {
+				gotNames[i] = result.name
+			}
+
+			assert.Equal(t, tc.wantNames, gotNames)
+		})
+	}
+}
+
+func TestSourceQueryBuilderTieDoesNotSeparateSources(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		desc      string
+		bottomUp  bool
+		wantNames []string
+	}
+
+	testCases := []testCase{
+		{
+			desc:      "sort-by-metric topdown",
+			bottomUp:  false,
+			wantNames: []string{"yay", "ruby-yard", "yay-git"},
+		},
+		{
+			desc:      "sort-by-metric bottomup",
+			bottomUp:  true,
+			wantNames: []string{"yay-git", "ruby-yard", "yay"},
+		},
+	}
+
+	mockDB, mockAUR := newYayQueryBuilderMocks()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &strings.Builder{}
+			queryBuilder := NewSourceQueryBuilder(mockAUR,
+				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
+				"", parser.ModeAny, "", tc.bottomUp,
+				false, true)
+
+			queryBuilder.Execute(context.Background(), mockDB, []string{"yay"})
+
+			gotNames := make([]string, len(queryBuilder.results))
+			for i, result := range queryBuilder.results {
+				gotNames[i] = result.name
+			}
+
+			assert.Equal(t, tc.wantNames, gotNames)
+		})
+	}
+}
+
+func TestSourceQueryBuilderSortByFields(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		desc      string
+		sortBy    string
+		bottomUp  bool
+		wantNames []string
+	}
+
+	testCases := []testCase{
+		{
+			desc:      "sort-by-base topdown",
+			sortBy:    "base",
+			bottomUp:  false,
+			wantNames: []string{"yay-git", "yay", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-base bottomup",
+			sortBy:    "base",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay", "yay-git"},
+		},
+		{
+			desc:      "sort-by-baseid topdown",
+			sortBy:    "baseid",
+			bottomUp:  false,
+			wantNames: []string{"yay-git", "yay", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-baseid bottomup",
+			sortBy:    "baseid",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay", "yay-git"},
+		},
+		{
+			desc:      "sort-by-id topdown",
+			sortBy:    "id",
+			bottomUp:  false,
+			wantNames: []string{"yay-git", "yay", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-id bottomup",
+			sortBy:    "id",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay", "yay-git"},
+		},
+		{
+			desc:      "sort-by-modified topdown",
+			sortBy:    "modified",
+			bottomUp:  false,
+			wantNames: []string{"yay-git", "yay", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-modified bottomup",
+			sortBy:    "modified",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay", "yay-git"},
+		},
+		{
+			desc:      "sort-by-name topdown",
+			sortBy:    "name",
+			bottomUp:  false,
+			wantNames: []string{"yay-git", "yay", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-name bottomup",
+			sortBy:    "name",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay", "yay-git"},
+		},
+		{
+			desc:      "sort-by-popularity topdown",
+			sortBy:    "popularity",
+			bottomUp:  false,
+			wantNames: []string{"yay", "yay-git", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-popularity bottomup",
+			sortBy:    "popularity",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay-git", "yay"},
+		},
+		{
+			desc:      "sort-by-votes topdown",
+			sortBy:    "votes",
+			bottomUp:  false,
+			wantNames: []string{"yay", "yay-git", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-votes bottomup",
+			sortBy:    "votes",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay-git", "yay"},
+		},
+		{
+			desc:      "sort-by-submitted topdown",
+			sortBy:    "submitted",
+			bottomUp:  false,
+			wantNames: []string{"yay-git", "yay", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-submitted bottomup",
+			sortBy:    "submitted",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay", "yay-git"},
+		},
+		{
+			desc:      "sort-by-metric topdown",
+			sortBy:    "",
+			bottomUp:  false,
+			wantNames: []string{"yay", "yay-git", "ruby-yard"},
+		},
+		{
+			desc:      "sort-by-metric bottomup",
+			sortBy:    "",
+			bottomUp:  true,
+			wantNames: []string{"ruby-yard", "yay-git", "yay"},
+		},
+	}
+
+	mockDB, mockAUR := newYayQueryBuilderMocks()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := &strings.Builder{}
+			queryBuilder := NewSourceQueryBuilder(mockAUR,
+				text.NewLogger(w, io.Discard, strings.NewReader(""), false, "test"),
+				tc.sortBy, parser.ModeAny, "", tc.bottomUp,
+				false, false)
+
+			queryBuilder.Execute(context.Background(), mockDB, []string{"yay"})
+
+			gotNames := make([]string, len(queryBuilder.results))
+			for i, result := range queryBuilder.results {
+				gotNames[i] = result.name
+			}
+
+			assert.Equal(t, tc.wantNames, gotNames)
+		})
+	}
+}
+
+func newYayQueryBuilderMocks() (*mock.DBExecutor, *mockaur.MockAUR) {
+	mockDB := &mock.DBExecutor{
+		ReposFn: func() []string {
+			// Match pacman.conf parsing order for source separation.
+			return []string{"core", "extra"}
+		},
+		SyncPackagesFn: func(pkgs ...string) []mock.IPackage {
+			mockDB := mock.NewDB("extra")
+			return []mock.IPackage{
+				&mock.Package{
+					PBase:         "ruby-yard",
+					PName:         "ruby-yard",
+					PVersion:      "0.9.34-5",
+					PDescription:  "YARD is a Ruby Documentation tool. The Y stands for \"Yay!\"",
+					PSize:         1,
+					PISize:        1,
+					PDB:           mockDB,
+					PArchitecture: "x86_64",
+				},
+			}
+		},
+		LocalPackageFn: func(string) mock.IPackage {
+			return nil
+		},
+	}
+
+	mockAUR := &mockaur.MockAUR{
+		GetFn: func(ctx context.Context, query *aur.Query) ([]aur.Pkg, error) {
+			return []aur.Pkg{
+				{
+					Description:    "Yet another yogurt. Pacman wrapper and AUR helper written in go.",
+					FirstSubmitted: 1475688004,
+					ID:             1911141,
+					LastModified:   1765742501,
+					Maintainer:     "jguer",
+					Name:           "yay",
+					NumVotes:       2461,
+					OutOfDate:      0,
+					PackageBase:    "yay",
+					PackageBaseID:  115973,
+					Popularity:     34.903162,
+					URL:            "https://github.com/Jguer/yay",
+					URLPath:        "/cgit/aur.git/snapshot/yay.tar.gz",
+					Version:        "12.5.7-1",
+				},
+				{
+					Description:    "Yet another yogurt. Pacman wrapper and AUR helper written in go. (development version)",
+					FirstSubmitted: 1517205142,
+					ID:             1911143,
+					LastModified:   1765742519,
+					Maintainer:     "jguer",
+					Name:           "yay-git",
+					NumVotes:       55,
+					OutOfDate:      0,
+					PackageBase:    "yay-git",
+					PackageBaseID:  129573,
+					Popularity:     1.850171,
+					URL:            "https://github.com/Jguer/yay",
+					URLPath:        "/cgit/aur.git/snapshot/yay-git.tar.gz",
+					Version:        "12.5.7.r0.g44dfda05-1",
 				},
 			}, nil
 		},


### PR DESCRIPTION
Fixes #2539.

Previously, only 'name' was a supported sortby option. Now, all sortby options are supported.

Whenever there is a tie for the primary sort, the metric is used as a tiebreaker (it is also the default when sortby is not specified). The only behavior that changed is that packages with the same metric are sorted oppositely when sorting bottomUp. This was actually a bug in the previous implementation which inverts the `cmpResult` for bottomUp and returns true if the metrics are the same. According to the docs for [Less](https://pkg.go.dev/sort#Interface), Less(i, i) should be false (the same element cannot sort before itself).

I mainly structured the code for efficiency by creating the sortby function once rather than checking `separateSources` and `bottomUp` every comparison, but I also think this improves readability compared to having a switch-case in the comparison function.

Going off of #2740, using a sortby metric besides the default (which uses `calculateMetric`) does not respect the repo order--but it didn't previously for `name` either. I can create a separate PR (or add to this one) to respect the repo order for non-default sortby options too.