### PR TITLE
fix: detect stale db.lck caused by terminated process holding the lock

### DIFF
--- a/pkg/settings/exe/cmd_builder.go
+++ b/pkg/settings/exe/cmd_builder.go
@@ -238,7 +238,7 @@ func (c *CmdBuilder) BuildPacmanCmd(ctx context.Context, args *parser.Arguments,
 	argArr = append(argArr, args.Targets...)
 
 	if needsRoot {
-		c.waitLock(c.PacmanDBPath)
+		c.waitLock(ctx, c.PacmanDBPath)
 
 		if os.Geteuid() != 0 {
 			return c.buildPrivilegeElevatorCommand(ctx, argArr)
@@ -254,10 +254,14 @@ func findLockOwner(lockPath string) (int, error) {
 		return 0, fmt.Errorf("could not read /proc: %w", err)
 	}
 
+	var permissionSkips int
 	// checking every pid running if they have the lock for the db
 	for _, fd := range fds {
 		target, err := os.Readlink(fd)
 		if err != nil {
+			if os.IsPermission(err) {
+				permissionSkips++
+			}
 			continue
 		}
 
@@ -278,13 +282,19 @@ func findLockOwner(lockPath string) (int, error) {
 
 		return pid, nil
 	}
+	if permissionSkips > 0 {
+		// Warn before concluding stale
+		fmt.Fprintf(os.Stderr,
+			"warning: could not inspect %d process(es) in /proc (permission denied) — "+
+				"lock may be held by a root-owned process\n", permissionSkips)
+	}
 
 	return 0, fmt.Errorf("lock file exists but no living process owns it (stale lock)")
 }
 
 // waitLock will lock yay checking the status of db.lck until it does not exist
 // or handle it if it is in a stale lock state
-func (c *CmdBuilder) waitLock(dbPath string) {
+func (c *CmdBuilder) waitLock(ctx context.Context, dbPath string) {
 	lockDBPath := filepath.Join(dbPath, "db.lck")
 	if _, err := os.Stat(lockDBPath); err != nil {
 		return
@@ -296,11 +306,16 @@ func (c *CmdBuilder) waitLock(dbPath string) {
 	ownerPID, err := findLockOwner(lockDBPath)
 	if err != nil {
 		c.Log.Warnln(gotext.Get("The lock file does not appear to be owned by any running process."))
-		c.Log.Warnln(gotext.Get("It may be stale. Want to remove it? [y/N]"))
+		c.Log.Warn(gotext.Get("It may be stale. Want to remove it? [y/N] "))
 
 		var response string
 		if _, scanErr := fmt.Scan(&response); scanErr == nil && strings.ToLower(strings.TrimSpace(response)) == "y" {
-			if removeErr := os.Remove(lockDBPath); removeErr != nil {
+			cmd := exec.CommandContext(ctx, "sudo", "rm", lockDBPath)
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+
+			if removeErr := cmd.Run(); removeErr != nil {
 				c.Log.Warnln(gotext.Get("Could not remove lock file: %s", removeErr))
 			} else {
 				c.Log.Println(gotext.Get("Lock file removed"))

--- a/pkg/settings/exe/cmd_builder.go
+++ b/pkg/settings/exe/cmd_builder.go
@@ -248,7 +248,42 @@ func (c *CmdBuilder) BuildPacmanCmd(ctx context.Context, args *parser.Arguments,
 	return exec.CommandContext(ctx, argArr[0], argArr[1:]...)
 }
 
-// waitLock will lock yay checking the status of db.lck until it does not exist.
+func findLockOwner(lockPath string) (int, error) {
+	fds, err := filepath.Glob("/proc/*/fd/*")
+	if err != nil {
+		return 0, fmt.Errorf("could not read /proc: %w", err)
+	}
+
+	// checking every pid running if they have the lock for the db
+	for _, fd := range fds {
+		target, err := os.Readlink(fd)
+		if err != nil {
+			continue
+		}
+
+		if target != lockPath {
+			continue
+		}
+
+		parts := strings.Split(fd, "/")
+
+		if len(parts) < 4 {
+			continue
+		}
+
+		pid, err := strconv.Atoi(parts[2])
+		if err != nil {
+			continue
+		}
+
+		return pid, nil
+	}
+
+	return 0, fmt.Errorf("lock file exists but no living process owns it (stale lock)")
+}
+
+// waitLock will lock yay checking the status of db.lck until it does not exist
+// or handle it if it is in a stale lock state
 func (c *CmdBuilder) waitLock(dbPath string) {
 	lockDBPath := filepath.Join(dbPath, "db.lck")
 	if _, err := os.Stat(lockDBPath); err != nil {
@@ -257,6 +292,29 @@ func (c *CmdBuilder) waitLock(dbPath string) {
 
 	c.Log.Warnln(gotext.Get("%s is present.", lockDBPath))
 	c.Log.Warn(gotext.Get("There may be another Pacman instance running. Waiting..."))
+
+	// Finding out which instance is running
+	ownerPID, err := findLockOwner(lockDBPath)
+	if err != nil {
+		c.Log.Warnln(gotext.Get("The lock file does not appear to be owned by any running process."))
+		c.Log.Warnln(gotext.Get("It may be stale. Want to remove it? [y/N]"))
+
+		var response string
+		if _, scanErr := fmt.Scan(&response); scanErr == nil && strings.ToLower(strings.TrimSpace(response)) == "y" {
+			if removeErr := os.Remove(lockDBPath); removeErr != nil {
+				c.Log.Warnln("Could not remove lock file: %s", removeErr)
+			} else {
+				c.Log.Println(gotext.Get("Lock file removed"))
+			}
+		}
+		return
+	}
+
+	if ownerPID == os.Getppid() {
+		c.Log.Warn(gotext.Get("Lock is held by parent process (%d). Waiting for it to finish...", ownerPID))
+	} else {
+		c.Log.Warn(gotext.Get("There may be another Pacman instance running. Waiting..."))
+	}
 
 	for {
 		time.Sleep(3 * time.Second)

--- a/pkg/settings/exe/cmd_builder.go
+++ b/pkg/settings/exe/cmd_builder.go
@@ -301,7 +301,7 @@ func (c *CmdBuilder) waitLock(dbPath string) {
 		var response string
 		if _, scanErr := fmt.Scan(&response); scanErr == nil && strings.ToLower(strings.TrimSpace(response)) == "y" {
 			if removeErr := os.Remove(lockDBPath); removeErr != nil {
-				c.Log.Warnln("Could not remove lock file: %s", removeErr)
+				c.Log.Warnln(gotext.Get("Could not remove lock file: %s", removeErr))
 			} else {
 				c.Log.Println(gotext.Get("Lock file removed"))
 			}

--- a/pkg/settings/exe/cmd_builder.go
+++ b/pkg/settings/exe/cmd_builder.go
@@ -291,7 +291,6 @@ func (c *CmdBuilder) waitLock(dbPath string) {
 	}
 
 	c.Log.Warnln(gotext.Get("%s is present.", lockDBPath))
-	c.Log.Warn(gotext.Get("There may be another Pacman instance running. Waiting..."))
 
 	// Finding out which instance is running
 	ownerPID, err := findLockOwner(lockDBPath)

--- a/pkg/settings/exe/cmd_builder_test.go
+++ b/pkg/settings/exe/cmd_builder_test.go
@@ -6,6 +6,7 @@ package exe
 import (
 	"context"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -71,4 +72,34 @@ func TestBuildPrivilegeElevatorCommand(t *testing.T) {
 	cmd := builder.buildPrivilegeElevatorCommand(context.Background(), []string{"echo", "hello"})
 	require.Equal(t, "su", filepath.Base(cmd.Path))
 	require.Equal(t, []string{"su", "-c", "echo hello"}, cmd.Args)
+}
+
+func TestFindLockOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "db.lck")
+
+	f, err := os.Create(lockPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	pid, err := findLockOwner(lockPath)
+	require.NoError(t, err)
+	require.Equal(t, os.Getpid(), pid)
+}
+
+func TestFindLockOwnerStale(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "db.lck")
+
+	f, err := os.Create(lockPath)
+	require.NoError(t, err)
+	f.Close()
+
+	pid, err := findLockOwner(lockPath)
+	require.Error(t, err)
+	require.Equal(t, 0, pid)
 }


### PR DESCRIPTION
Updated the waitLock() function so that yay no longer waits indefinitely when the db.lck is left behind by a terminated process.

**Changes:**

- Added a findLockOwner function that identifies which process holds db.lck
- Added Tests for findLockOwner that covers live and stale lock cases
- Modified waitLock to call findLockOwner to check if the process holding lock is live
- waitLock now prompts user to remove the lock if the lock is found to be stale

Closes #2123