### PR TITLE
feat: add --upgrademinage to delay AUR updates

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -77,6 +77,7 @@ Permanent configuration options:
     --nomakepkgconf       Use the default makepkg.conf
 
     --requestsplitn <n>   Max amount of packages to query per AUR request
+    --upgrademinage <h>   Withhold AUR updates until the package is <h> hours old (0 to disable)
     --completioninterval  <n> Time in days to refresh completion cache
     --sortby    <field>   Sort AUR results by a specific field during search
     --searchby  <field>   Search for packages using a specified field

--- a/completions/bash
+++ b/completions/bash
@@ -71,7 +71,7 @@ _yay() {
   ##yay stuff
   common=('arch cachedir color config confirm dbpath debug gpgdir help hookdir logfile
           noconfirm noprogressbar noscriptlet quiet root verbose disable-download-timeout sysroot
-          save builddir editor editorflags makepkg pacman git gitflags gpg gpgflags mflags config requestsplitn sudoloop sudo sudoflags
+          save builddir editor editorflags makepkg pacman git gitflags gpg gpgflags mflags config requestsplitn upgrademinage sudoloop sudo sudoflags
           redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild sortby
           singlelineresults doublelineresults answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
           noansweredit noanswerupgrade cleanmenu diffmenu editmenu cleanafter keepsrc topdown bottomup devel separatesources

--- a/completions/fish
+++ b/completions/fish
@@ -204,6 +204,7 @@ complete -c $progname -n "not $noopt" -l config -d 'The pacman config file to us
 complete -c $progname -n "not $noopt" -l makepkgconf -d 'Use custom makepkg.conf location' -r
 complete -c $progname -n "not $noopt" -l nomakepkgconf -d 'Use default makepkg.conf' -f
 complete -c $progname -n "not $noopt" -l requestsplitn -d 'Max amount of packages to query per AUR request' -x
+complete -c $progname -n "not $noopt" -l upgrademinage -d 'Withhold AUR updates until the package is n hours old' -x
 complete -c $progname -n "not $noopt" -l completioninterval -d 'Refresh interval for completion cache' -x
 complete -c $progname -n "not $noopt" -l sortby -d 'Sort AUR results by a specific field during search' -xa "{votes,popularity,name,base,submitted,modified}"
 complete -c $progname -n "not $noopt" -l searchby -d 'Search for AUR packages by querying the specified field' -xa "{name,name-desc,maintainer,depends,checkdepends,makedepends,optdepends}"

--- a/completions/zsh
+++ b/completions/zsh
@@ -39,6 +39,7 @@ _pacman_opts_common=(
 	'(--nomakepkgconf)--makepkgconf[makepkg.conf file to use]:config file:_files'
 	'(--makepkgconf)--nomakepkgconf[Use the default makepkg.conf]'
 	'--requestsplitn[Max amount of packages to query per AUR request]:number'
+	'--upgrademinage[Withhold AUR updates until the package is n hours old]:hours'
 	'--completioninterval[Time in days to refresh completion cache]:number'
 	'--confirm[Always ask for confirmation]'
 	'--debug[Display debug messages]'

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -241,6 +241,14 @@ AUR query will cause an error. This should only make a noticeable difference
 with very large requests (>500) packages.
 
 .TP
+.B \-\-upgrademinage <hours>
+Withhold an AUR package upgrade until at least this many hours have passed since
+the package was last modified on the AUR. This adds a cooldown so freshly pushed
+updates are not offered immediately, giving time for problems to surface. Only
+affects AUR packages; repository packages are unaffected. A value of 0 (the
+default) disables the delay.
+
+.TP
 .B \-\-completioninterval <days>
 Time in days to refresh the completion cache. Setting this to 0 will cause
 the cache to be refreshed every time, while setting this to -1 will cause the

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -149,6 +149,11 @@ func (c *Configuration) handleOption(option, value string) bool {
 		if err == nil && n > 0 {
 			c.RequestSplitN = n
 		}
+	case "upgrademinage":
+		n, err := strconv.Atoi(value)
+		if err == nil && n >= 0 {
+			c.UpgradeMinAge = n
+		}
 	case "sudoloop":
 		c.SudoLoop = boolValue
 	case "provides":

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -49,6 +49,7 @@ type Configuration struct {
 	SudoFlags              string `json:"sudoflags" lua:"sudo_flags"`
 	Version                string `json:"version" lua:"-"`
 	RequestSplitN          int    `json:"requestsplitn" lua:"request_split_n"`
+	UpgradeMinAge          int    `json:"upgrademinage" lua:"upgrade_min_age"`
 	CompletionInterval     int    `json:"completionrefreshtime" lua:"completion_refresh_time"`
 	MaxConcurrentDownloads int    `json:"maxconcurrentdownloads" lua:"max_concurrent_downloads"`
 	BottomUp               bool   `json:"bottomup" lua:"bottom_up"`
@@ -216,6 +217,7 @@ func DefaultConfig(version string) *Configuration {
 		SudoBin:                "sudo",
 		SudoFlags:              "",
 		RequestSplitN:          150,
+		UpgradeMinAge:          0,
 		ReDownload:             "no",
 		ReBuild:                "no",
 		BatchInstall:           false,

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -415,6 +415,7 @@ func isArg(arg string) bool {
 	case "sudo":
 	case "sudoflags":
 	case "requestsplitn":
+	case "upgrademinage":
 	case "sudoloop":
 	case "provides":
 	case "pgpfetch":
@@ -525,6 +526,7 @@ func hasParam(arg string) bool {
 	case "sudo":
 	case "sudoflags":
 	case "requestsplitn":
+	case "upgrademinage":
 	case "answerclean":
 	case "answerdiff":
 	case "answeredit":

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Jguer/aur"
 	alpm "github.com/Jguer/dyalpm"
@@ -83,7 +84,7 @@ func (u *UpgradeService) upGraph(ctx context.Context, graph *topo.Graph[string, 
 
 			u.AURWarnings.CalculateMissing(remoteNames, remote, aurdata)
 
-			aurUp = UpAUR(u.log, remote, aurdata, enableDowngrade)
+			aurUp = UpAUR(u.log, remote, aurdata, enableDowngrade, u.cfg.UpgradeMinAge, time.Now())
 
 			if u.cfg.Devel {
 				u.log.OperationInfoln(gotext.Get("Checking development packages..."))

--- a/pkg/upgrade/sources.go
+++ b/pkg/upgrade/sources.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"context"
+	"time"
 
 	"github.com/leonelquinteros/gotext"
 
@@ -64,8 +65,10 @@ func printIgnoringPackage(log *text.Logger, pkg db.IPackage, newPkgVersion strin
 
 // UpAUR gathers foreign packages and checks if they have new versions.
 // Output: Upgrade type package list.
+// minAgeHours, when > 0, withholds updates whose AUR package was last modified
+// fewer than that many hours before now.
 func UpAUR(log *text.Logger, remote map[string]db.IPackage, aurdata map[string]*query.Pkg,
-	enableDowngrade bool,
+	enableDowngrade bool, minAgeHours int, now time.Time,
 ) UpSlice {
 	toUpgrade := UpSlice{Up: make([]Upgrade, 0), Repos: []string{"aur"}}
 
@@ -77,6 +80,18 @@ func UpAUR(log *text.Logger, remote map[string]db.IPackage, aurdata map[string]*
 
 		if (db.VerCmp(pkg.Version(), aurPkg.Version) < 0) ||
 			(enableDowngrade && (db.VerCmp(pkg.Version(), aurPkg.Version) > 0)) {
+			if minAgeHours > 0 && aurPkg.LastModified > 0 {
+				age := now.Sub(time.Unix(int64(aurPkg.LastModified), 0))
+				if age < time.Duration(minAgeHours)*time.Hour {
+					log.Warnln(gotext.Get(
+						"%s: delaying upgrade (updated %s ago, minimum age is %dh)",
+						text.Cyan(name),
+						age.Round(time.Hour).String(), minAgeHours))
+
+					continue
+				}
+			}
+
 			if pkg.ShouldIgnore() {
 				printIgnoringPackage(log, pkg, aurPkg.Version)
 			} else {

--- a/pkg/upgrade/sources_test.go
+++ b/pkg/upgrade/sources_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	aur "github.com/Jguer/aur"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,11 @@ func Test_upAUR(t *testing.T) {
 		remote          map[string]alpm.Package
 		aurdata         map[string]*aur.Pkg
 		enableDowngrade bool
+		minAgeHours     int
 	}
+
+	// Fixed reference time so age-based cases are deterministic.
+	now := time.Unix(1_700_000_000, 0)
 	tests := []struct {
 		name string
 		args args
@@ -112,13 +117,41 @@ func Test_upAUR(t *testing.T) {
 			},
 			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{}},
 		},
+		{
+			name: "Update delayed by minimum age",
+			args: args{
+				minAgeHours: 48,
+				remote: map[string]alpm.Package{
+					"hello": &mock.Package{PName: "hello", PVersion: "2.0.0"},
+				},
+				// Modified 1h before now, below the 48h minimum.
+				aurdata: map[string]*aur.Pkg{
+					"hello": {Version: "2.1.0", Name: "hello", LastModified: int(now.Add(-time.Hour).Unix())},
+				},
+			},
+			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{}},
+		},
+		{
+			name: "Update older than minimum age",
+			args: args{
+				minAgeHours: 48,
+				remote: map[string]alpm.Package{
+					"hello": &mock.Package{PName: "hello", PVersion: "2.0.0"},
+				},
+				// Modified 72h before now, past the 48h minimum.
+				aurdata: map[string]*aur.Pkg{
+					"hello": {Version: "2.1.0", Name: "hello", LastModified: int(now.Add(-72 * time.Hour).Unix())},
+				},
+			},
+			want: UpSlice{Repos: []string{"aur"}, Up: []Upgrade{{Name: "hello", Repository: "aur", LocalVersion: "2.0.0", RemoteVersion: "2.1.0", LastModified: now.Add(-72 * time.Hour).Unix()}}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			got := UpAUR(text.NewLogger(io.Discard, os.Stderr, strings.NewReader(""), false, "test"),
-				tt.args.remote, tt.args.aurdata, tt.args.enableDowngrade)
+				tt.args.remote, tt.args.aurdata, tt.args.enableDowngrade, tt.args.minAgeHours, now)
 			assert.ElementsMatch(t, tt.want.Repos, got.Repos)
 			assert.ElementsMatch(t, tt.want.Up, got.Up)
 			assert.Equal(t, tt.want.Len(), got.Len())


### PR DESCRIPTION
## What

Adds an `--upgrademinage <hours>` option that withholds an AUR package upgrade until its AUR `LastModified` timestamp is at least the given number of hours old.

The idea is a cooldown on fresh AUR pushes: instead of being offered an update the moment a maintainer pushes it, you only see it once it has survived in the AUR for a while. That leaves time for broken or malicious pushes to be noticed and corrected before they land on your machine.

## Behaviour

- Configurable via the `--upgrademinage` flag or the `upgrademinage` config key (JSON and Lua).
- `0` is the default and disables the delay, so existing behaviour is unchanged for anyone who does not set it.
- Only AUR packages are affected. Repo packages (handled by pacman) and devel/VCS packages are untouched, since their age is not a meaningful signal here.
- When an upgrade is held back, yay logs why, e.g. `hello: delaying upgrade (updated 1h0m0s ago, minimum age is 48h)`.

This builds directly on the recently added AUR package age feature (#2846) — the `LastModified` timestamp is already collected per package, so this just filters on it.

## Implementation notes

- The filter lives in `UpAUR`, which now takes the current time as a parameter rather than calling `time.Now()` internally, so the age logic is testable with a fixed clock.
- Option wiring mirrors the existing `requestsplitn` integer option (config struct + default, arg parser, `isArg`/`hasParam`).
- Man page, `--help` text, and bash/zsh/fish completions updated.
- New unit tests cover both the delayed and old-enough cases.

## Open question

Happy to adjust the scope or naming. If a duration string (e.g. `48h`) is preferred over a plain hours integer, I can switch to that — I kept it as an integer of hours for simplicity since Go's `time.ParseDuration` does not support days/weeks anyway.