### PR TITLE
fix(alpm): wire up log callback and add Debug method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Jguer/yay/v12
 
 require (
 	github.com/Jguer/aur v1.3.0
-	github.com/Jguer/dyalpm v0.1.2
+	github.com/Jguer/dyalpm v0.1.3
 	github.com/Jguer/votar v1.0.0
 	github.com/Morganamilo/go-pacmanconf v0.0.0-20210502114700-cff030e927a5
 	github.com/Morganamilo/go-srcinfo v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Jguer/aur v1.3.0 h1:skdjp/P9kB75TBaJmn9PKK/kCeA9QsgjdUrORZ3gldU=
 github.com/Jguer/aur v1.3.0/go.mod h1:F8Awo+WKzTxlXtNOO4pDQjMkePLZ+oMSbu+1fKLTTLo=
-github.com/Jguer/dyalpm v0.1.2 h1:Gl0+GDWBQmo3DSsfzTPnKqCwYqcroq0j6kAtsIUkpUw=
-github.com/Jguer/dyalpm v0.1.2/go.mod h1:FpcWwU1eYHVWMKmr/yHFqHYKsS+qGKCtk/FIXirj2MY=
+github.com/Jguer/dyalpm v0.1.3 h1:hXwzc9LInpg4F1walco+1eS+AziK4ybqBWwUPUbfREg=
+github.com/Jguer/dyalpm v0.1.3/go.mod h1:QfKO3rYndbmh5ptIGYa1Uw5DOeIDPbCG1gJGbyqWaiI=
 github.com/Jguer/votar v1.0.0 h1:drPYpV5Py5BeAQS8xezmT6uCEfLzotNjLf5yfmlHKTg=
 github.com/Jguer/votar v1.0.0/go.mod h1:rc6vgVlTqNjI4nAnPbDTbdxw/N7kXkbB8BcUDjeFbYQ=
 github.com/Morganamilo/go-pacmanconf v0.0.0-20210502114700-cff030e927a5 h1:TMscPjkb1ThXN32LuFY5bEYIcXZx3YlwzhS1GxNpn/c=

--- a/pkg/db/ialpm/alpm.go
+++ b/pkg/db/ialpm/alpm.go
@@ -150,6 +150,8 @@ func configureAlpm(pacmanConf *pacmanconf.Config, alpmHandle alpm.Handle) error 
 func (ae *AlpmExecutor) logCallback() func(level alpm.LogLevel, str string) {
 	return func(level alpm.LogLevel, str string) {
 		switch level {
+		case alpm.LogDebug:
+			ae.log.Debug(str)
 		case alpm.LogWarning:
 			ae.log.Warn(str)
 		case alpm.LogError:
@@ -258,7 +260,9 @@ func (ae *AlpmExecutor) RefreshHandle() error {
 	if err := alpmSetQuestionCallback(alpmHandle, ae.questionCallback()); err != nil {
 		return err
 	}
-	alpmSetLogCallback(alpmHandle, ae.logCallback())
+	if err := alpmSetLogCallback(alpmHandle, ae.logCallback()); err != nil {
+		return err
+	}
 	ae.handle = alpmHandle
 	ae.syncDBsCache = nil
 
@@ -507,11 +511,8 @@ func (ae *AlpmExecutor) AlpmArchitectures() ([]string, error) {
 	return architectures, err
 }
 
-func alpmSetLogCallback(alpmHandle alpm.Handle, cb func(alpm.LogLevel, string)) {
-	// dyalpm uses a different callback mechanism - log callback not easily supported
-	// due to va_list in libalpm. Skip setting log callback.
-	_ = alpmHandle
-	_ = cb
+func alpmSetLogCallback(alpmHandle alpm.Handle, cb func(alpm.LogLevel, string)) error {
+	return alpmHandle.SetLogCallbackFunc(cb)
 }
 
 func alpmSetQuestionCallback(alpmHandle alpm.Handle, cb func(alpm.QuestionAny)) error {

--- a/pkg/text/service.go
+++ b/pkg/text/service.go
@@ -13,7 +13,7 @@ const (
 
 type Logger struct {
 	name   string
-	Debug  bool
+	debug  bool
 	stdout io.Writer
 	stderr io.Writer
 	r      io.Reader
@@ -21,7 +21,7 @@ type Logger struct {
 
 func NewLogger(stdout, stderr io.Writer, r io.Reader, debug bool, name string) *Logger {
 	return &Logger{
-		Debug:  debug,
+		debug:  debug,
 		name:   name,
 		r:      r,
 		stderr: stderr,
@@ -30,17 +30,29 @@ func NewLogger(stdout, stderr io.Writer, r io.Reader, debug bool, name string) *
 }
 
 func (l *Logger) Child(name string) *Logger {
-	return NewLogger(l.stdout, l.stderr, l.r, l.Debug, name)
+	return NewLogger(l.stdout, l.stderr, l.r, l.debug, name)
 }
 
-func (l *Logger) Debugln(a ...any) {
-	if !l.Debug {
+func (l *Logger) sprintDebug(a ...any) string {
+	return fmt.Sprint(append([]any{
+		Bold(yellow(fmt.Sprintf("[DEBUG:%s]", l.name))),
+	}, a...)...)
+}
+
+func (l *Logger) Debug(a ...any) {
+	if !l.debug {
 		return
 	}
 
-	l.Println(append([]any{
-		Bold(yellow(fmt.Sprintf("[DEBUG:%s]", l.name))),
-	}, a...)...)
+	l.Print(l.sprintDebug(a...))
+}
+
+func (l *Logger) Debugln(a ...any) {
+	if !l.debug {
+		return
+	}
+
+	l.Println(l.sprintDebug(a...))
 }
 
 func (l *Logger) OperationInfoln(a ...any) {


### PR DESCRIPTION
The log callback in the ALPM executor was stubbed out and never actually connected to libalpm. This happened because the old dyalpm version didn't expose SetLogCallbackFunc.

Bumps dyalpm to v0.1.3 which exposes the callback setter, then wires everything up properly. Also adds a missing DebugLog level case and extracts the debug formatting so Debug and Debugln stay consistent.