### PR TITLE
Fix Pages artifact action pin

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/
 


### PR DESCRIPTION
## Summary
- update upload-pages-artifact to a SHA-pinned v5 release
- avoid the nested actions/upload-artifact@v4 tag rejected by action pinning rules

## Testing
- not run (workflow-only change)