### PR TITLE
fix: remove debug counterpart packages when conflict is resolved

### DIFF
--- a/pkg/sync/build/installer.go
+++ b/pkg/sync/build/installer.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"github.com/Jguer/yay/v12/pkg/text"
 	"github.com/Jguer/yay/v12/pkg/vcs"
 
+	"github.com/Morganamilo/go-srcinfo"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/leonelquinteros/gotext"
 )
@@ -243,6 +245,7 @@ func (installer *Installer) installAURPackages(ctx context.Context,
 	deps := make([]string, 0, aurDepNames.Cardinality())
 	exps := make([]string, 0, aurExpNames.Cardinality())
 	pkgArchives := make([]string, 0, len(all))
+	debugPkgs := make([]string, 0, len(all))
 
 	for _, name := range all {
 		base := nameToBase[name]
@@ -288,11 +291,27 @@ func (installer *Installer) installAURPackages(ctx context.Context,
 
 		if hasDebug {
 			deps = append(deps, name+"-debug")
+			sourceInfo, err := srcinfo.ParseFile(dir + "/.SRCINFO")
+			if err != nil {
+				return errors.New(gotext.Get("could not read conflicts for debug package: %s", name))
+			}
+			for _, conflict := range sourceInfo.Conflicts {
+				if installer.dbExecutor.LocalPackage(conflict.Value+"-debug") != nil {
+					debugPkgs = append(debugPkgs, conflict.Value+"-debug")
+				}
+			}
 		}
 	}
 
 	if len(pkgArchives) == 0 || !installer.installBuiltPackages {
 		return nil
+	}
+
+	if len(debugPkgs) > 0 {
+		err := removeDebugCounterpart(ctx, installer.targetMode, installer.exeCmd, debugPkgs, cmdArgs)
+		if err != nil {
+			return fmt.Errorf("%s - %w", gotext.Get("error removing debug counterpart packages"), err)
+		}
 	}
 
 	if err := installPkgArchive(ctx, installer.exeCmd, installer.targetMode,

--- a/pkg/sync/build/pkg_archive.go
+++ b/pkg/sync/build/pkg_archive.go
@@ -163,3 +163,24 @@ func parsePackageList(ctx context.Context, cmdBuilder exe.ICmdBuilder,
 
 	return pkgdests, pkgVersion, nil
 }
+
+func removeDebugCounterpart(ctx context.Context, mode parser.TargetMode, cmdBuilder exe.ICmdBuilder, debugPkgs []string, cmdArgs *parser.Arguments) error {
+	removeArguments := cmdArgs.CopyGlobal()
+
+	err := removeArguments.AddArg("R", "d", "d")
+	if err != nil {
+		return err
+	}
+
+	for _, pkg := range debugPkgs {
+		removeArguments.AddTarget(pkg)
+	}
+
+	oldValue := settings.NoConfirm
+	settings.NoConfirm = true
+	err = cmdBuilder.Show(cmdBuilder.BuildPacmanCmd(ctx,
+		removeArguments, mode, settings.NoConfirm))
+	settings.NoConfirm = oldValue
+
+	return err
+}


### PR DESCRIPTION
Fixes #2499                                                                                                                                                                                 
                                                                                                                                                                                              
  When installing an AUR package that produces a -debug counterpart and                                                                                                                       
  conflicts with an installed package, the conflicting package's -debug                                                                                                                       
  counterpart was not being removed, causing a file conflict error.                                                                                                                           
                                                                                                                                                                                              
  This fix reads the conflicts declared in the .SRCINFO of the package                                                                                                                        
  being installed, checks if their -debug counterparts are installed                                                                                                                          
  locally, and removes them before calling pacman -U.    