### PR TITLE
fix(runtime): use AUR cache in query builder when RPC disabled

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -127,7 +127,7 @@ func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version 
 	}
 
 	queryBuilder := query.NewSourceQueryBuilder(
-		aurClient,
+		aurCache,
 		logger.Child("mixed.querybuilder"), cfg.SortBy,
 		cfg.Mode, cfg.SearchBy,
 		cfg.BottomUp, cfg.SingleLineResults, cfg.SeparateSources)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestBuildRuntime(t *testing.T) {
-	t.Parallel()
 	path := "../../testdata/pacman.conf"
 
 	absPath, err := filepath.Abs(path)
@@ -55,7 +54,6 @@ func TestBuildRuntime(t *testing.T) {
 }
 
 func TestBuildRuntimeSearchUsesMetadataCacheWhenRPCDisabled(t *testing.T) {
-	t.Parallel()
 	path := "../../testdata/pacman.conf"
 
 	absPath, err := filepath.Abs(path)
@@ -76,7 +74,7 @@ func TestBuildRuntimeSearchUsesMetadataCacheWhenRPCDisabled(t *testing.T) {
 			"LastModified": 1660494113
 		}
 	]`)
-	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "aur.json"), cacheContent, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "aur.json"), cacheContent, 0o600))
 
 	cfg := &settings.Configuration{
 		Debug:       true,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4,12 +4,15 @@
 package runtime_test
 
 import (
+	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Jguer/yay/v12/pkg/db/mock"
 	"github.com/Jguer/yay/v12/pkg/runtime"
 	"github.com/Jguer/yay/v12/pkg/settings"
 	"github.com/Jguer/yay/v12/pkg/settings/parser"
@@ -49,4 +52,47 @@ func TestBuildRuntime(t *testing.T) {
 	assert.NotNil(t, run.VoteClient)
 	assert.NotNil(t, run.AURClient)
 	assert.NotNil(t, run.Logger)
+}
+
+func TestBuildRuntimeSearchUsesMetadataCacheWhenRPCDisabled(t *testing.T) {
+	t.Parallel()
+	path := "../../testdata/pacman.conf"
+
+	absPath, err := filepath.Abs(path)
+	require.NoError(t, err)
+
+	buildDir := t.TempDir()
+	cacheContent := []byte(`[
+		{
+			"ID": 1125983,
+			"Name": "yay",
+			"PackageBaseID": 115973,
+			"PackageBase": "yay",
+			"Version": "11.3.0-1",
+			"Description": "Yet another yogurt. Pacman wrapper and AUR helper written in go.",
+			"NumVotes": 1855,
+			"Popularity": 39.741927,
+			"FirstSubmitted": 1475688004,
+			"LastModified": 1660494113
+		}
+	]`)
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "aur.json"), cacheContent, 0o644))
+
+	cfg := &settings.Configuration{
+		Debug:       true,
+		UseRPC:      false,
+		AURURL:      "https://aur.archlinux.org",
+		AURRPCURL:   "http://127.0.0.1:1/rpc?",
+		BuildDir:    buildDir,
+		VCSFilePath: filepath.Join(buildDir, "vcs.json"),
+		PacmanConf:  absPath,
+		Mode:        parser.ModeAUR,
+	}
+	cmdArgs := parser.MakeArguments()
+
+	run, err := runtime.NewRuntime(cfg, cmdArgs, "1.0.0")
+	require.NoError(t, err)
+
+	run.QueryBuilder.Execute(context.Background(), &mock.DBExecutor{}, []string{"yay"})
+	assert.Equal(t, 1, run.QueryBuilder.Len())
 }


### PR DESCRIPTION
When RPC is disabled, the query builder was still receiving the AUR client instead of the AUR cache, so metadata searches would bypass the cached JSON file and try to hit the (disabled) RPC endpoint. This routes the query builder to the cache when RPC is off