### PR TITLE
AUR: Add AURPreInstall hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ xgotext
 init.lua
 dyalpm/
 !doc/init.lua
+reference

--- a/doc/init.lua
+++ b/doc/init.lua
@@ -60,7 +60,7 @@ yay.opt.double_confirm = true -- Ask for confirmation before and after builds du
 --   desc = "inspect or modify AUR package files",
 --   callback = function(event)
 --     if event.data.pkgbuild:match("forbidden.example") then
---       error(event.match .. ": forbidden source URL")
+--       yay.abort(event.match .. ": forbidden source URL")
 --     end
 --
 --     -- File edits are picked up by later menus and build steps.

--- a/doc/init.lua
+++ b/doc/init.lua
@@ -51,3 +51,22 @@ yay.opt.separate_sources = true -- Separate query results by source (repo vs AUR
 yay.opt.debug = false -- Enable debug logging and local init.lua lookup convenience.
 yay.opt.rpc = true -- Use AUR RPC for dependency/query operations.
 yay.opt.double_confirm = true -- Ask for confirmation before and after builds during upgrades.
+
+-- Hooks
+-- Run Lua after AUR PKGBUILD repos are downloaded/merged and before the
+-- clean/diff/edit menus or source downloads.
+--
+-- yay.create_autocmd("AURPreInstall", {
+--   desc = "inspect or modify AUR package files",
+--   callback = function(event)
+--     if event.data.pkgbuild:match("forbidden.example") then
+--       error(event.match .. ": forbidden source URL")
+--     end
+--
+--     -- File edits are picked up by later menus and build steps.
+--     -- local path = event.data.pkgbuild_path
+--     -- local f = assert(io.open(path, "a"))
+--     -- f:write("\n# edited by yay init.lua\n")
+--     -- f:close()
+--   end,
+-- })

--- a/doc/lua.md
+++ b/doc/lua.md
@@ -47,3 +47,107 @@ startup and reports the offending keys/values so misconfigurations fail fast.
 
 A ready-to-copy example
 lives at [`doc/init.lua`](init.lua).
+
+## AUR pre-install hooks
+
+`init.lua` can register hooks with a small autocmd API:
+
+```lua
+yay.create_autocmd("AURPreInstall", {
+  desc = "inspect or modify AUR package files",
+  callback = function(event)
+    -- event.match is the package base.
+    -- event.data has package metadata and local file paths.
+  end,
+})
+```
+
+`AURPreInstall` runs once per AUR package base, in sorted package-base order,
+after the AUR PKGBUILD repositories are downloaded and merged. It runs before
+the clean, diff, and edit menus, and before source downloads or builds.
+
+If a callback raises a Lua error, yay aborts the install before build work
+starts. The error includes the event name and package base.
+
+Changing fields in the Lua `event` table does not change yay's internal
+package state. Hooks can still edit files through Lua's normal `io` and `os`
+libraries; later menus and build steps will see those file changes.
+
+### AURPreInstall event
+
+The callback receives this table:
+
+```lua
+{
+  event = "AURPreInstall",
+  match = "pkgbase",
+  data = {
+    base = "pkgbase",
+    dir = "/path/to/build/pkgbase",
+    pkgbuild_path = "/path/to/build/pkgbase/PKGBUILD",
+    srcinfo_path = "/path/to/build/pkgbase/.SRCINFO",
+    pkgbuild = "...PKGBUILD contents...",
+    version = "1:1.2.3-4",
+    last_modified = 1700000000,
+    installed = true,
+    packages = {
+      {
+        name = "pkgname",
+        version = "1:1.2.3-4",
+        local_version = "1:1.2.3-3",
+        reason = "explicit",
+        upgrade = true,
+        devel = false,
+      },
+    },
+    srcinfo = {
+      pkgbase = "pkgbase",
+      pkgver = "1.2.3",
+      pkgrel = "4",
+      epoch = "1",
+      version = "1:1.2.3-4",
+      pkgdesc = "description",
+      url = "https://example.invalid",
+      arch = { "x86_64" },
+      license = { "MIT" },
+      depends = { "glibc" },
+      makedepends = { "go" },
+      checkdepends = { "bats" },
+      optdepends = { "pkg: optional feature" },
+      provides = { "virtual-pkg" },
+      conflicts = { "old-pkg" },
+      replaces = { "older-pkg" },
+    },
+  },
+}
+```
+
+`data.packages` contains the target packages for that base. Split packages are
+listed separately. `reason` is one of `explicit`, `dependency`,
+`make_dependency`, `check_dependency`, or `unknown`.
+
+### Example
+
+```lua
+yay.create_autocmd("AURPreInstall", {
+  desc = "block forbidden sources and patch a PKGBUILD",
+  callback = function(event)
+    if event.data.pkgbuild:match("forbidden.example") then
+      error(event.match .. ": forbidden source URL")
+    end
+
+    if event.match == "demo-pkg" then
+      local path = event.data.pkgbuild_path
+      local f = assert(io.open(path, "r"))
+      local body = f:read("*a")
+      f:close()
+
+      body = body:gsub("options=%('strip'%)", "options=('!strip')")
+
+      f = assert(io.open(path, "w"))
+      f:write(body)
+      f:close()
+    end
+  end,
+})
+```

--- a/doc/lua.md
+++ b/doc/lua.md
@@ -66,8 +66,9 @@ yay.create_autocmd("AURPreInstall", {
 after the AUR PKGBUILD repositories are downloaded and merged. It runs before
 the clean, diff, and edit menus, and before source downloads or builds.
 
-If a callback raises a Lua error, yay aborts the install before build work
-starts. The error includes the event name and package base.
+Use `yay.abort("message")` for controlled policy stops without a Lua
+traceback. If a callback raises a Lua error, yay aborts the install before
+build work starts and includes the Lua traceback for debugging.
 
 Changing fields in the Lua `event` table does not change yay's internal
 package state. Hooks can still edit files through Lua's normal `io` and `os`
@@ -133,7 +134,7 @@ yay.create_autocmd("AURPreInstall", {
   desc = "block forbidden sources and patch a PKGBUILD",
   callback = function(event)
     if event.data.pkgbuild:match("forbidden.example") then
-      error(event.match .. ": forbidden source URL")
+      yay.abort(event.match .. ": forbidden source URL")
     end
 
     if event.match == "demo-pkg" then

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -551,6 +551,9 @@ The config directory is \fI$XDG_CONFIG_HOME/yay/\fR. If
 this file should be done through Yay, using the options
 mentioned in \fBPERMANENT CONFIGURATION SETTINGS\fR.
 
+\fIinit.lua\fR can set Lua configuration options and define Lua hooks, such as
+pre-install hooks for AUR PKGBUILDs. See \fIdoc/lua.md\fR for the Lua API.
+
 .TP
 .B CACHE DIRECTORY
 The cache directory is \fI$XDG_CACHE_HOME/yay/\fR. If

--- a/main.go
+++ b/main.go
@@ -86,13 +86,16 @@ func main() {
 		fallbackLog.Errorln(errS)
 	}
 
+	var luaEngine *lua.Engine
 	if luaPath := settings.GetLuaConfigPath(cfg.Debug); luaPath != "" {
-		if errLua := lua.LoadInto(fallbackLog, luaPath, cfg); errLua != nil {
-			fallbackLog.Errorln(errLua)
+		luaEngine, err = lua.Load(fallbackLog, luaPath, cfg)
+		if err != nil {
+			fallbackLog.Errorln(err)
 			ret = 1
 
 			return
 		}
+		defer luaEngine.Close()
 	}
 
 	cmdArgs := parser.MakeArguments()
@@ -125,6 +128,7 @@ func main() {
 
 		return
 	}
+	run.Lua = luaEngine
 
 	dbExecutor, err := ialpm.NewExecutor(run.PacmanConf, run.Logger.Child("db"))
 	if err != nil {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -37,10 +37,7 @@ type Runtime struct {
 	VoteClient   *vote.Client
 	AURClient    aur.QueryClient
 	Logger       *text.Logger
-	// Lua wraps a single gopher-lua LState, which is not goroutine-safe.
-	// Only access it from a single goroutine (today: the sequential
-	// pre-install hook path).
-	Lua *settingslua.Engine
+	Lua          *settingslua.Engine // not goroutine-safe
 }
 
 func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version string) (*Runtime, error) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -37,7 +37,10 @@ type Runtime struct {
 	VoteClient   *vote.Client
 	AURClient    aur.QueryClient
 	Logger       *text.Logger
-	Lua          *settingslua.Engine
+	// Lua wraps a single gopher-lua LState, which is not goroutine-safe.
+	// Only access it from a single goroutine (today: the sequential
+	// pre-install hook path).
+	Lua *settingslua.Engine
 }
 
 func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version string) (*Runtime, error) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Jguer/yay/v12/pkg/query"
 	"github.com/Jguer/yay/v12/pkg/settings"
 	"github.com/Jguer/yay/v12/pkg/settings/exe"
+	settingslua "github.com/Jguer/yay/v12/pkg/settings/lua"
 	"github.com/Jguer/yay/v12/pkg/settings/parser"
 	"github.com/Jguer/yay/v12/pkg/text"
 	"github.com/Jguer/yay/v12/pkg/vcs"
@@ -36,6 +37,7 @@ type Runtime struct {
 	VoteClient   *vote.Client
 	AURClient    aur.QueryClient
 	Logger       *text.Logger
+	Lua          *settingslua.Engine
 }
 
 func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version string) (*Runtime, error) {

--- a/pkg/settings/lua/abort.go
+++ b/pkg/settings/lua/abort.go
@@ -1,0 +1,39 @@
+package lua
+
+import (
+	"errors"
+
+	glua "github.com/yuin/gopher-lua"
+)
+
+type abortError string
+
+func (err abortError) Error() string {
+	return string(err)
+}
+
+func (err abortError) String() string {
+	return string(err)
+}
+
+func (abortError) Type() glua.LValueType {
+	return glua.LTUserData
+}
+
+func abort(state *glua.LState) int {
+	message := state.CheckString(1)
+	state.Error(abortError(message), 0)
+
+	return 0
+}
+
+func luaAbortError(err error) (abortError, bool) {
+	var apiErr *glua.ApiError
+	if !errors.As(err, &apiErr) {
+		return "", false
+	}
+
+	abortErr, ok := apiErr.Object.(abortError)
+
+	return abortErr, ok
+}

--- a/pkg/settings/lua/autocmd.go
+++ b/pkg/settings/lua/autocmd.go
@@ -1,0 +1,197 @@
+package lua
+
+import (
+	"fmt"
+
+	glua "github.com/yuin/gopher-lua"
+)
+
+const EventAURPreInstall = "AURPreInstall"
+
+type Autocmd struct {
+	Event    string
+	Desc     string
+	callback *glua.LFunction
+}
+
+type AURPreInstallEvent struct {
+	Base         string
+	Dir          string
+	PKGBUILDPath string
+	SRCINFOPath  string
+	PKGBUILD     string
+	Version      string
+	LastModified int64
+	Installed    bool
+	Packages     []AURPreInstallPackage
+	SRCINFO      AURPreInstallSRCINFO
+}
+
+type AURPreInstallPackage struct {
+	Name         string
+	Version      string
+	LocalVersion string
+	Reason       string
+	Upgrade      bool
+	Devel        bool
+}
+
+type AURPreInstallSRCINFO struct {
+	Pkgbase      string
+	Pkgver       string
+	Pkgrel       string
+	Epoch        string
+	Version      string
+	Pkgdesc      string
+	URL          string
+	Arch         []string
+	License      []string
+	Depends      []string
+	MakeDepends  []string
+	CheckDepends []string
+	OptDepends   []string
+	Provides     []string
+	Conflicts    []string
+	Replaces     []string
+}
+
+func (e *Engine) createAutocmd(state *glua.LState) int {
+	event := state.CheckString(1)
+	if event != EventAURPreInstall {
+		state.ArgError(1, fmt.Sprintf("unsupported event %q", event))
+		return 0
+	}
+
+	opts := state.CheckTable(2)
+	callback := state.GetField(opts, "callback")
+	fn, ok := callback.(*glua.LFunction)
+	if !ok {
+		state.ArgError(2, "callback must be a function")
+		return 0
+	}
+
+	desc := ""
+	if val := state.GetField(opts, "desc"); val != glua.LNil {
+		str, ok := val.(glua.LString)
+		if !ok {
+			state.ArgError(2, "desc must be a string")
+			return 0
+		}
+		desc = string(str)
+	}
+
+	e.autocmds[event] = append(e.autocmds[event], Autocmd{
+		Event:    event,
+		Desc:     desc,
+		callback: fn,
+	})
+
+	return 0
+}
+
+func (e *Engine) HasAutocmd(event string) bool {
+	return e != nil && len(e.autocmds[event]) > 0
+}
+
+func (e *Engine) Autocmds(event string) []Autocmd {
+	if e == nil {
+		return nil
+	}
+
+	out := make([]Autocmd, len(e.autocmds[event]))
+	copy(out, e.autocmds[event])
+
+	return out
+}
+
+func (e *Engine) RunAURPreInstall(event *AURPreInstallEvent) error {
+	if !e.HasAutocmd(EventAURPreInstall) {
+		return nil
+	}
+
+	for _, autocmd := range e.autocmds[EventAURPreInstall] {
+		if err := e.L.CallByParam(glua.P{
+			Fn:      autocmd.callback,
+			NRet:    0,
+			Protect: true,
+		}, e.aurPreInstallTable(event)); err != nil {
+			return fmt.Errorf("%s %s: %w", EventAURPreInstall, event.Base, err)
+		}
+	}
+
+	return nil
+}
+
+func (e *Engine) aurPreInstallTable(event *AURPreInstallEvent) *glua.LTable {
+	state := e.L
+	eventTable := state.NewTable()
+	data := state.NewTable()
+
+	eventTable.RawSetString("event", glua.LString(EventAURPreInstall))
+	eventTable.RawSetString("match", glua.LString(event.Base))
+	eventTable.RawSetString("data", data)
+
+	data.RawSetString("base", glua.LString(event.Base))
+	data.RawSetString("dir", glua.LString(event.Dir))
+	data.RawSetString("pkgbuild_path", glua.LString(event.PKGBUILDPath))
+	data.RawSetString("srcinfo_path", glua.LString(event.SRCINFOPath))
+	data.RawSetString("pkgbuild", glua.LString(event.PKGBUILD))
+	data.RawSetString("version", glua.LString(event.Version))
+	data.RawSetString("last_modified", glua.LNumber(event.LastModified))
+	data.RawSetString("installed", glua.LBool(event.Installed))
+	data.RawSetString("packages", e.packagesTable(event.Packages))
+	data.RawSetString("srcinfo", e.srcinfoTable(&event.SRCINFO))
+
+	return eventTable
+}
+
+func (e *Engine) packagesTable(packages []AURPreInstallPackage) *glua.LTable {
+	state := e.L
+	tbl := state.NewTable()
+
+	for _, pkg := range packages {
+		pkgTbl := state.NewTable()
+		pkgTbl.RawSetString("name", glua.LString(pkg.Name))
+		pkgTbl.RawSetString("version", glua.LString(pkg.Version))
+		pkgTbl.RawSetString("local_version", glua.LString(pkg.LocalVersion))
+		pkgTbl.RawSetString("reason", glua.LString(pkg.Reason))
+		pkgTbl.RawSetString("upgrade", glua.LBool(pkg.Upgrade))
+		pkgTbl.RawSetString("devel", glua.LBool(pkg.Devel))
+		tbl.Append(pkgTbl)
+	}
+
+	return tbl
+}
+
+func (e *Engine) srcinfoTable(srcinfo *AURPreInstallSRCINFO) *glua.LTable {
+	state := e.L
+	tbl := state.NewTable()
+
+	tbl.RawSetString("pkgbase", glua.LString(srcinfo.Pkgbase))
+	tbl.RawSetString("pkgver", glua.LString(srcinfo.Pkgver))
+	tbl.RawSetString("pkgrel", glua.LString(srcinfo.Pkgrel))
+	tbl.RawSetString("epoch", glua.LString(srcinfo.Epoch))
+	tbl.RawSetString("version", glua.LString(srcinfo.Version))
+	tbl.RawSetString("pkgdesc", glua.LString(srcinfo.Pkgdesc))
+	tbl.RawSetString("url", glua.LString(srcinfo.URL))
+	tbl.RawSetString("arch", e.stringArray(srcinfo.Arch))
+	tbl.RawSetString("license", e.stringArray(srcinfo.License))
+	tbl.RawSetString("depends", e.stringArray(srcinfo.Depends))
+	tbl.RawSetString("makedepends", e.stringArray(srcinfo.MakeDepends))
+	tbl.RawSetString("checkdepends", e.stringArray(srcinfo.CheckDepends))
+	tbl.RawSetString("optdepends", e.stringArray(srcinfo.OptDepends))
+	tbl.RawSetString("provides", e.stringArray(srcinfo.Provides))
+	tbl.RawSetString("conflicts", e.stringArray(srcinfo.Conflicts))
+	tbl.RawSetString("replaces", e.stringArray(srcinfo.Replaces))
+
+	return tbl
+}
+
+func (e *Engine) stringArray(values []string) *glua.LTable {
+	tbl := e.L.NewTable()
+	for _, value := range values {
+		tbl.Append(glua.LString(value))
+	}
+
+	return tbl
+}

--- a/pkg/settings/lua/autocmd.go
+++ b/pkg/settings/lua/autocmd.go
@@ -93,17 +93,6 @@ func (e *Engine) HasAutocmd(event string) bool {
 	return e != nil && len(e.autocmds[event]) > 0
 }
 
-func (e *Engine) Autocmds(event string) []Autocmd {
-	if e == nil {
-		return nil
-	}
-
-	out := make([]Autocmd, len(e.autocmds[event]))
-	copy(out, e.autocmds[event])
-
-	return out
-}
-
 func (e *Engine) RunAURPreInstall(event *AURPreInstallEvent) error {
 	if !e.HasAutocmd(EventAURPreInstall) {
 		return nil
@@ -115,7 +104,12 @@ func (e *Engine) RunAURPreInstall(event *AURPreInstallEvent) error {
 			NRet:    0,
 			Protect: true,
 		}, e.aurPreInstallTable(event)); err != nil {
-			return fmt.Errorf("%s %s: %w", EventAURPreInstall, event.Base, err)
+			wrapped := err
+			if abortErr, ok := luaAbortError(err); ok {
+				wrapped = abortErr
+			}
+
+			return fmt.Errorf("%s %s: %w", EventAURPreInstall, event.Base, wrapped)
 		}
 	}
 

--- a/pkg/settings/lua/autocmd_test.go
+++ b/pkg/settings/lua/autocmd_test.go
@@ -31,7 +31,7 @@ func TestCreateAutocmdRegistersAndRunsInOrder(t *testing.T) {
 		})
 	`))
 
-	autocmds := e.Autocmds(EventAURPreInstall)
+	autocmds := e.autocmds[EventAURPreInstall]
 	require.Len(t, autocmds, 2)
 	require.Equal(t, "first", autocmds[0].Desc)
 
@@ -90,4 +90,20 @@ func TestRunAURPreInstallReturnsCallbackErrorWithEventAndBase(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "AURPreInstall demo-base")
 	require.Contains(t, err.Error(), "blocked by policy")
+}
+
+func TestRunAURPreInstallReturnsAbortWithoutTraceback(t *testing.T) {
+	e := New()
+	defer e.Close()
+
+	require.NoError(t, e.L.DoString(`
+		yay.create_autocmd("AURPreInstall", {
+			callback = function()
+				yay.abort("blocked by policy")
+			end,
+		})
+	`))
+
+	err := e.RunAURPreInstall(&AURPreInstallEvent{Base: "demo-base"})
+	require.EqualError(t, err, "AURPreInstall demo-base: blocked by policy")
 }

--- a/pkg/settings/lua/autocmd_test.go
+++ b/pkg/settings/lua/autocmd_test.go
@@ -1,0 +1,93 @@
+package lua
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+)
+
+func TestCreateAutocmdRegistersAndRunsInOrder(t *testing.T) {
+	e := New()
+	defer e.Close()
+
+	order := []string{}
+	e.L.SetGlobal("record", e.L.NewFunction(func(L *glua.LState) int {
+		order = append(order, L.CheckString(1))
+		return 0
+	}))
+
+	require.NoError(t, e.L.DoString(`
+		yay.create_autocmd("AURPreInstall", {
+			desc = "first",
+			callback = function(event)
+				record("first:" .. event.match .. ":" .. event.data.packages[1].name .. ":" .. event.data.srcinfo.pkgbase)
+			end,
+		})
+		yay.create_autocmd("AURPreInstall", {
+			callback = function()
+				record("second")
+			end,
+		})
+	`))
+
+	autocmds := e.Autocmds(EventAURPreInstall)
+	require.Len(t, autocmds, 2)
+	require.Equal(t, "first", autocmds[0].Desc)
+
+	err := e.RunAURPreInstall(&AURPreInstallEvent{
+		Base: "demo-base",
+		Packages: []AURPreInstallPackage{{
+			Name: "demo",
+		}},
+		SRCINFO: AURPreInstallSRCINFO{
+			Pkgbase: "demo-base",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"first:demo-base:demo:demo-base", "second"}, order)
+}
+
+func TestCreateAutocmdRejectsInvalidEvent(t *testing.T) {
+	e := New()
+	defer e.Close()
+
+	err := e.L.DoString(`
+		yay.create_autocmd("User", {
+			callback = function() end,
+		})
+	`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unsupported event "User"`)
+}
+
+func TestCreateAutocmdRejectsMissingCallback(t *testing.T) {
+	e := New()
+	defer e.Close()
+
+	err := e.L.DoString(`
+		yay.create_autocmd("AURPreInstall", {
+			desc = "missing callback",
+		})
+	`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "callback must be a function")
+}
+
+func TestRunAURPreInstallReturnsCallbackErrorWithEventAndBase(t *testing.T) {
+	e := New()
+	defer e.Close()
+
+	require.NoError(t, e.L.DoString(`
+		yay.create_autocmd("AURPreInstall", {
+			callback = function()
+				error("blocked by policy")
+			end,
+		})
+	`))
+
+	err := e.RunAURPreInstall(&AURPreInstallEvent{Base: "demo-base"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AURPreInstall demo-base")
+	require.Contains(t, err.Error(), "blocked by policy")
+}

--- a/pkg/settings/lua/load.go
+++ b/pkg/settings/lua/load.go
@@ -7,19 +7,19 @@ import (
 	"github.com/Jguer/yay/v12/pkg/text"
 )
 
-// LoadInto applies the yay.opt values from path onto cfg.
-func LoadInto(_ *text.Logger, path string, cfg any) error {
+// Load loads path, applies its yay.opt values onto cfg, and returns the live engine.
+func Load(_ *text.Logger, path string, cfg any) (*Engine, error) {
 	engine := New()
-	defer engine.Close()
 
 	if err := engine.L.DoFile(path); err != nil {
-		return err
+		engine.Close()
+		return nil, err
 	}
 
 	unknown, errs := engine.Apply(cfg)
 
 	if len(unknown) == 0 && len(errs) == 0 {
-		return nil
+		return engine, nil
 	}
 
 	merr := &multierror.MultiError{}
@@ -32,5 +32,20 @@ func LoadInto(_ *text.Logger, path string, cfg any) error {
 		merr.Add(fmt.Errorf("init.lua: %w", err))
 	}
 
-	return merr.Return()
+	if err := merr.Return(); err != nil {
+		engine.Close()
+		return nil, err
+	}
+
+	return engine, nil
+}
+
+// LoadInto applies the yay.opt values from path onto cfg.
+func LoadInto(logger *text.Logger, path string, cfg any) error {
+	engine, err := Load(logger, path, cfg)
+	if engine != nil {
+		defer engine.Close()
+	}
+
+	return err
 }

--- a/pkg/settings/lua/load_test.go
+++ b/pkg/settings/lua/load_test.go
@@ -54,3 +54,20 @@ func TestLoadIntoAppliesValidValues(t *testing.T) {
 	require.Equal(t, 123, cfg.RequestSplitN)
 	require.True(t, cfg.Devel)
 }
+
+func TestLoadReturnsLiveEngine(t *testing.T) {
+	path := writeLuaFile(t, `
+		yay.create_autocmd("AURPreInstall", {
+			callback = function() end,
+		})
+		yay.opt.build_dir = "/tmp/yay"
+	`)
+
+	cfg := &testConfig{}
+	engine, err := Load(nil, path, cfg)
+	require.NoError(t, err)
+	defer engine.Close()
+
+	require.Equal(t, "/tmp/yay", cfg.BuildDir)
+	require.True(t, engine.HasAutocmd(EventAURPreInstall))
+}

--- a/pkg/settings/lua/lua.go
+++ b/pkg/settings/lua/lua.go
@@ -14,17 +14,23 @@ const (
 )
 
 type Engine struct {
-	L *lua.LState
+	L        *lua.LState
+	autocmds map[string][]Autocmd
 }
 
 func New() *Engine {
 	state := lua.NewState()
+	engine := &Engine{
+		L:        state,
+		autocmds: make(map[string][]Autocmd),
+	}
 
 	yayTbl := state.NewTable()
 	state.SetGlobal(globalName, yayTbl)
 	state.SetField(yayTbl, optTableName, state.NewTable())
+	state.SetField(yayTbl, "create_autocmd", state.NewFunction(engine.createAutocmd))
 
-	return &Engine{L: state}
+	return engine
 }
 
 func (e *Engine) Close() {

--- a/pkg/settings/lua/lua.go
+++ b/pkg/settings/lua/lua.go
@@ -28,6 +28,7 @@ func New() *Engine {
 	yayTbl := state.NewTable()
 	state.SetGlobal(globalName, yayTbl)
 	state.SetField(yayTbl, optTableName, state.NewTable())
+	state.SetField(yayTbl, "abort", state.NewFunction(abort))
 	state.SetField(yayTbl, "create_autocmd", state.NewFunction(engine.createAutocmd))
 
 	return engine

--- a/pkg/sync/workdir/aur_preinstall.go
+++ b/pkg/sync/workdir/aur_preinstall.go
@@ -190,6 +190,7 @@ func aurPreInstallInstalled(packages []settingslua.AURPreInstallPackage, srcinfo
 	for _, pkg := range packages {
 		if pkg.LocalVersion != "" || installed.Contains(pkg.Name) {
 			isInstalled = true
+			break
 		}
 	}
 
@@ -208,7 +209,11 @@ func aurPreInstallLastModified(base string, targets []map[string]*dep.InstallInf
 
 	for _, layer := range targets {
 		for _, info := range layer {
-			if info.AURBase != nil && *info.AURBase == base && info.LastModified > lastModified {
+			if info == nil || info.AURBase == nil {
+				continue
+			}
+
+			if *info.AURBase == base && info.LastModified > lastModified {
 				lastModified = info.LastModified
 			}
 		}

--- a/pkg/sync/workdir/aur_preinstall.go
+++ b/pkg/sync/workdir/aur_preinstall.go
@@ -1,0 +1,360 @@
+package workdir
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Jguer/yay/v12/pkg/dep"
+	"github.com/Jguer/yay/v12/pkg/runtime"
+	settingslua "github.com/Jguer/yay/v12/pkg/settings/lua"
+
+	gosrc "github.com/Morganamilo/go-srcinfo"
+	mapset "github.com/deckarep/golang-set/v2"
+)
+
+func (preper *Preparer) runPreDownloadSourcesHooks(ctx context.Context, run *runtime.Runtime, w io.Writer,
+	pkgbuildDirsByBase map[string]string, installed mapset.Set[string],
+	targets []map[string]*dep.InstallInfo,
+) error {
+	if err := runAURPreInstallLuaHooks(run, pkgbuildDirsByBase, installed, targets); err != nil {
+		return err
+	}
+
+	for _, hookFn := range preper.hooks {
+		if hookFn.Type != PreDownloadSourcesHook {
+			continue
+		}
+
+		if err := hookFn.Hookfn(ctx, run, w, pkgbuildDirsByBase, installed); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func runAURPreInstallLuaHooks(run *runtime.Runtime, pkgbuildDirsByBase map[string]string,
+	installed mapset.Set[string], targets []map[string]*dep.InstallInfo,
+) error {
+	if run == nil || run.Lua == nil || !run.Lua.HasAutocmd(settingslua.EventAURPreInstall) {
+		return nil
+	}
+
+	events, err := aurPreInstallEvents(pkgbuildDirsByBase, installed, targets)
+	if err != nil {
+		return err
+	}
+
+	for i := range events {
+		if err := run.Lua.RunAURPreInstall(&events[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func aurPreInstallEvents(pkgbuildDirsByBase map[string]string, installed mapset.Set[string],
+	targets []map[string]*dep.InstallInfo,
+) ([]settingslua.AURPreInstallEvent, error) {
+	packagesByBase := aurTargetPackagesByBase(targets)
+	bases := sortedAURBases(pkgbuildDirsByBase)
+
+	events := make([]settingslua.AURPreInstallEvent, 0, len(bases))
+	for _, base := range bases {
+		event, err := aurPreInstallEvent(base, pkgbuildDirsByBase[base],
+			packagesByBase[base], installed, targets)
+		if err != nil {
+			return nil, err
+		}
+
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func sortedAURBases(pkgbuildDirsByBase map[string]string) []string {
+	bases := make([]string, 0, len(pkgbuildDirsByBase))
+	for base := range pkgbuildDirsByBase {
+		bases = append(bases, base)
+	}
+	sort.Strings(bases)
+
+	return bases
+}
+
+func aurPreInstallEvent(base, path string, packages []settingslua.AURPreInstallPackage,
+	installed mapset.Set[string], targets []map[string]*dep.InstallInfo,
+) (settingslua.AURPreInstallEvent, error) {
+	dir, pkgbuildPath, srcinfoPath := aurPreInstallPaths(path)
+
+	pkgbuildBytes, err := os.ReadFile(pkgbuildPath)
+	if err != nil {
+		return settingslua.AURPreInstallEvent{},
+			fmt.Errorf("%s %s: read PKGBUILD: %w", settingslua.EventAURPreInstall, base, err)
+	}
+
+	srcinfo, err := gosrc.ParseFile(srcinfoPath)
+	if err != nil {
+		return settingslua.AURPreInstallEvent{},
+			fmt.Errorf("%s %s: parse .SRCINFO: %w", settingslua.EventAURPreInstall, base, err)
+	}
+
+	if len(packages) == 0 {
+		packages = packagesFromSRCINFO(srcinfo)
+	}
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].Name < packages[j].Name
+	})
+
+	return settingslua.AURPreInstallEvent{
+		Base:         base,
+		Dir:          dir,
+		PKGBUILDPath: pkgbuildPath,
+		SRCINFOPath:  srcinfoPath,
+		PKGBUILD:     string(pkgbuildBytes),
+		Version:      srcinfo.Version(),
+		LastModified: aurPreInstallLastModified(base, targets),
+		Installed:    aurPreInstallInstalled(packages, srcinfo, installed),
+		Packages:     packages,
+		SRCINFO:      srcinfoEventData(srcinfo),
+	}, nil
+}
+
+func aurPreInstallPaths(path string) (dir, pkgbuildPath, srcinfoPath string) {
+	info, err := os.Stat(path)
+	if err == nil && !info.IsDir() {
+		dir = filepath.Dir(path)
+		srcinfoPath = path
+		pkgbuildPath = filepath.Join(dir, "PKGBUILD")
+
+		return dir, pkgbuildPath, srcinfoPath
+	}
+
+	dir = path
+	pkgbuildPath = filepath.Join(dir, "PKGBUILD")
+	srcinfoPath = filepath.Join(dir, ".SRCINFO")
+
+	return dir, pkgbuildPath, srcinfoPath
+}
+
+func aurTargetPackagesByBase(targets []map[string]*dep.InstallInfo) map[string][]settingslua.AURPreInstallPackage {
+	packages := map[string][]settingslua.AURPreInstallPackage{}
+
+	for _, layer := range targets {
+		for name, info := range layer {
+			if info == nil || info.AURBase == nil {
+				continue
+			}
+
+			if info.Source != dep.AUR && info.Source != dep.SrcInfo {
+				continue
+			}
+
+			base := *info.AURBase
+			packages[base] = append(packages[base], settingslua.AURPreInstallPackage{
+				Name:         name,
+				Version:      info.Version,
+				LocalVersion: info.LocalVersion,
+				Reason:       luaReason(info.Reason),
+				Upgrade:      info.Upgrade,
+				Devel:        info.Devel,
+			})
+		}
+	}
+
+	return packages
+}
+
+func packagesFromSRCINFO(srcinfo *gosrc.Srcinfo) []settingslua.AURPreInstallPackage {
+	packages := make([]settingslua.AURPreInstallPackage, 0, len(srcinfo.Packages))
+	for i := range srcinfo.Packages {
+		packages = append(packages, settingslua.AURPreInstallPackage{
+			Name:    srcinfo.Packages[i].Pkgname,
+			Version: srcinfo.Version(),
+		})
+	}
+
+	return packages
+}
+
+func aurPreInstallInstalled(packages []settingslua.AURPreInstallPackage, srcinfo *gosrc.Srcinfo,
+	installed mapset.Set[string],
+) bool {
+	isInstalled := false
+	for _, pkg := range packages {
+		if pkg.LocalVersion != "" || installed.Contains(pkg.Name) {
+			isInstalled = true
+		}
+	}
+
+	for i := range srcinfo.Packages {
+		if installed.Contains(srcinfo.Packages[i].Pkgname) {
+			isInstalled = true
+			break
+		}
+	}
+
+	return isInstalled
+}
+
+func aurPreInstallLastModified(base string, targets []map[string]*dep.InstallInfo) int64 {
+	var lastModified int64
+
+	for _, layer := range targets {
+		for _, info := range layer {
+			if info.AURBase != nil && *info.AURBase == base && info.LastModified > lastModified {
+				lastModified = info.LastModified
+			}
+		}
+	}
+
+	return lastModified
+}
+
+func luaReason(reason dep.Reason) string {
+	switch reason {
+	case dep.Explicit:
+		return "explicit"
+	case dep.Dep:
+		return "dependency"
+	case dep.MakeDep:
+		return "make_dependency"
+	case dep.CheckDep:
+		return "check_dependency"
+	default:
+		return "unknown"
+	}
+}
+
+func srcinfoEventData(srcinfo *gosrc.Srcinfo) settingslua.AURPreInstallSRCINFO {
+	pkgdesc, url := srcinfoDescriptionAndURL(srcinfo)
+	packageArch := packageStringValues(srcinfo.Packages, func(pkg *gosrc.Package) []string {
+		return pkg.Arch
+	})
+	packageLicense := packageStringValues(srcinfo.Packages, func(pkg *gosrc.Package) []string {
+		return pkg.License
+	})
+	packageDepends := packageArchStringValues(srcinfo.Packages, func(pkg *gosrc.Package) []gosrc.ArchString {
+		return pkg.Depends
+	})
+	packageOptDepends := packageArchStringValues(srcinfo.Packages, func(pkg *gosrc.Package) []gosrc.ArchString {
+		return pkg.OptDepends
+	})
+	packageProvides := packageArchStringValues(srcinfo.Packages, func(pkg *gosrc.Package) []gosrc.ArchString {
+		return pkg.Provides
+	})
+	packageConflicts := packageArchStringValues(srcinfo.Packages, func(pkg *gosrc.Package) []gosrc.ArchString {
+		return pkg.Conflicts
+	})
+	packageReplaces := packageArchStringValues(srcinfo.Packages, func(pkg *gosrc.Package) []gosrc.ArchString {
+		return pkg.Replaces
+	})
+
+	return settingslua.AURPreInstallSRCINFO{
+		Pkgbase:      srcinfo.Pkgbase,
+		Pkgver:       srcinfo.Pkgver,
+		Pkgrel:       srcinfo.Pkgrel,
+		Epoch:        srcinfo.Epoch,
+		Version:      srcinfo.Version(),
+		Pkgdesc:      pkgdesc,
+		URL:          url,
+		Arch:         mergedStringValues(srcinfo.Arch, packageArch...),
+		License:      mergedStringValues(srcinfo.License, packageLicense...),
+		Depends:      mergedArchStringValues(srcinfo.Depends, packageDepends...),
+		MakeDepends:  archStringValues(srcinfo.MakeDepends),
+		CheckDepends: archStringValues(srcinfo.CheckDepends),
+		OptDepends:   mergedArchStringValues(srcinfo.OptDepends, packageOptDepends...),
+		Provides:     mergedArchStringValues(srcinfo.Provides, packageProvides...),
+		Conflicts:    mergedArchStringValues(srcinfo.Conflicts, packageConflicts...),
+		Replaces:     mergedArchStringValues(srcinfo.Replaces, packageReplaces...),
+	}
+}
+
+func srcinfoDescriptionAndURL(srcinfo *gosrc.Srcinfo) (pkgdesc, url string) {
+	pkgdesc = srcinfo.Pkgdesc
+	url = srcinfo.URL
+	if pkgdesc != "" && url != "" {
+		return pkgdesc, url
+	}
+
+	for i := range srcinfo.Packages {
+		pkg := &srcinfo.Packages[i]
+		if pkgdesc == "" {
+			pkgdesc = pkg.Pkgdesc
+		}
+		if url == "" {
+			url = pkg.URL
+		}
+		if pkgdesc != "" && url != "" {
+			break
+		}
+	}
+
+	return pkgdesc, url
+}
+
+func packageStringValues(packages []gosrc.Package, selectValues func(*gosrc.Package) []string) [][]string {
+	values := make([][]string, 0, len(packages))
+	for i := range packages {
+		values = append(values, selectValues(&packages[i]))
+	}
+
+	return values
+}
+
+func packageArchStringValues(packages []gosrc.Package, selectValues func(*gosrc.Package) []gosrc.ArchString) [][]gosrc.ArchString {
+	values := make([][]gosrc.ArchString, 0, len(packages))
+	for i := range packages {
+		values = append(values, selectValues(&packages[i]))
+	}
+
+	return values
+}
+
+func mergedStringValues(global []string, packageValues ...[]string) []string {
+	out := make([]string, 0, len(global))
+	seen := map[string]struct{}{}
+
+	appendValue := func(value string) {
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+
+	for _, value := range global {
+		appendValue(value)
+	}
+	for _, values := range packageValues {
+		for _, value := range values {
+			appendValue(value)
+		}
+	}
+
+	return out
+}
+
+func mergedArchStringValues(global []gosrc.ArchString, packageValues ...[]gosrc.ArchString) []string {
+	values := make([][]string, 0, len(packageValues))
+	for _, packageValue := range packageValues {
+		values = append(values, archStringValues(packageValue))
+	}
+
+	return mergedStringValues(archStringValues(global), values...)
+}
+
+func archStringValues(values []gosrc.ArchString) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, value.Value)
+	}
+
+	return out
+}

--- a/pkg/sync/workdir/aur_preinstall_test.go
+++ b/pkg/sync/workdir/aur_preinstall_test.go
@@ -1,0 +1,237 @@
+//go:build !integration
+// +build !integration
+
+package workdir
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/require"
+	glua "github.com/yuin/gopher-lua"
+
+	"github.com/Jguer/yay/v12/pkg/dep"
+	"github.com/Jguer/yay/v12/pkg/runtime"
+	"github.com/Jguer/yay/v12/pkg/settings"
+	settingslua "github.com/Jguer/yay/v12/pkg/settings/lua"
+)
+
+func TestAURPreInstallEventsFromPackageFiles(t *testing.T) {
+	base := "demo-base"
+	dir := writeAURPreInstallPackage(t, base)
+	targets := []map[string]*dep.InstallInfo{
+		{
+			"demo-doc": {
+				Source:       dep.AUR,
+				Reason:       dep.MakeDep,
+				Version:      "1:1.2.3-4",
+				LocalVersion: "1:1.2.3-3",
+				AURBase:      &base,
+				Upgrade:      true,
+				Devel:        true,
+				LastModified: 1700000001,
+			},
+			"demo": {
+				Source:       dep.AUR,
+				Reason:       dep.Explicit,
+				Version:      "1:1.2.3-4",
+				AURBase:      &base,
+				LastModified: 1700000000,
+			},
+		},
+	}
+
+	events, err := aurPreInstallEvents(map[string]string{base: dir},
+		mapset.NewThreadUnsafeSet("demo-doc"), targets)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	event := events[0]
+	require.Equal(t, base, event.Base)
+	require.Equal(t, dir, event.Dir)
+	require.Equal(t, filepath.Join(dir, "PKGBUILD"), event.PKGBUILDPath)
+	require.Equal(t, filepath.Join(dir, ".SRCINFO"), event.SRCINFOPath)
+	require.Contains(t, event.PKGBUILD, "pkgbase=demo-base")
+	require.Equal(t, "1:1.2.3-4", event.Version)
+	require.Equal(t, int64(1700000001), event.LastModified)
+	require.True(t, event.Installed)
+
+	require.Len(t, event.Packages, 2)
+	require.Equal(t, "demo", event.Packages[0].Name)
+	require.Equal(t, "explicit", event.Packages[0].Reason)
+	require.False(t, event.Packages[0].Upgrade)
+	require.Equal(t, "demo-doc", event.Packages[1].Name)
+	require.Equal(t, "make_dependency", event.Packages[1].Reason)
+	require.Equal(t, "1:1.2.3-3", event.Packages[1].LocalVersion)
+	require.True(t, event.Packages[1].Upgrade)
+	require.True(t, event.Packages[1].Devel)
+
+	require.Equal(t, base, event.SRCINFO.Pkgbase)
+	require.Equal(t, "1", event.SRCINFO.Epoch)
+	require.Equal(t, "1.2.3", event.SRCINFO.Pkgver)
+	require.Equal(t, "4", event.SRCINFO.Pkgrel)
+	require.Equal(t, "1:1.2.3-4", event.SRCINFO.Version)
+	require.Equal(t, "global description", event.SRCINFO.Pkgdesc)
+	require.Equal(t, "https://example.test/demo", event.SRCINFO.URL)
+	require.Equal(t, []string{"x86_64"}, event.SRCINFO.Arch)
+	require.Equal(t, []string{"MIT"}, event.SRCINFO.License)
+	require.Equal(t, []string{"glibc", "demo-runtime", "demo-doc-runtime"}, event.SRCINFO.Depends)
+	require.Equal(t, []string{"go"}, event.SRCINFO.MakeDepends)
+	require.Equal(t, []string{"bats"}, event.SRCINFO.CheckDepends)
+	require.Equal(t, []string{"demo-optional: optional support", "demo-doc-viewer"}, event.SRCINFO.OptDepends)
+	require.Equal(t, []string{"demo-virtual", "demo-doc-virtual"}, event.SRCINFO.Provides)
+	require.Equal(t, []string{"old-demo"}, event.SRCINFO.Conflicts)
+	require.Equal(t, []string{"older-demo"}, event.SRCINFO.Replaces)
+}
+
+func TestRunAURPreInstallLuaHooksRunsBasesInSortedOrder(t *testing.T) {
+	firstDir := writeAURPreInstallPackage(t, "a-base")
+	secondDir := writeAURPreInstallPackage(t, "z-base")
+
+	engine := settingslua.New()
+	defer engine.Close()
+
+	order := []string{}
+	engine.L.SetGlobal("record", engine.L.NewFunction(func(L *glua.LState) int {
+		order = append(order, L.CheckString(1))
+		return 0
+	}))
+	require.NoError(t, engine.L.DoString(`
+		yay.create_autocmd("AURPreInstall", {
+			callback = function(event)
+				record(event.match)
+			end,
+		})
+	`))
+
+	err := runAURPreInstallLuaHooks(&runtime.Runtime{Lua: engine},
+		map[string]string{"z-base": secondDir, "a-base": firstDir},
+		mapset.NewThreadUnsafeSet[string](),
+		[]map[string]*dep.InstallInfo{
+			{
+				"a": {Source: dep.AUR, AURBase: ptrString("a-base")},
+				"z": {Source: dep.AUR, AURBase: ptrString("z-base")},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a-base", "z-base"}, order)
+}
+
+func TestRunPreDownloadSourcesHooksRunsLuaBeforeMenus(t *testing.T) {
+	base := "demo-base"
+	dir := writeAURPreInstallPackage(t, base)
+
+	engine := settingslua.New()
+	defer engine.Close()
+
+	order := []string{}
+	engine.L.SetGlobal("record", engine.L.NewFunction(func(L *glua.LState) int {
+		order = append(order, L.CheckString(1))
+		return 0
+	}))
+	require.NoError(t, engine.L.DoString(`
+		yay.create_autocmd("AURPreInstall", {
+			callback = function()
+				record("lua")
+			end,
+		})
+	`))
+
+	preper := NewPreparerWithoutHooks(nil, nil, &settings.Configuration{}, newTestLogger(), true)
+	preper.hooks = []Hook{
+		{Name: "clean", Type: PreDownloadSourcesHook, Hookfn: func(context.Context, *runtime.Runtime, io.Writer, map[string]string, mapset.Set[string]) error {
+			order = append(order, "clean")
+			return nil
+		}},
+		{Name: "diff", Type: PreDownloadSourcesHook, Hookfn: func(context.Context, *runtime.Runtime, io.Writer, map[string]string, mapset.Set[string]) error {
+			order = append(order, "diff")
+			return nil
+		}},
+		{Name: "edit", Type: PreDownloadSourcesHook, Hookfn: func(context.Context, *runtime.Runtime, io.Writer, map[string]string, mapset.Set[string]) error {
+			order = append(order, "edit")
+			return nil
+		}},
+	}
+
+	err := preper.runPreDownloadSourcesHooks(context.Background(), &runtime.Runtime{Lua: engine}, io.Discard,
+		map[string]string{base: dir}, mapset.NewThreadUnsafeSet[string](),
+		[]map[string]*dep.InstallInfo{
+			{
+				"demo": {Source: dep.AUR, AURBase: &base},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, []string{"lua", "clean", "diff", "edit"}, order)
+}
+
+func TestRunAURPreInstallLuaHooksReturnsCallbackError(t *testing.T) {
+	base := "demo-base"
+	dir := writeAURPreInstallPackage(t, base)
+
+	engine := settingslua.New()
+	defer engine.Close()
+
+	require.NoError(t, engine.L.DoString(`
+		yay.create_autocmd("AURPreInstall", {
+			callback = function()
+				error("blocked")
+			end,
+		})
+	`))
+
+	err := runAURPreInstallLuaHooks(&runtime.Runtime{Lua: engine},
+		map[string]string{base: dir}, mapset.NewThreadUnsafeSet[string](),
+		[]map[string]*dep.InstallInfo{
+			{
+				"demo": {Source: dep.AUR, AURBase: &base},
+			},
+		})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AURPreInstall demo-base")
+	require.Contains(t, err.Error(), "blocked")
+}
+
+func writeAURPreInstallPackage(t *testing.T, base string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "PKGBUILD"), []byte(`pkgbase=`+base+`
+pkgname=(demo demo-doc)
+pkgver=1.2.3
+pkgrel=4
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".SRCINFO"), []byte(`pkgbase = `+base+`
+	pkgdesc = global description
+	pkgver = 1.2.3
+	pkgrel = 4
+	epoch = 1
+	url = https://example.test/demo
+	arch = x86_64
+	license = MIT
+	depends = glibc
+	makedepends = go
+	checkdepends = bats
+	optdepends = demo-optional: optional support
+	provides = demo-virtual
+	conflicts = old-demo
+	replaces = older-demo
+
+pkgname = demo
+	depends = demo-runtime
+
+pkgname = demo-doc
+	depends = demo-doc-runtime
+	optdepends = demo-doc-viewer
+	provides = demo-doc-virtual
+`), 0o600))
+
+	return dir
+}
+
+func ptrString(s string) *string {
+	return &s
+}

--- a/pkg/sync/workdir/preparer.go
+++ b/pkg/sync/workdir/preparer.go
@@ -225,12 +225,9 @@ func (preper *Preparer) PrepareWorkspace(ctx context.Context,
 
 	remoteNames := preper.dbExecutor.InstalledRemotePackageNames()
 	remoteNamesCache := mapset.NewThreadUnsafeSet(remoteNames...)
-	for _, hookFn := range preper.hooks {
-		if hookFn.Type == PreDownloadSourcesHook {
-			if err := hookFn.Hookfn(ctx, run, os.Stdout, pkgBuildDirsByBase, remoteNamesCache); err != nil {
-				return nil, err
-			}
-		}
+	if err := preper.runPreDownloadSourcesHooks(ctx, run, os.Stdout,
+		pkgBuildDirsByBase, remoteNamesCache, targets); err != nil {
+		return nil, err
 	}
 
 	if errP := downloadPKGBUILDSourceFanout(ctx, preper.cmdBuilder,

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -36,7 +36,7 @@ func TestParsing(t *testing.T) {
 	}
 
 	urls := []string{
-		"git+https://github.com/example/project.git",
+		"git+https://github.com/neovim/neovim.git",
 		"git://github.com/jguer/yay.git#branch=master",
 		"git://github.com/davidgiven/ack",
 		"git://github.com/jguer/yay.git#tag=v3.440",
@@ -45,7 +45,7 @@ func TestParsing(t *testing.T) {
 	}
 
 	sources := []source{
-		{"github.com/example/project.git", "HEAD", []string{"https"}},
+		{"github.com/neovim/neovim.git", "HEAD", []string{"https"}},
 		{"github.com/jguer/yay.git", "master", []string{"git"}},
 		{"github.com/davidgiven/ack", "HEAD", []string{"git"}},
 		{"", "", nil},

--- a/pkg/vcs/vcs_test.go
+++ b/pkg/vcs/vcs_test.go
@@ -36,7 +36,7 @@ func TestParsing(t *testing.T) {
 	}
 
 	urls := []string{
-		"git+https://github.com/neovim/neovim.git",
+		"git+https://github.com/example/project.git",
 		"git://github.com/jguer/yay.git#branch=master",
 		"git://github.com/davidgiven/ack",
 		"git://github.com/jguer/yay.git#tag=v3.440",
@@ -45,7 +45,7 @@ func TestParsing(t *testing.T) {
 	}
 
 	sources := []source{
-		{"github.com/neovim/neovim.git", "HEAD", []string{"https"}},
+		{"github.com/example/project.git", "HEAD", []string{"https"}},
 		{"github.com/jguer/yay.git", "master", []string{"git"}},
 		{"github.com/davidgiven/ack", "HEAD", []string{"git"}},
 		{"", "", nil},


### PR DESCRIPTION
Add lua callback funcs after PKGbUILD clone, these are same type of hooks that yay uses for clean/diff/edit menus but as per-package, not as batch.

If no hook is registered, no lua execution is run. 
Unstable API as "what's needed for good hooks" is figured out, although I'm more on the removing than the adding.