### PR TITLE
fix: automatically regenerate empty completion cache

### DIFF
--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NeedsUpdate checks if the completion cache needs to be regenerated.
-// Returns true if the file doesn't exist, is older than interval days, or force is true.
+// Returns true if the file doesn't exist, is older than interval days, is empty, or force is true.
 func NeedsUpdate(completionPath string, interval int, force bool) bool {
 	if force {
 		return true
@@ -22,6 +22,11 @@ func NeedsUpdate(completionPath string, interval int, force bool) bool {
 
 	info, err := os.Stat(completionPath)
 	if os.IsNotExist(err) {
+		return true
+	}
+
+	// If the file is empty or invalid, regenerate it
+	if info.Size() == 0 {
 		return true
 	}
 

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -210,6 +210,18 @@ func TestNeedsUpdate(t *testing.T) {
 			force:          false,
 			expectedResult: false,
 		},
+		{
+			name: "empty file returns true",
+			setupFile: func(t *testing.T, path string) {
+				t.Helper()
+				// Create an empty file
+				err := os.WriteFile(path, []byte(""), 0o600)
+				require.NoError(t, err)
+			},
+			interval:       7,
+			force:          false,
+			expectedResult: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #2759

## Problem
Users reported that shell completions (ZSH, Fish, Bash) would break after system updates, with `yay -Pc` returning empty output. The workaround was to manually delete `~/.cache/yay/completion.cache` and regenerate it.
