### PR TITLE
Remove timeupdate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ pacman -S --needed git base-devel yay
 | `yay -Gp <AUR Package>`           | Print to stdout PKGBUILD from ABS or AUR.                                                                  |
 | `yay -Ps`                         | Print system statistics.                                                                                   |
 | `yay -Syu --devel`                | Perform system upgrade, but also check for development package updates.                                    |
-| `yay -Syu --timeupdate`           | Perform system upgrade and use PKGBUILD modification time (not version number) to determine update.        |
 | `yay -Wu <AUR Package>`           | Unvote for package (Requires setting `AUR_USERNAME` and `AUR_PASSWORD` environment variables) (yay v11.3+) |
 | `yay -Wv <AUR Package>`           | Vote for package (Requires setting `AUR_USERNAME` and `AUR_PASSWORD` environment variables). (yay v11.3+)  |
 | `yay -Y --combinedupgrade --save` | Make combined upgrade the default mode.                                                                    |

--- a/cmd.go
+++ b/cmd.go
@@ -119,8 +119,6 @@ Permanent configuration options:
     --sudoflags           <flags> Pass arguments to sudo
     --sudoloop            Loop sudo calls in the background to avoid timeout
 
-    --timeupdate          Check packages' AUR page for changes during sysupgrade
-
 show specific options (used with -P):
     -c --complete         Used for completions
     -d --defaultconfig    Print default yay configuration

--- a/completions/fish
+++ b/completions/fish
@@ -227,7 +227,6 @@ complete -c $progname -n "not $noopt" -l doublelineresults -d 'List each search 
 complete -c $progname -n "not $noopt" -l devel -d 'Check -git/-svn/-hg development version' -f
 complete -c $progname -n "not $noopt" -l cleanafter -d 'Clean package sources after successful build' -f
 complete -c $progname -n "not $noopt" -l keepsrc -d 'Keep pkg/ and src/ after building packages' -f
-complete -c $progname -n "not $noopt" -l timeupdate -d 'Check package modification date and version' -f
 complete -c $progname -n "not $noopt" -l redownload -d 'Redownload PKGBUILD of package even if up-to-date' -f
 complete -c $progname -n "not $noopt" -l redownloadall -d 'Redownload PKGBUILD of package and deps even if up-to-date' -f
 complete -c $progname -n "not $noopt" -l noredownload -d 'Do not redownload up-to-date PKGBUILDs' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -83,7 +83,6 @@ _pacman_opts_common=(
 	'--devel[Check -git/-svn/-hg development version]'
 	'--cleanafter[Clean package sources after successful build]'
 	'--keepsrc[Keep pkg/ and src/ after building packages]'
-	'--timeupdate[Check packages modification date and version]'
 	'--separatesources[Separate query results by source, AUR and sync]'
 	'(--redownloadall --noredownload)--redownload[Always download pkgbuilds of targets]'
 	'(--redownload --noredownload)--redownloadall[Always download pkgbuilds of all AUR packages]'

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -381,11 +381,6 @@ instead of having to reclone the entire repo.
 Keep pkg/ and src/ after building packages
 
 .TP
-.B \-\-timeupdate
-During sysupgrade also compare the build time of installed packages against
-the last modification time of each package's AUR page.
-
-.TP
 .B \-\-separatesources
 Separate query results by source, AUR and sync
 

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -63,8 +63,6 @@ func (c *Configuration) handleOption(option, value string) bool {
 		return !boolValue
 	case "devel":
 		c.Devel = boolValue
-	case "timeupdate":
-		c.TimeUpdate = boolValue
 	case "topdown":
 		c.BottomUp = false
 	case "bottomup":

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -58,7 +58,6 @@ type Configuration struct {
 	MaxConcurrentDownloads int    `json:"maxconcurrentdownloads" ini:"MaxConcurrentDownloads"`
 	BottomUp               bool   `json:"bottomup" ini:"BottomUp"`
 	SudoLoop               bool   `json:"sudoloop" ini:"SudoLoop"`
-	TimeUpdate             bool   `json:"timeupdate" ini:"TimeUpdate"`
 	Devel                  bool   `json:"devel" ini:"Devel"`
 	CleanAfter             bool   `json:"cleanAfter" ini:"CleanAfter"`
 	KeepSrc                bool   `json:"keepSrc" ini:"KeepSrc"`

--- a/pkg/settings/ini_test.go
+++ b/pkg/settings/ini_test.go
@@ -93,7 +93,6 @@ MaxConcurrentDownloads = 4
 # Boolean options
 BottomUp = true
 SudoLoop = false
-TimeUpdate = yes
 Devel = no
 CleanAfter = true
 KeepSrc = false
@@ -154,7 +153,6 @@ DoubleConfirm = false
 		// Boolean options
 		assert.True(t, cfg.BottomUp)
 		assert.False(t, cfg.SudoLoop)
-		assert.True(t, cfg.TimeUpdate)
 		assert.False(t, cfg.Devel)
 		assert.True(t, cfg.CleanAfter)
 		assert.False(t, cfg.KeepSrc)

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -379,7 +379,6 @@ func isArg(arg string) bool {
 	case "afterclean", "cleanafter":
 	case "keepsrc":
 	case "devel":
-	case "timeupdate":
 	case "topdown":
 	case "bottomup":
 	case "completioninterval":

--- a/pkg/settings/yay.conf
+++ b/pkg/settings/yay.conf
@@ -61,7 +61,6 @@ DiffMenu
 # Behavior
 CombinedUpgrade
 #SudoLoop
-#TimeUpdate
 #Provides
 #UseAsk
 DoubleConfirm

--- a/pkg/settings/yay.conf
+++ b/pkg/settings/yay.conf
@@ -62,7 +62,7 @@ DiffMenu
 CombinedUpgrade
 #SudoLoop
 #TimeUpdate
-Provides
+#Provides
 #UseAsk
 DoubleConfirm
 Rpc

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -83,7 +83,7 @@ func (u *UpgradeService) upGraph(ctx context.Context, graph *topo.Graph[string, 
 
 			u.AURWarnings.CalculateMissing(remoteNames, remote, aurdata)
 
-			aurUp = UpAUR(u.log, remote, aurdata, u.cfg.TimeUpdate, enableDowngrade)
+			aurUp = UpAUR(u.log, remote, aurdata, enableDowngrade)
 
 			if u.cfg.Devel {
 				u.log.OperationInfoln(gotext.Get("Checking development packages..."))

--- a/pkg/upgrade/sources.go
+++ b/pkg/upgrade/sources.go
@@ -63,7 +63,7 @@ func printIgnoringPackage(log *text.Logger, pkg db.IPackage, newPkgVersion strin
 // UpAUR gathers foreign packages and checks if they have new versions.
 // Output: Upgrade type package list.
 func UpAUR(log *text.Logger, remote map[string]db.IPackage, aurdata map[string]*query.Pkg,
-	timeUpdate, enableDowngrade bool,
+	enableDowngrade bool,
 ) UpSlice {
 	toUpgrade := UpSlice{Up: make([]Upgrade, 0), Repos: []string{"aur"}}
 
@@ -73,8 +73,7 @@ func UpAUR(log *text.Logger, remote map[string]db.IPackage, aurdata map[string]*
 			continue
 		}
 
-		if (timeUpdate && (int64(aurPkg.LastModified) > pkg.BuildDate().Unix())) ||
-			(db.VerCmp(pkg.Version(), aurPkg.Version) < 0) ||
+		if (db.VerCmp(pkg.Version(), aurPkg.Version) < 0) ||
 			(enableDowngrade && (db.VerCmp(pkg.Version(), aurPkg.Version) > 0)) {
 			if pkg.ShouldIgnore() {
 				printIgnoringPackage(log, pkg, aurPkg.Version)

--- a/pkg/upgrade/sources_test.go
+++ b/pkg/upgrade/sources_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	aur "github.com/Jguer/aur"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,6 @@ func Test_upAUR(t *testing.T) {
 	type args struct {
 		remote          map[string]alpm.Package
 		aurdata         map[string]*aur.Pkg
-		timeUpdate      bool
 		enableDowngrade bool
 	}
 	tests := []struct {
@@ -47,7 +45,6 @@ func Test_upAUR(t *testing.T) {
 					"hello":   {Version: "2.0.0", Name: "hello"},
 					"ignored": {Version: "2.0.0", Name: "ignored"},
 				},
-				timeUpdate: false,
 			},
 			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{}},
 		},
@@ -57,8 +54,7 @@ func Test_upAUR(t *testing.T) {
 				remote: map[string]alpm.Package{
 					"hello": &mock.Package{PName: "hello", PVersion: "2.0.0"},
 				},
-				aurdata:    map[string]*aur.Pkg{"hello": {Version: "2.1.0", Name: "hello"}},
-				timeUpdate: false,
+				aurdata: map[string]*aur.Pkg{"hello": {Version: "2.1.0", Name: "hello"}},
 			},
 			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{{Name: "hello", Repository: "aur", LocalVersion: "2.0.0", RemoteVersion: "2.1.0"}}},
 		},
@@ -69,7 +65,6 @@ func Test_upAUR(t *testing.T) {
 					"hello": &mock.Package{PName: "hello", PVersion: "2.0.0"},
 				},
 				aurdata:         map[string]*aur.Pkg{"hello": {Version: "1.0.0", Name: "hello"}},
-				timeUpdate:      false,
 				enableDowngrade: true,
 			},
 			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{{Name: "hello", Repository: "aur", LocalVersion: "2.0.0", RemoteVersion: "1.0.0"}}},
@@ -81,7 +76,6 @@ func Test_upAUR(t *testing.T) {
 					"hello": &mock.Package{PName: "hello", PVersion: "2.0.0"},
 				},
 				aurdata:         map[string]*aur.Pkg{"hello": {Version: "1.0.0", Name: "hello"}},
-				timeUpdate:      false,
 				enableDowngrade: false,
 			},
 			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{}},
@@ -102,7 +96,6 @@ func Test_upAUR(t *testing.T) {
 					"down":    {Version: "1.0.0", Name: "down"},
 					"ignored": {Version: "2.0.0", Name: "ignored"},
 				},
-				timeUpdate: false,
 			},
 			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{
 				{Name: "up", Repository: "aur", LocalVersion: "2.0.0", RemoteVersion: "2.1.0"},
@@ -110,15 +103,14 @@ func Test_upAUR(t *testing.T) {
 			}},
 		},
 		{
-			name: "Time Update",
+			name: "Ignore LastModified When Version Is Unchanged",
 			args: args{
 				remote: map[string]alpm.Package{
-					"hello": &mock.Package{PName: "hello", PVersion: "2.0.0", PBuildDate: time.Now()},
+					"hello": &mock.Package{PName: "hello", PVersion: "2.0.0"},
 				},
-				aurdata:    map[string]*aur.Pkg{"hello": {Version: "2.0.0", Name: "hello", LastModified: int(time.Now().AddDate(0, 0, 2).Unix())}},
-				timeUpdate: true,
+				aurdata: map[string]*aur.Pkg{"hello": {Version: "2.0.0", Name: "hello", LastModified: 9999999999}},
 			},
-			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{{Name: "hello", Repository: "aur", LocalVersion: "2.0.0", RemoteVersion: "2.0.0"}}},
+			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{}},
 		},
 	}
 	for _, tt := range tests {
@@ -126,7 +118,7 @@ func Test_upAUR(t *testing.T) {
 			t.Parallel()
 
 			got := UpAUR(text.NewLogger(io.Discard, os.Stderr, strings.NewReader(""), false, "test"),
-				tt.args.remote, tt.args.aurdata, tt.args.timeUpdate, tt.args.enableDowngrade)
+				tt.args.remote, tt.args.aurdata, tt.args.enableDowngrade)
 			assert.ElementsMatch(t, tt.want.Repos, got.Repos)
 			assert.ElementsMatch(t, tt.want.Up, got.Up)
 			assert.Equal(t, tt.want.Len(), got.Len())


### PR DESCRIPTION
## Summary
- remove the `timeupdate` option from code paths, default config, completions, and docs
- update tests to cover the removed behavior

## Why
`timeupdate` adds config and upgrade-selection complexity for a niche behavior. A quick sample of issue reports where users shared their yay config shows the option disabled, which suggests low real-world usage and weak justification for keeping the extra surface area around.

EDIT: also fixes accidental provides search enable by default