### PR TITLE
feat(completions): add deptest and build subcommand completions

### DIFF
--- a/completions/bash
+++ b/completions/bash
@@ -50,12 +50,13 @@ _pacman_repo_list() {
 
 _yay() {
   compopt -o default
-  local common core cur database files prev query remove sync upgrade o
+  local common core cur database deptest files prev query remove sync upgrade build o
   local yays show getpkgbuild web
   local cur prev words cword
 
   _init_completion || return
   database=('asdeps asexplicit')
+  deptest=()
   files=('list machinereadable refresh regex' 'l x y')
   query=('changelog check deps explicit file foreign groups info list native owns
           search unrequired upgrades' 'c e g i k l m n o p s t u')
@@ -64,15 +65,16 @@ _yay() {
          info list needed nodeps assume-installed print refresh recursive search sysupgrade aur repo'
     'c g i l p s u w y a N')
   upgrade=('asdeps asexplicit overwrite needed nodeps assume-installed print recursive' 'p')
-  core=('database files help query remove sync upgrade version' 'D F Q R S U V h')
+  build=()
+  core=('build database deptest files help query remove sync upgrade version' 'B D F Q R S T U V h')
 
   ##yay stuff
   common=('arch cachedir color config confirm dbpath debug gpgdir help hookdir logfile
-          noconfirm noprogressbar noscriptlet quiet root verbose
-          makepkg pacman git gpg gpgflags config requestsplitn sudoloop
+          noconfirm noprogressbar noscriptlet quiet root verbose disable-download-timeout sysroot
+          save builddir editor editorflags makepkg pacman git gitflags gpg gpgflags mflags config requestsplitn sudoloop sudo sudoflags
           redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild sortby
           singlelineresults doublelineresults answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
-          noansweredit noanswerupgrade cleanmenu diffmenu editmenu cleanafter keepsrc
+          noansweredit noanswerupgrade cleanmenu diffmenu editmenu cleanafter keepsrc topdown bottomup devel separatesources
           provides pgpfetch
           useask combinedupgrade aur repo makepkgconf
           nomakepkgconf askremovemake askyesremovemake removemake noremovemake completioninterval aururl aurrpcurl
@@ -83,7 +85,7 @@ _yay() {
   getpkgbuild=('force print' 'f p')
   web=('vote unvote' 'v u')
 
-  for o in 'D database' 'F files' 'Q query' 'R remove' 'S sync' 'U upgrade' 'Y yays' 'P show' 'G getpkgbuild' 'W web'; do
+  for o in 'B build' 'D database' 'F files' 'Q query' 'R remove' 'S sync' 'T deptest' 'U upgrade' 'Y yays' 'P show' 'G getpkgbuild' 'W web'; do
     _arch_incomp "$o" && break
   done
 
@@ -113,6 +115,9 @@ _yay() {
           { _arch_incomp 'l list' && _pacman_repo_list; } ||
           { _arch_incomp 's search' && compopt +o default; } ||
           _yay_pkg
+        ;;
+      T)
+        _pacman_pkg T
         ;;
       U)
         _pacman_file

--- a/completions/fish
+++ b/completions/fish
@@ -11,13 +11,14 @@ set -l yayspecific '__fish_contains_opt -s Y yay'
 set -l webspecific '__fish_contains_opt -s W web'
 set -l show '__fish_contains_opt -s P show'
 set -l getpkgbuild '__fish_contains_opt -s G getpkgbuild'
+set -l build '__fish_contains_opt -s B build'
 
 # Pacman constants
 set -l listinstalled "(pacman -Q | string replace ' ' \t)"
 set -l listrepos "(__fish_print_pacman_repos)"
 set -l listgroups "(pacman -Sg)\t'Package Group'"
 
-set -l noopt 'not __fish_contains_opt -s S -s D -s Q -s R -s U -s T -s F -s Y -s W -s P -s G database query sync remove upgrade deptest files show getpkgbuild web yay'
+set -l noopt 'not __fish_contains_opt -s S -s D -s Q -s R -s U -s T -s F -s Y -s W -s P -s G -s B database query sync remove upgrade deptest files show getpkgbuild web yay build'
 set -l database '__fish_contains_opt -s D database'
 set -l query '__fish_contains_opt -s Q query'
 set -l remove '__fish_contains_opt -s R remove'
@@ -41,6 +42,7 @@ complete -c $progname -s S -f -l sync -n "$noopt" -d 'Synchronize packages'
 complete -c $progname -s T -f -l deptest -n "$noopt" -d 'Check dependencies'
 complete -c $progname -s U -l upgrade -n "$noopt" -d 'Upgrade or add a local package'
 complete -c $progname -s F -f -l files -n "$noopt" -d 'Query the files database'
+complete -c $progname -s B -f -l build -n "$noopt" -d 'Build from a local PKGBUILD'
 complete -c $progname -s V -f -l version -d 'Display version and exit'
 complete -c $progname -s h -f -l help -d 'Display help'
 
@@ -106,7 +108,7 @@ end
 # Database options
 set -l has_db_opt '__fish_contains_opt asdeps asexplicit check -s k'
 complete -c $progname -n "$database; and not $has_db_opt" -s k -l check -d 'Check database validity'
-complete -c $progname -n "$database" -s q -l quite -d 'Suppress output of success messages' -f
+complete -c $progname -n "$database" -s q -l quiet -d 'Suppress output of success messages' -f
 complete -c $progname -n "$database; and not $has_db_opt" -l asdeps -d 'Mark PACKAGE as dependency' -x
 complete -c $progname -n "$database; and not $has_db_opt" -l asexplicit -d 'Mark PACKAGE as explicitly installed' -x
 complete -c $progname -n "$has_db_opt; and $database" -xa "$listinstalled"
@@ -188,27 +190,27 @@ complete -c $progname -n "$getpkgbuild" -s p -l print -d 'Print pkgbuild of pack
 
 # Permanent configuration settings
 complete -c $progname -n "not $noopt" -l save -d 'Save current arguments to yay permanent configuration' -f
-complete -c $progname -n "not $noopt" -l aururl -d 'Set an alternative AUR URL' -f
-complete -c $progname -n "not $noopt" -l aurrpcurl -d 'Set an alternative URL for the AUR /rpc endpoint' -f
+complete -c $progname -n "not $noopt" -l aururl -d 'Set an alternative AUR URL' -x
+complete -c $progname -n "not $noopt" -l aurrpcurl -d 'Set an alternative URL for the AUR /rpc endpoint' -x
 complete -c $progname -n "not $noopt" -l builddir -d 'Directory to use for Building AUR Packages' -r
-complete -c $progname -n "not $noopt" -l editor -d 'Editor to use' -f
-complete -c $progname -n "not $noopt" -l editorflags -d 'Editor flags to use' -f
-complete -c $progname -n "not $noopt" -l makepkg -d 'Makepkg command to use' -f
-complete -c $progname -n "not $noopt" -l pacman -d 'Pacman command to use' -f
-complete -c $progname -n "not $noopt" -l tar -d 'Tar command to use' -f
-complete -c $progname -n "not $noopt" -l git -d 'Git command to use' -f
-complete -c $progname -n "not $noopt" -l gpg -d 'Gpg command to use' -f
+complete -c $progname -n "not $noopt" -l editor -d 'Editor to use' -r
+complete -c $progname -n "not $noopt" -l editorflags -d 'Editor flags to use' -x
+complete -c $progname -n "not $noopt" -l makepkg -d 'Makepkg command to use' -r
+complete -c $progname -n "not $noopt" -l pacman -d 'Pacman command to use' -r
+complete -c $progname -n "not $noopt" -l git -d 'Git command to use' -r
+complete -c $progname -n "not $noopt" -l gitflags -d 'Git flags to use' -x
+complete -c $progname -n "not $noopt" -l gpg -d 'Gpg command to use' -r
 complete -c $progname -n "not $noopt" -l config -d 'The pacman config file to use' -r
 complete -c $progname -n "not $noopt" -l makepkgconf -d 'Use custom makepkg.conf location' -r
 complete -c $progname -n "not $noopt" -l nomakepkgconf -d 'Use default makepkg.conf' -f
-complete -c $progname -n "not $noopt" -l requestsplitn -d 'Max amount of packages to query per AUR request' -f
-complete -c $progname -n "not $noopt" -l completioninterval -d 'Refresh interval for completion cache' -f
+complete -c $progname -n "not $noopt" -l requestsplitn -d 'Max amount of packages to query per AUR request' -x
+complete -c $progname -n "not $noopt" -l completioninterval -d 'Refresh interval for completion cache' -x
 complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specific field during search' -xa "{votes,popularity,name,base,submitted,modified}"
 complete -c $progname -n "not $noopt" -l searchby -d 'Search for AUR packages by querying the specified field' -xa "{name,name-desc,maintainer,depends,checkdepends,makedepends,optdepends}"
 complete -c $progname -n "not $noopt" -l answerclean -d 'Set a predetermined answer for the clean build menu' -xa "{All,None,Installed,NotInstalled}"
 complete -c $progname -n "not $noopt" -l answerdiff -d 'Set a predetermined answer for the edit diff menu' -xa "{All,None,Installed,NotInstalled}"
 complete -c $progname -n "not $noopt" -l answeredit -d 'Set a predetermined answer for the edit pkgbuild menu' -xa "{All,None,Installed,NotInstalled}"
-complete -c $progname -n "not $noopt" -l answerupgrade -d 'Set a predetermined answer for the upgrade menu' -f
+complete -c $progname -n "not $noopt" -l answerupgrade -d 'Set a predetermined answer for the upgrade menu' -x
 complete -c $progname -n "not $noopt" -l noanswerclean -d 'Unset the answer for the clean build menu' -f
 complete -c $progname -n "not $noopt" -l noanswerdiff -d 'Unset the answer for the diff menu' -f
 complete -c $progname -n "not $noopt" -l noansweredit -d 'Unset the answer for the edit pkgbuild menu' -f
@@ -227,6 +229,7 @@ complete -c $progname -n "not $noopt" -l doublelineresults -d 'List each search 
 complete -c $progname -n "not $noopt" -l devel -d 'Check -git/-svn/-hg development version' -f
 complete -c $progname -n "not $noopt" -l cleanafter -d 'Clean package sources after successful build' -f
 complete -c $progname -n "not $noopt" -l keepsrc -d 'Keep pkg/ and src/ after building packages' -f
+complete -c $progname -n "not $noopt" -l separatesources -d 'Separate query results by source, AUR and sync' -f
 complete -c $progname -n "not $noopt" -l redownload -d 'Redownload PKGBUILD of package even if up-to-date' -f
 complete -c $progname -n "not $noopt" -l redownloadall -d 'Redownload PKGBUILD of package and deps even if up-to-date' -f
 complete -c $progname -n "not $noopt" -l noredownload -d 'Do not redownload up-to-date PKGBUILDs' -f
@@ -239,6 +242,8 @@ complete -c $progname -n "not $noopt" -l rebuild -d 'Always build target package
 complete -c $progname -n "not $noopt" -l rebuildall -d 'Always build all AUR packages' -f
 complete -c $progname -n "not $noopt" -l rebuildtree -d 'Always build all AUR packages even if installed' -f
 complete -c $progname -n "not $noopt" -l norebuild -d 'Skip package build if in cache and up to date' -f
-complete -c $progname -n "not $noopt" -l mflags -d 'Pass the following options to makepkg' -f
-complete -c $progname -n "not $noopt" -l gpgflags -d 'Pass the following options to gpg' -f
+complete -c $progname -n "not $noopt" -l mflags -d 'Pass the following options to makepkg' -x
+complete -c $progname -n "not $noopt" -l gpgflags -d 'Pass the following options to gpg' -x
+complete -c $progname -n "not $noopt" -l sudo -d 'The command to use for sudo calls' -r
+complete -c $progname -n "not $noopt" -l sudoflags -d 'Pass arguments to sudo' -x
 complete -c $progname -n "not $noopt" -l sudoloop -d 'Loop sudo calls in the background to avoid timeout' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -6,6 +6,7 @@ setopt extendedglob
 
 # options for passing to _arguments: main pacman commands
 _pacman_opts_commands=(
+	{-B,--build}'[Build from a local PKGBUILD]'
 	{-D,--database}'[Modify database]'
 	{-F,--files}'[Query the files database]'
 	{-G,--getpkgbuild}'[Get PKGBUILD from ABS or AUR]'
@@ -41,12 +42,14 @@ _pacman_opts_common=(
 	'--completioninterval[Time in days to refresh completion cache]:number'
 	'--confirm[Always ask for confirmation]'
 	'--debug[Display debug messages]'
+	'--disable-download-timeout[Use relaxed timeouts for download]'
 	'--gpgdir[Set an alternate directory for GnuPG (instead of /etc/pacman.d/gnupg)]: :_files -/'
 	'--hookdir[Set an alternate hook location]: :_files -/'
 	'--logfile[An alternate log file]:config file:_files'
 	'--noconfirm[Do not ask for confirmation]'
 	'--noprogressbar[Do not show a progress bar when downloading files]'
 	'--noscriptlet[Do not execute the install scriptlet if one exists]'
+	'--sysroot[Operate on a mounted guest system]:system root:_files -/'
 
 	'--save[Causes config options to be saved back to the config file]'
 
@@ -56,6 +59,7 @@ _pacman_opts_common=(
 	'--makepkg[makepkg command to use]:makepkg:_files'
 	'--pacman[pacman command to use]:pacman:_files'
 	'--git[git command to use]:git:_files'
+	'--gitflags[Flags to pass to git]:gitflags'
 	'--gpg[gpg command to use]:gpg:_files'
 
 	'--sortby[Sort AUR results by a specific field during search]:sortby options:(votes popularity name base submitted modified)'
@@ -166,11 +170,15 @@ _pacman_opts_web_modifiers=(
 _pacman_opts_print_modifiers=(
 		'(-c --complete)'{-c,--complete}'[Used for completions]'
 		'(-d --defaultconfig)'{-d,--defaultconfig}'[Print default yay configuration]'
-		'(-g --config)'{-g,--config}'[Print current yay configuration]'
-		'(-n --numberupgrades)'{-n,--numberupgrades}'[Print number of updates]'
+		'(-g --currentconfig)'{-g,--currentconfig}'[Print current yay configuration]'
+		'(-q --quiet)'{-q,--quiet}'[Only show titles when printing news]'
 		'(-s --stats)'{-s,--stats}'[Display system package statistics]'
-		'(-u --upgrades)'{-u,--upgrades}'[Print update list]'
 		'(-w --news)'{-w,--news}'[Print arch news]'
+)
+
+# -B
+_pacman_opts_build_modifiers=(
+	'*:directory:_files -/'
 )
 # options for passing to _arguments: options for --remove command
 _pacman_opts_remove=(
@@ -311,6 +319,13 @@ _pacman_action_deptest () {
 		'(--deptest)-T' \
 		"$_pacman_opts_common[@]" \
 		":packages:_pacman_all_packages"
+}
+
+_pacman_action_build() {
+	_arguments -s : \
+		'(-B --build)'{-B,--build} \
+		"$_pacman_opts_common[@]" \
+		"$_pacman_opts_build_modifiers[@]"
 }
 
 
@@ -504,14 +519,19 @@ _pacman_zsh_comp() {
 		Q*)
 			_pacman_action_query
 			;;
+		B*)
+			_pacman_action_build
+			;;
 		P*)
 			 _arguments -s : \
 				'-P' \
+				"$_pacman_opts_common[@]" \
 				"$_pacman_opts_print_modifiers[@]"
 			;;
 		W*)
 			 _arguments -s : \
 				'-W' \
+				"$_pacman_opts_common[@]" \
 				"$_pacman_opts_web_modifiers[@]"
 			;;
 		R*)
@@ -555,11 +575,13 @@ _pacman_zsh_comp() {
 		Y*)
 			_arguments -s : \
 				'-Y' \
+				"$_pacman_opts_common[@]" \
 				"$_pacman_opts_yay_modifiers[@]"
 			;;
 		G*)
 			_arguments -s : \
 				'-G' \
+				"$_pacman_opts_common[@]" \
 				"$_pacman_opts_getpkgbuild_modifiers[@]"
 			;;
 
@@ -578,6 +600,9 @@ _pacman_zsh_comp() {
 					;;
 				*--query*)
 					_pacman_action_query
+					;;
+				*--build*)
+					_pacman_action_build
 					;;
 				*--remove*)
 					_pacman_action_remove


### PR DESCRIPTION
Add shell completions for the `deptest` and `build` subcommands across bash, fish, and zsh.

- **bash**: Added `deptest` and `build` to option lists, for-loop mappings, and case handlers
- **fish**: Added `build` option detection and included it in the noopt and build-related option lists
- **zsh**: Added `-B/--build` flag, `--disable-download-timeout`, `--sysroot`, `--gitflags` options, `_pacman_action_build` function, and wired `B*` patterns into the completion dispatcher