### PR TITLE
fix(query): incorporate AUR popularity into search metric

### DIFF
--- a/pkg/query/metric.go
+++ b/pkg/query/metric.go
@@ -7,14 +7,21 @@ import (
 )
 
 const minVotes = 30
+const minPopularity = 0.5
 const (
 	separateSourceMax = 45.0
 	separateSourceMin = 5.0
 )
 
-// TODO: Add support for Popularity and LastModified
 func (a *abstractResults) aurSortByMetric(pkg *abstractResult) float64 {
-	return 1 - (minVotes / (minVotes + float64(pkg.votes)))
+	votesScore := 1 - (minVotes / (minVotes + float64(pkg.votes)))
+	if pkg.popularity <= 0 {
+		return votesScore
+	}
+
+	popularityScore := 1 - (minPopularity / (minPopularity + pkg.popularity))
+
+	return (votesScore + popularityScore) / 2
 }
 
 func (a *abstractResults) GetMetric(pkg *abstractResult) float64 {

--- a/pkg/query/query_builder_test.go
+++ b/pkg/query/query_builder_test.go
@@ -71,10 +71,10 @@ func TestSourceQueryBuilder(t *testing.T) {
 			separateSources: false,
 			sortBy:          "",
 			verbosity:       Detailed,
-			wantResults:     []string{"linux-zen", "linux-ck", "linux"},
+			wantResults:     []string{"linux-ck", "linux-zen", "linux"},
 			wantOutput: []string{
-				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
 				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
+				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
 			},
 		},
@@ -85,11 +85,11 @@ func TestSourceQueryBuilder(t *testing.T) {
 			separateSources: false,
 			sortBy:          "",
 			verbosity:       Detailed,
-			wantResults:     []string{"linux", "linux-ck", "linux-zen"},
+			wantResults:     []string{"linux", "linux-zen", "linux-ck"},
 			wantOutput: []string{
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux kernel and modules\n",
-				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
 				"\x1b]8;;https://archlinux.org/packages/core/x86_64/linux-zen\x1b\\\x1b[1m\x1b[33mcore\x1b[0m\x1b[0m/\x1b[1mlinux-zen\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.0\x1b[0m\x1b[1m (1.0 B 1.0 B) \x1b[0m\n    The Linux ZEN kernel and modules\n",
+				"\x1b]8;;https://aur.archlinux.org/packages/linux-ck\x1b\\\x1b[1m\x1b[34maur\x1b[0m\x1b[0m/\x1b[1mlinux-ck\x1b[0m\x1b]8;;\x1b\\ \x1b[36m5.16.12-1\x1b[0m\x1b[1m (+450\x1b[0m \x1b[1m1.51) \x1b[0m\n    The Linux-ck kernel and modules with ck's hrtimer patches\n",
 			},
 		},
 		{


### PR DESCRIPTION
Replace vote-only sigmoid with a blended votes+popularity score in `aurSortByMetric`. AUR's Popularity field is a time-decayed vote score that better reflects current relevance than raw NumVotes alone.

Falls back to votes-only when popularity <= 0. Uses the same sigmoid normalization pattern as the existing minVotes constant (minPopularity = 0.5).

Side effect: AUR packages no longer artificially outscore repo packages via historical vote counts when separateSources is disabled. Updated two noseparatesources test expectations accordingly.