### PR TITLE
feat: expose AUR package maintainer to upgrade hooks

### DIFF
--- a/doc/lua.md
+++ b/doc/lua.md
@@ -117,6 +117,7 @@ The callback receives this table:
         remote_version = "1.2.3-4",
         reason = "explicit",
         last_modified = 1700000000,
+        maintainer = "username",
       },
     },
     pulled_dependencies = {
@@ -129,6 +130,7 @@ The callback receives this table:
         remote_version = "1.0-1",
         reason = "dependency",
         last_modified = 0,
+        maintainer = "",
       },
     },
   },

--- a/pkg/db/executor.go
+++ b/pkg/db/executor.go
@@ -26,8 +26,10 @@ type Upgrade struct {
 	LocalVersion  string
 	RemoteVersion string
 	Reason        alpm.PkgReason
-	Extra         string // Extra information to be displayed
-	LastModified  int64  // Unix timestamp of last AUR modification, 0 for non-AUR packages
+	// Technical debt. This is provider specific information
+	Extra        string // Extra information to be displayed
+	LastModified int64  // Unix timestamp of last AUR modification, 0 for non-AUR packages
+	Maintainer   string // AUR maintainer username, empty for orphaned or non-AUR packages
 }
 
 type SyncUpgrade struct {

--- a/pkg/settings/lua/autocmd.go
+++ b/pkg/settings/lua/autocmd.go
@@ -74,6 +74,7 @@ type UpgradeSelectPackage struct {
 	RemoteVersion string
 	Reason        string
 	LastModified  int64
+	Maintainer    string
 }
 
 type UpgradeSelectResult struct {
@@ -162,8 +163,8 @@ func (e *Engine) RunUpgradeSelect(event *UpgradeSelectEvent) (UpgradeSelectResul
 	}
 
 	validExcludes := mapset.NewThreadUnsafeSetWithSize[string](len(event.Upgrades))
-	for _, pkg := range event.Upgrades {
-		validExcludes.Add(pkg.Name)
+	for i := range event.Upgrades {
+		validExcludes.Add(event.Upgrades[i].Name)
 	}
 
 	seenExcludes := mapset.NewThreadUnsafeSet[string]()
@@ -258,7 +259,8 @@ func (e *Engine) upgradeSelectPackagesTable(packages []UpgradeSelectPackage) *gl
 	state := e.L
 	tbl := state.NewTable()
 
-	for _, pkg := range packages {
+	for i := range packages {
+		pkg := &packages[i]
 		pkgTbl := state.NewTable()
 		pkgTbl.RawSetString("id", glua.LNumber(pkg.ID))
 		pkgTbl.RawSetString("name", glua.LString(pkg.Name))
@@ -268,6 +270,7 @@ func (e *Engine) upgradeSelectPackagesTable(packages []UpgradeSelectPackage) *gl
 		pkgTbl.RawSetString("remote_version", glua.LString(pkg.RemoteVersion))
 		pkgTbl.RawSetString("reason", glua.LString(pkg.Reason))
 		pkgTbl.RawSetString("last_modified", glua.LNumber(pkg.LastModified))
+		pkgTbl.RawSetString("maintainer", glua.LString(pkg.Maintainer))
 		tbl.Append(pkgTbl)
 	}
 

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -265,19 +265,19 @@ func (u *UpgradeService) upgradeSelection(graph *topo.Graph[string, *dep.Install
 	sort.Sort(aurUp)
 
 	allUp := UpSlice{Repos: append(repoUp.Repos, aurUp.Repos...)}
-	for _, up := range repoUp.Up {
-		if up.LocalVersion == "" && up.Reason != alpm.PkgReasonExplicit {
-			allUp.PulledDeps = append(allUp.PulledDeps, up)
+	for i := range repoUp.Up {
+		if repoUp.Up[i].LocalVersion == "" && repoUp.Up[i].Reason != alpm.PkgReasonExplicit {
+			allUp.PulledDeps = append(allUp.PulledDeps, repoUp.Up[i])
 		} else {
-			allUp.Up = append(allUp.Up, up)
+			allUp.Up = append(allUp.Up, repoUp.Up[i])
 		}
 	}
 
-	for _, up := range aurUp.Up {
-		if up.LocalVersion == "" && up.Reason != alpm.PkgReasonExplicit {
-			allUp.PulledDeps = append(allUp.PulledDeps, up)
+	for i := range aurUp.Up {
+		if aurUp.Up[i].LocalVersion == "" && aurUp.Up[i].Reason != alpm.PkgReasonExplicit {
+			allUp.PulledDeps = append(allUp.PulledDeps, aurUp.Up[i])
 		} else {
-			allUp.Up = append(allUp.Up, up)
+			allUp.Up = append(allUp.Up, aurUp.Up[i])
 		}
 	}
 
@@ -427,6 +427,7 @@ func upgradeSelectPackages(upgrades []Upgrade, selectable bool) []settingslua.Up
 			RemoteVersion: up.RemoteVersion,
 			Reason:        upgradeSelectReason(up.Reason),
 			LastModified:  up.LastModified,
+			Maintainer:    up.Maintainer,
 		})
 	}
 

--- a/pkg/upgrade/sources.go
+++ b/pkg/upgrade/sources.go
@@ -43,6 +43,7 @@ func UpDevel(
 					RemoteVersion: "latest-commit",
 					Reason:        pkg.Reason(),
 					LastModified:  int64(aurPkg.LastModified),
+					Maintainer:    aurPkg.Maintainer,
 				})
 		}
 	}
@@ -89,6 +90,7 @@ func UpAUR(log *text.Logger, remote map[string]db.IPackage, aurdata map[string]*
 						RemoteVersion: aurPkg.Version,
 						Reason:        pkg.Reason(),
 						LastModified:  int64(aurPkg.LastModified),
+						Maintainer:    aurPkg.Maintainer,
 					})
 			}
 		}


### PR DESCRIPTION
Adding maintainer to hooks is important even if introduces a bit of techdebt.