### PR TITLE
fix: properly handle install reason on upgrades

### DIFF
--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -332,11 +332,7 @@ func (g *Grapher) GraphSyncPkg(ctx context.Context,
 		SyncDBName: &dbName,
 	}
 
-	if upgradeInfo == nil {
-		if localPkg := g.dbExecutor.LocalPackage(pkg.Name()); localPkg != nil {
-			info.Reason = Reason(localPkg.Reason())
-		}
-	} else {
+	if upgradeInfo != nil {
 		info.Upgrade = true
 		info.Reason = Reason(upgradeInfo.Reason)
 		info.LocalVersion = upgradeInfo.LocalVersion
@@ -450,11 +446,8 @@ func (g *Grapher) GraphFromAUR(ctx context.Context,
 			g.providerCache[target] = []aurc.Pkg{*aurPkg}
 		}
 
-		reason := Explicit
-		if pkg := g.dbExecutor.LocalPackage(aurPkg.Name); pkg != nil {
-			reason = Reason(pkg.Reason())
-
-			if g.needed {
+		if g.needed {
+			if pkg := g.dbExecutor.LocalPackage(aurPkg.Name); pkg != nil {
 				if db.VerCmp(pkg.Version(), aurPkg.Version) >= 0 {
 					g.logger.Warnln(gotext.Get("%s is up to date -- skipping", text.Cyan(pkg.Name()+"-"+pkg.Version())))
 					continue
@@ -464,7 +457,7 @@ func (g *Grapher) GraphFromAUR(ctx context.Context,
 
 		graph = g.GraphAURTarget(ctx, graph, aurPkg, &InstallInfo{
 			AURBase: &aurPkg.PackageBase,
-			Reason:  reason,
+			Reason:  Explicit,
 			Source:  AUR,
 			Version: aurPkg.Version,
 		})

--- a/pkg/dep/dep_graph_test.go
+++ b/pkg/dep/dep_graph_test.go
@@ -701,7 +701,7 @@ func TestGrapher_GraphFromAUR_Deps_gourou(t *testing.T) {
 	}
 }
 
-func TestGrapher_GraphFromTargets_ReinstalledDeps(t *testing.T) {
+func TestGrapher_GraphFromTargets_ExplicitTargets(t *testing.T) {
 	mockDB := &mock.DBExecutor{
 		SyncPackageFn:       func(string) mock.IPackage { return nil },
 		PackagesFromGroupFn: func(string) []mock.IPackage { return []mock.IPackage{} },
@@ -786,15 +786,15 @@ func TestGrapher_GraphFromTargets_ReinstalledDeps(t *testing.T) {
 	}}
 
 	installInfos := map[string]*InstallInfo{
-		"gourou dep": {
+		"gourou": {
 			Source:  AUR,
-			Reason:  Dep,
+			Reason:  Explicit,
 			Version: "0.8.1",
 			AURBase: ptrString("gourou"),
 		},
-		"libzip dep": {
+		"libzip": {
 			Source:     Sync,
-			Reason:     Dep,
+			Reason:     Explicit,
 			Version:    "1.9.2-1",
 			SyncDBName: ptrString("extra"),
 		},
@@ -810,8 +810,8 @@ func TestGrapher_GraphFromTargets_ReinstalledDeps(t *testing.T) {
 			name:    "gourou libzip",
 			targets: []string{"gourou", "libzip"},
 			wantLayers: []map[string]*InstallInfo{
-				{"gourou": installInfos["gourou dep"]},
-				{"libzip": installInfos["libzip dep"]},
+				{"gourou": installInfos["gourou"]},
+				{"libzip": installInfos["libzip"]},
 			},
 			wantErr: false,
 		},
@@ -819,8 +819,8 @@ func TestGrapher_GraphFromTargets_ReinstalledDeps(t *testing.T) {
 			name:    "aur/gourou extra/libzip",
 			targets: []string{"aur/gourou", "extra/libzip"},
 			wantLayers: []map[string]*InstallInfo{
-				{"gourou": installInfos["gourou dep"]},
-				{"libzip": installInfos["libzip dep"]},
+				{"gourou": installInfos["gourou"]},
+				{"libzip": installInfos["libzip"]},
 			},
 			wantErr: false,
 		},

--- a/pkg/sync/build/installer.go
+++ b/pkg/sync/build/installer.go
@@ -173,7 +173,11 @@ func (installer *Installer) handleLayer(ctx context.Context,
 					aurExp.Add(name)
 				}
 			case dep.Dep, dep.MakeDep, dep.CheckDep:
-				aurDeps.Add(name)
+				if cmdArgs.ExistsArg("asexplicit", "asexp") {
+					aurExp.Add(name)
+				} else {
+					aurDeps.Add(name)
+				}
 			}
 		case dep.Sync:
 			if info.Upgrade {
@@ -195,7 +199,11 @@ func (installer *Installer) handleLayer(ctx context.Context,
 					syncExp.Add(compositePkgName)
 				}
 			case dep.Dep, dep.MakeDep, dep.CheckDep:
-				syncDeps.Add(compositePkgName)
+				if cmdArgs.ExistsArg("asexplicit", "asexp") {
+					syncExp.Add(compositePkgName)
+				} else {
+					syncDeps.Add(compositePkgName)
+				}
 			}
 		}
 	}

--- a/pkg/sync/build/installer.go
+++ b/pkg/sync/build/installer.go
@@ -173,11 +173,7 @@ func (installer *Installer) handleLayer(ctx context.Context,
 					aurExp.Add(name)
 				}
 			case dep.Dep, dep.MakeDep, dep.CheckDep:
-				if cmdArgs.ExistsArg("asexplicit", "asexp") {
-					aurExp.Add(name)
-				} else {
-					aurDeps.Add(name)
-				}
+				aurDeps.Add(name)
 			}
 		case dep.Sync:
 			if info.Upgrade {
@@ -199,11 +195,7 @@ func (installer *Installer) handleLayer(ctx context.Context,
 					syncExp.Add(compositePkgName)
 				}
 			case dep.Dep, dep.MakeDep, dep.CheckDep:
-				if cmdArgs.ExistsArg("asexplicit", "asexp") {
-					syncExp.Add(compositePkgName)
-				} else {
-					syncDeps.Add(compositePkgName)
-				}
+				syncDeps.Add(compositePkgName)
 			}
 		}
 	}


### PR DESCRIPTION
When a user explicitly re-installs a package with `yay -S <pkg>`, it should be marked as "Explicitly installed" regardless of how it was previously installed.

Right now if a package is already installed as a dependency and you do  `yay -S <pkg>` to explicitly install it, yay preserves the old install reason instead of marking it as explicit as pacman does.

**Before:**
```
$ yay -S vlc-plugin-vorbis
$ yay -Qi vlc-plugin-vorbis | grep "Install Reason"
Install Reason  : Installed as a dependency for another package
```

**After:**
```
$ yay -S vlc-plugin-vorbis
$ yay -Qi vlc-plugin-vorbis | grep "Install Reason"
Install Reason  : Explicitly installed
```

Test also was expecting the wrong behavior so i changed it to reflect this and renamed since it seemed misleading otherwise.

Fixes https://github.com/Jguer/yay/issues/2288