### PR TITLE
fix: skip cache clean when no valid pacman cache directories exist  #2652

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -67,11 +67,11 @@ func syncClean(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argume
 		validDirExists := false
 
 		for _, dir := range run.PacmanConf.CacheDir {
-		    info, err := os.Stat(dir)
-		    if err == nil && info.IsDir() {
-		        validDirExists = true
-		        break
-		    }
+			info, err := os.Stat(dir)
+			if err == nil && info.IsDir() {
+				validDirExists = true
+				break
+			}
 		}
 
 		if validDirExists {
@@ -80,7 +80,7 @@ func syncClean(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argume
 				return err
 			}
 		} else {
-			run.Logger.Println(gotext.Get("No valid pacman cache directories found. Skipping cache clean.")) 
+			run.Logger.Println(gotext.Get("No valid pacman cache directories found. Skipping cache clean."))
 			return nil
 		}
 	}

--- a/clean.go
+++ b/clean.go
@@ -83,7 +83,6 @@ func syncClean(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argume
 			run.Logger.Println(gotext.Get("No valid pacman cache directories found. Skipping cache clean.")) 
 			return nil
 		}
-		
 	}
 
 	if !run.Cfg.Mode.AtLeastAUR() {

--- a/clean.go
+++ b/clean.go
@@ -64,10 +64,26 @@ func syncClean(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argume
 	}
 
 	if run.Cfg.Mode.AtLeastRepo() {
-		if err := run.CmdBuilder.Show(run.CmdBuilder.BuildPacmanCmd(ctx,
-			cmdArgs, run.Cfg.Mode, settings.NoConfirm)); err != nil {
-			return err
+		validDirExists := false
+
+		for _, dir := range run.PacmanConf.CacheDir {
+		    info, err := os.Stat(dir)
+		    if err == nil && info.IsDir() {
+		        validDirExists = true
+		        break
+		    }
 		}
+
+		if validDirExists {
+			if err := run.CmdBuilder.Show(run.CmdBuilder.BuildPacmanCmd(ctx,
+				cmdArgs, run.Cfg.Mode, settings.NoConfirm)); err != nil {
+				return err
+			}
+		} else {
+			run.Logger.Println(gotext.Get("No valid pacman cache directories found. Skipping cache clean.")) 
+			return nil
+		}
+		
 	}
 
 	if !run.Cfg.Mode.AtLeastAUR() {


### PR DESCRIPTION
# Fixes #2652 

## Problem

When all `CacheDir` paths are missing (e.g., when using tmpfs or after a fresh boot), `yay -Scc` attempts to invoke pacman, which results in:

```
    error: could not access cache directory
    -> exit status 1
```

In addition, execution continues into AUR cleaning logic, which can lead to runtime panics.


##  Solution

- Check whether at least one configured `CacheDir` exists
- If none exist:
  - Log an informative message
  - Return early, skipping both pacman and AUR clean steps

### Before the fix :

<img width="818" height="199" alt="image" src="https://github.com/user-attachments/assets/772e1c2f-3791-4cb2-9e17-1169e3d4ae69" />

### After the fix:
<img width="550" height="72" alt="image" src="https://github.com/user-attachments/assets/74a0ddba-1925-4418-80f1-12f9b8d4911c" />

Renamed ```/var/cache/pacman/pkg/``` to ```/var/cache/pacman/pkg_backup/``` to reproduce the issue.
