### PR TITLE
fix install of AUR package from interactive install menu

### DIFF
--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -158,6 +158,7 @@ func (g *Grapher) GraphFromTargets(ctx context.Context,
 
 			fallthrough
 		case "aur":
+		case "AUR":
 			aurTargets = append(aurTargets, target.Name)
 		default:
 			pkg, err := g.dbExecutor.SatisfierFromDB(target.Name, target.DB)


### PR DESCRIPTION
When trying to install an AUR package the following error is printed:
 -> database AUR not found

This regression was introduce in commit
df80f397af63ce51044418c5c9cba0a29aa1c108.
In pkg/query/query_builder.go, sourceAUR was set to AUR instead of aur.