### PR TITLE
Fix: Remove extra scanner.Scan() call in syncList

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -428,8 +428,6 @@ func syncList(ctx context.Context, run *runtime.Runtime,
 		}
 		defer scanner.Close()
 
-		scanner.Scan()
-
 		for scanner.Scan() {
 			name := scanner.Text()
 			if cmdArgs.ExistsArg("q", "quiet") {


### PR DESCRIPTION
When running `yay -l` without arguments, the first AUR package ("010editor") was missing from the output. The list started from the second package("02engine-bin").

The `syncList` function in `cmd.go` had an extra `scanner.Scan()` call, before entering the main loop . This redundant call consumed the first line from the scanner, causing the first package to be skipped.


