### PR TITLE
feat: add pkgbuild pager config

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -65,6 +65,7 @@ Permanent configuration options:
     --builddir    <dir>   Directory used to download and run PKGBUILDS
     --editor      <file>  Editor to use when editing PKGBUILDs
     --editorflags <flags> Pass arguments to editor
+    --pkgbuildpager <cmd> Command to page PKGBUILDs printed by -Gp
     --makepkg     <file>  makepkg command to use
     --mflags      <flags> Pass arguments to makepkg
     --pacman      <file>  pacman command to use
@@ -307,8 +308,8 @@ func handleWeb(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argume
 
 func handleGetpkgbuild(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Arguments, dbExecutor download.DBSearcher) error {
 	if cmdArgs.ExistsArg("p", "print") {
-		return printPkgbuilds(dbExecutor, run.AURClient,
-			run.HTTPClient, run.Logger, cmdArgs.Targets, run.Cfg.Mode, run.Cfg.AURURL)
+		return printPkgbuilds(ctx, dbExecutor, run.AURClient,
+			run.HTTPClient, run.Logger, cmdArgs.Targets, run.Cfg.Mode, run.Cfg.AURURL, run.Cfg.PkgbuildPager)
 	}
 
 	return getPkgbuilds(ctx, dbExecutor, run.AURClient, run,

--- a/completions/bash
+++ b/completions/bash
@@ -70,6 +70,7 @@ _yay() {
   common=('arch cachedir color config confirm dbpath debug gpgdir help hookdir logfile
           noconfirm noprogressbar noscriptlet quiet root verbose
           makepkg pacman git gpg gpgflags config requestsplitn sudoloop
+          pkgbuildpager
           redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild sortby
           singlelineresults doublelineresults answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
           noansweredit noanswerupgrade cleanmenu diffmenu editmenu cleanafter keepsrc
@@ -89,7 +90,7 @@ _yay() {
 
   if [[ $? != 0 ]]; then
     _arch_ptr2comp core
-  elif [[ ! $prev =~ ^-[[:alnum:]_]*[Vbhr] && ! $prev == --@(cachedir|color|config|dbpath|help|hookdir|gpgdir|logfile|root|version) ]]; then
+  elif [[ ! $prev =~ ^-[[:alnum:]_]*[Vbhr] && ! $prev == --@(cachedir|color|config|dbpath|help|hookdir|gpgdir|logfile|pkgbuildpager|root|version) ]]; then
     [[ $cur == -* ]] && _arch_ptr2comp ${o#* } common ||
       case ${o% *} in
       D | R)

--- a/completions/fish
+++ b/completions/fish
@@ -193,6 +193,7 @@ complete -c $progname -n "not $noopt" -l aurrpcurl -d 'Set an alternative URL fo
 complete -c $progname -n "not $noopt" -l builddir -d 'Directory to use for Building AUR Packages' -r
 complete -c $progname -n "not $noopt" -l editor -d 'Editor to use' -f
 complete -c $progname -n "not $noopt" -l editorflags -d 'Editor flags to use' -f
+complete -c $progname -n "not $noopt" -l pkgbuildpager -d 'Command used to display PKGBUILDs printed by -Gp' -f
 complete -c $progname -n "not $noopt" -l makepkg -d 'Makepkg command to use' -f
 complete -c $progname -n "not $noopt" -l pacman -d 'Pacman command to use' -f
 complete -c $progname -n "not $noopt" -l tar -d 'Tar command to use' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -53,6 +53,7 @@ _pacman_opts_common=(
 	'--builddir[Directory to use for building AUR Packages]:build dir:_files -/'
 	'--editor[Editor to use when editing PKGBUILDs]:editor:_files'
 	'--editorflags[Flags to pass to editor]'
+	'--pkgbuildpager[Command used to display PKGBUILDs printed by -Gp]:command'
 	'--makepkg[makepkg command to use]:makepkg:_files'
 	'--pacman[pacman command to use]:pacman:_files'
 	'--git[git command to use]:git:_files'

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -194,6 +194,13 @@ passed to the editor. Multiple arguments may be passed by supplying a space
 separated list that is quoted by the shell.
 
 .TP
+.B \-\-pkgbuildpager <command>
+Command used to display PKGBUILDs printed by \fB\-Gp\fR. The generated
+PKGBUILD output is piped to the command on standard input. The command is run
+through \fBsh -c\fR. If this is not set, PKGBUILDs are printed directly to
+standard output.
+
+.TP
 .B \-\-makepkg <command>
 The command to use for \fBmakepkg\fR calls. This can be a command in
 \fBPATH\fR or an absolute path to the file.

--- a/get.go
+++ b/get.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/Jguer/aur"
 	"github.com/leonelquinteros/gotext"
@@ -17,17 +20,22 @@ import (
 )
 
 // yay -Gp.
-func printPkgbuilds(dbExecutor download.DBSearcher, aurClient aur.QueryClient,
+func printPkgbuilds(ctx context.Context, dbExecutor download.DBSearcher, aurClient aur.QueryClient,
 	httpClient *http.Client, logger *text.Logger, targets []string,
-	mode parser.TargetMode, aurURL string,
+	mode parser.TargetMode, aurURL, pkgbuildPager string,
 ) error {
 	pkgbuilds, err := download.PKGBUILDs(dbExecutor, aurClient, httpClient, logger, targets, aurURL, mode)
 	if err != nil {
 		logger.Errorln(err)
 	}
 
+	output := &bytes.Buffer{}
 	for target, pkgbuild := range pkgbuilds {
-		logger.Printf("\n\n# %s\n\n%s", target, string(pkgbuild))
+		fmt.Fprintf(output, "\n\n# %s\n\n%s", target, string(pkgbuild))
+	}
+
+	if err := printPkgbuildOutput(ctx, logger, output.Bytes(), pkgbuildPager); err != nil {
+		return err
 	}
 
 	if len(pkgbuilds) != len(targets) {
@@ -42,6 +50,44 @@ func printPkgbuilds(dbExecutor download.DBSearcher, aurClient aur.QueryClient,
 		logger.Warnln(gotext.Get("Unable to find the following packages:"), " ", strings.Join(missing, ", "))
 
 		return fmt.Errorf("")
+	}
+
+	return nil
+}
+
+func printPkgbuildOutput(ctx context.Context, logger *text.Logger, output []byte, pkgbuildPager string) error {
+	if len(output) == 0 {
+		return nil
+	}
+
+	if strings.TrimSpace(pkgbuildPager) == "" {
+		logger.Print(string(output))
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", pkgbuildPager)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to open pkgbuild pager stdin: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to run pkgbuild pager: %w", err)
+	}
+
+	// Let users quit pagers early without treating the resulting broken pipe as
+	// a yay error; the pager's exit status is still checked below.
+	_, _ = stdin.Write(output)
+	_ = stdin.Close()
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("failed to run pkgbuild pager: %w", err)
 	}
 
 	return nil

--- a/get_ops_test.go
+++ b/get_ops_test.go
@@ -4,9 +4,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -21,18 +26,26 @@ import (
 )
 
 func TestPrintPkgbuilds(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
-		name    string
-		targets []string
-		results []aur.Pkg
-		wantErr bool
+		name          string
+		targets       []string
+		results       []aur.Pkg
+		pkgbuildPager string
+		wantOutput    string
+		wantPager     string
+		wantErr       bool
 	}{
 		{
-			name:    "prints pkgbuild when package exists",
-			targets: []string{"aur/pkg"},
-			results: []aur.Pkg{{Name: "pkg", PackageBase: "pkg"}},
+			name:       "prints pkgbuild when package exists",
+			targets:    []string{"aur/pkg"},
+			results:    []aur.Pkg{{Name: "pkg", PackageBase: "pkg"}},
+			wantOutput: "\n\n# aur/pkg\n\npkgbuild",
+		},
+		{
+			name:      "pipes pkgbuild through configured pager",
+			targets:   []string{"aur/pkg"},
+			results:   []aur.Pkg{{Name: "pkg", PackageBase: "pkg"}},
+			wantPager: "\n\n# aur/pkg\n\npkgbuild",
 		},
 		{
 			name:    "returns error when package does not exist",
@@ -46,24 +59,55 @@ func TestPrintPkgbuilds(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			defer gock.Off()
+			pagerOut := ""
+			pkgbuildPager := tc.pkgbuildPager
+			if tc.wantPager != "" {
+				pagerOut = filepath.Join(t.TempDir(), "pager-out")
+				pkgbuildPager = fmt.Sprintf("cat > %s", strconv.Quote(pagerOut))
+			}
+
 			gock.New("https://aur.archlinux.org").
 				Get("/cgit/aur.git/plain/PKGBUILD").
 				Reply(200).
 				BodyString("pkgbuild")
 
-			err := printPkgbuilds(&mockDBSearcher{}, &mockaur.MockAUR{
+			var stdout bytes.Buffer
+			err := printPkgbuilds(context.Background(), &mockDBSearcher{}, &mockaur.MockAUR{
 				GetFn: func(ctx context.Context, query *aur.Query) ([]aur.Pkg, error) {
 					return tc.results, nil
 				},
-			}, &http.Client{}, text.NewLogger(io.Discard, io.Discard, strings.NewReader(""), true, "test"),
-				tc.targets, parser.ModeAny, "https://aur.archlinux.org")
+			}, &http.Client{}, text.NewLogger(&stdout, io.Discard, strings.NewReader(""), true, "test"),
+				tc.targets, parser.ModeAny, "https://aur.archlinux.org", pkgbuildPager)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
+			require.Equal(t, tc.wantOutput, stdout.String())
+			if tc.wantPager != "" {
+				got, readErr := os.ReadFile(pagerOut)
+				require.NoError(t, readErr)
+				require.Equal(t, tc.wantPager, string(got))
+			}
 		})
 	}
+}
+
+func TestPrintPkgbuildsReturnsPagerError(t *testing.T) {
+	defer gock.Off()
+	gock.New("https://aur.archlinux.org").
+		Get("/cgit/aur.git/plain/PKGBUILD").
+		Reply(200).
+		BodyString("pkgbuild")
+
+	err := printPkgbuilds(context.Background(), &mockDBSearcher{}, &mockaur.MockAUR{
+		GetFn: func(ctx context.Context, query *aur.Query) ([]aur.Pkg, error) {
+			return []aur.Pkg{{Name: "pkg", PackageBase: "pkg"}}, nil
+		},
+	}, &http.Client{}, text.NewLogger(io.Discard, io.Discard, strings.NewReader(""), true, "test"),
+		[]string{"aur/pkg"}, parser.ModeAny, "https://aur.archlinux.org", "exit 42")
+
+	require.ErrorContains(t, err, "failed to run pkgbuild pager")
 }
 
 type mockDBSearcher struct{}

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -128,6 +128,8 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.Editor = value
 	case "editorflags":
 		c.EditorFlags = value
+	case "pkgbuildpager":
+		c.PkgbuildPager = value
 	case "makepkg":
 		c.MakepkgBin = value
 	case "makepkgconf":

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -33,6 +33,7 @@ type Configuration struct {
 	BuildDir               string `json:"buildDir" ini:"BuildDir"`
 	Editor                 string `json:"editor" ini:"Editor"`
 	EditorFlags            string `json:"editorflags" ini:"EditorFlags"`
+	PkgbuildPager          string `json:"pkgbuildpager" ini:"PkgbuildPager"`
 	MakepkgBin             string `json:"makepkgbin" ini:"MakepkgBin"`
 	MakepkgConf            string `json:"makepkgconf" ini:"MakepkgConf"`
 	PacmanBin              string `json:"pacmanbin" ini:"PacmanBin"`
@@ -99,6 +100,7 @@ func (c *Configuration) expandEnv() {
 	c.BuildDir = expandEnvOrHome(c.BuildDir)
 	c.Editor = expandEnvOrHome(c.Editor)
 	c.EditorFlags = os.ExpandEnv(c.EditorFlags)
+	c.PkgbuildPager = os.ExpandEnv(c.PkgbuildPager)
 	c.MakepkgBin = expandEnvOrHome(c.MakepkgBin)
 	c.MakepkgConf = expandEnvOrHome(c.MakepkgConf)
 	c.PacmanBin = expandEnvOrHome(c.PacmanBin)

--- a/pkg/settings/config_test.go
+++ b/pkg/settings/config_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v12/pkg/settings/parser"
 )
 
 // GIVEN a non existing build dir in the config
@@ -109,6 +111,33 @@ func TestNewConfigAURDESTTildeExpansion(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(homeDir, "test-build-dir"))
 	assert.NoError(t, err)
+}
+
+func TestConfigurationPkgbuildPagerOption(t *testing.T) {
+	config := DefaultConfig("test")
+
+	ok := config.handleOption("pkgbuildpager", "bat -pp --color=always -lPKGBUILD")
+
+	require.True(t, ok)
+	assert.Equal(t, "bat -pp --color=always -lPKGBUILD", config.PkgbuildPager)
+}
+
+func TestConfigurationParsePkgbuildPagerOption(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+
+	os.Args = []string{"yay", "--pkgbuildpager", "bat -pp --color=always -lPKGBUILD", "-Gp", "yay"}
+	config := DefaultConfig("test")
+	cmdArgs := parser.MakeArguments()
+
+	require.NoError(t, config.ParseCommandLine(cmdArgs))
+
+	assert.Equal(t, "bat -pp --color=always -lPKGBUILD", config.PkgbuildPager)
+	assert.False(t, cmdArgs.ExistsArg("pkgbuildpager"))
+	assert.Equal(t, "G", cmdArgs.Op)
+	assert.Equal(t, []string{"yay"}, cmdArgs.Targets)
 }
 
 // GIVEN default config

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -406,6 +406,7 @@ func isArg(arg string) bool {
 	case "builddir":
 	case "editor":
 	case "editorflags":
+	case "pkgbuildpager":
 	case "makepkg":
 	case "makepkgconf":
 	case "nomakepkgconf":
@@ -517,6 +518,7 @@ func hasParam(arg string) bool {
 	case "builddir":
 	case "editor":
 	case "editorflags":
+	case "pkgbuildpager":
 	case "makepkg":
 	case "makepkgconf":
 	case "pacman":

--- a/pkg/settings/yay.conf
+++ b/pkg/settings/yay.conf
@@ -11,6 +11,7 @@ BuildDir = ~/.cache/yay
 # Binaries
 #Editor = vim
 #EditorFlags = 
+#PkgbuildPager = bat -pp --color=always -lPKGBUILD
 MakepkgBin = makepkg
 #MakepkgConf = 
 PacmanBin = pacman


### PR DESCRIPTION
## Summary

- add a `PkgbuildPager` config option for `yay -Gp` output
- preserve current raw stdout behavior when the option is unset
- pipe generated PKGBUILD output through the configured command when set
- document the option and update shell completions

Example config:

```ini
PkgbuildPager = bat -pp --color=always -lPKGBUILD
```

Closes #2831

## Tests

- `go test ./...`
- `make test`
- `git diff --check`

## Note

This PR was prepared with assistance from OpenAI Codex. The changes were reviewed locally and validated with the tests above.