### PR TITLE
fix(lua): Reduce event size of PostInstall and SearchFilter hooks

### DIFF
--- a/doc/examples/install_log.lua
+++ b/doc/examples/install_log.lua
@@ -15,19 +15,11 @@ yay.create_autocmd("PostInstall", {
     local ts = os.date("%Y-%m-%dT%H:%M:%S")
 
     for _, pkg in ipairs(event.data.packages) do
-      if pkg.installed then
-        local action = pkg.upgrade and "upgrade" or "install"
-        local version_change
-        if pkg.upgrade then
-          version_change = pkg.local_version .. " -> " .. pkg.version
-        else
-          version_change = pkg.version
-        end
-
-        local flags = pkg.devel and " devel" or ""
-        f:write(string.format("%s  %-9s %-7s %-14s %-12s %s%s\n",
-          ts, action, pkg.source, pkg.reason, pkg.name, version_change, flags))
-      end
+      local upgrade = pkg.local_version ~= ""
+      local action = upgrade and "upgrade" or "install"
+      local version_change = upgrade and (pkg.local_version .. " -> " .. pkg.version) or pkg.version
+      f:write(string.format("%s  %-9s %-7s %-14s %-12s %s\n",
+        ts, action, pkg.source, pkg.reason, pkg.name, version_change))
     end
 
     f:close()

--- a/doc/lua.md
+++ b/doc/lua.md
@@ -346,13 +346,10 @@ yay.create_autocmd("PostInstall", {
   desc = "log every package yay installed",
   callback = function(event)
     for _, pkg in ipairs(event.data.packages) do
-      if pkg.installed then
-        yay.log.info(pkg.name .. " " .. pkg.version .. " installed (" .. pkg.source .. ")")
-      end
+      yay.log.info(pkg.name .. " " .. pkg.version .. " (" .. pkg.source .. ")")
     end
   end,
 })
-```
 
 ---
 

--- a/doc/lua.md
+++ b/doc/lua.md
@@ -327,9 +327,6 @@ logs the message but cannot roll back anything.
         local_version = "1.0.0-1",    -- previously installed ("" if not installed)
         source        = "aur",        -- "aur" | "sync" | "local" | "srcinfo" | "missing"
         reason        = "explicit",   -- "explicit" | "dependency" | "make_dependency" | "check_dependency" | "unknown"
-        installed     = true,         -- false for AUR bases that failed but were tolerated
-        upgrade       = false,        -- true when replacing an older version
-        devel         = false,        -- true for VCS (-git/-svn/…) packages
       },
       -- one entry per package yay resolved; sorted alphabetically
     },
@@ -389,7 +386,6 @@ the **unfiltered** results are shown rather than aborting the command.
         popularity      = 1.23,       -- -1 for sync packages
         first_submitted = 1700000000, -- -1 for sync packages
         last_modified   = 1700000001, -- -1 for sync packages
-        provides        = { "virtual-pkg" },
       },
       -- …
     },

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -369,7 +369,6 @@ func (s *SourceQueryBuilder) applySearchFilter(results []abstractResult) []abstr
 			Popularity:     results[i].popularity,
 			FirstSubmitted: results[i].firstSubmitted,
 			LastModified:   results[i].lastModified,
-			Provides:       results[i].provides,
 		}
 	}
 

--- a/pkg/settings/lua/autocmd.go
+++ b/pkg/settings/lua/autocmd.go
@@ -94,9 +94,6 @@ type PostInstallPackage struct {
 	LocalVersion string
 	Source       string
 	Reason       string
-	Installed    bool
-	Upgrade      bool
-	Devel        bool
 }
 
 type SearchFilterEvent struct {
@@ -112,7 +109,6 @@ type SearchResultPackage struct {
 	Popularity     float64
 	FirstSubmitted int
 	LastModified   int
-	Provides       []string
 }
 
 type SearchResultRef struct {
@@ -478,9 +474,6 @@ func (e *Engine) postInstallPackagesTable(packages []PostInstallPackage) *glua.L
 		pkgTbl.RawSetString("local_version", glua.LString(pkg.LocalVersion))
 		pkgTbl.RawSetString("source", glua.LString(pkg.Source))
 		pkgTbl.RawSetString("reason", glua.LString(pkg.Reason))
-		pkgTbl.RawSetString("installed", glua.LBool(pkg.Installed))
-		pkgTbl.RawSetString("upgrade", glua.LBool(pkg.Upgrade))
-		pkgTbl.RawSetString("devel", glua.LBool(pkg.Devel))
 		tbl.Append(pkgTbl)
 	}
 
@@ -508,7 +501,6 @@ func (e *Engine) searchResultPackagesTable(packages []SearchResultPackage) *glua
 		pkgTbl.RawSetString("popularity", glua.LNumber(pkg.Popularity))
 		pkgTbl.RawSetString("first_submitted", glua.LNumber(pkg.FirstSubmitted))
 		pkgTbl.RawSetString("last_modified", glua.LNumber(pkg.LastModified))
-		pkgTbl.RawSetString("provides", e.stringArray(pkg.Provides))
 		tbl.Append(pkgTbl)
 	}
 

--- a/pkg/settings/lua/autocmd_bench_test.go
+++ b/pkg/settings/lua/autocmd_bench_test.go
@@ -131,12 +131,10 @@ func makePostInstallEvent(n int) *PostInstallEvent {
 	pkgs := make([]PostInstallPackage, n)
 	for i := range pkgs {
 		pkgs[i] = PostInstallPackage{
-			Name:      "pkg-" + string(rune('a'+i%26)),
-			Version:   "2.0-1",
-			Source:    "aur",
-			Reason:    "explicit",
-			Installed: true,
-			Upgrade:   true,
+			Name:    "pkg-" + string(rune('a'+i%26)),
+			Version: "2.0-1",
+			Source:  "aur",
+			Reason:  "explicit",
 		}
 	}
 

--- a/pkg/settings/lua/autocmd_postinstall_searchfilter_test.go
+++ b/pkg/settings/lua/autocmd_postinstall_searchfilter_test.go
@@ -31,9 +31,6 @@ func TestRunPostInstallEventTableShape(t *testing.T) {
 				if pkg.local_version ~= "1.0.0-1" then error("bad local_version") end
 				if pkg.source ~= "aur" then error("bad source") end
 				if pkg.reason ~= "explicit" then error("bad reason") end
-				if pkg.installed ~= true then error("bad installed") end
-				if pkg.upgrade ~= false then error("bad upgrade") end
-				if pkg.devel ~= true then error("bad devel") end
 				setRan()
 			end,
 		})
@@ -93,8 +90,6 @@ func TestRunSearchFilterEventTableShapeAndReturn(t *testing.T) {
 				if math.abs(r.popularity - 3.14) > 0.001 then error("bad popularity") end
 				if r.first_submitted ~= 1000 then error("bad first_submitted") end
 				if r.last_modified ~= 2000 then error("bad last_modified") end
-				if r.provides[1] ~= "pkgA-compat" then error("bad provides") end
-
 				-- Return reversed order, dropping pkgC
 				return {
 					{ source = "sync", name = "pkgB" },

--- a/pkg/settings/lua/autocmd_postinstall_searchfilter_test.go
+++ b/pkg/settings/lua/autocmd_postinstall_searchfilter_test.go
@@ -47,9 +47,6 @@ func TestRunPostInstallEventTableShape(t *testing.T) {
 				LocalVersion: "1.0.0-1",
 				Source:       "aur",
 				Reason:       "explicit",
-				Installed:    true,
-				Upgrade:      false,
-				Devel:        true,
 			},
 		},
 	})
@@ -118,7 +115,6 @@ func TestRunSearchFilterEventTableShapeAndReturn(t *testing.T) {
 				Popularity:     3.14,
 				FirstSubmitted: 1000,
 				LastModified:   2000,
-				Provides:       []string{"pkgA-compat"},
 			},
 			{Source: "sync", Name: "pkgB"},
 			{Source: "aur", Name: "pkgC"},

--- a/pkg/sync/post_install.go
+++ b/pkg/sync/post_install.go
@@ -8,9 +8,7 @@ import (
 	settingslua "github.com/Jguer/yay/v13/pkg/settings/lua"
 )
 
-// postInstallEvent flattens the resolved topo layers into the PostInstall
-// payload. Packages recorded in failedAndIgnored (last-layer AUR build
-// failures tolerated by the installer) are marked installed = false.
+// postInstallEvent flattens the resolved topo layers into the PostInstall payload.
 func postInstallEvent(targets []map[string]*dep.InstallInfo) *settingslua.PostInstallEvent {
 	merged := map[string]*dep.InstallInfo{}
 	for _, layer := range targets {

--- a/pkg/sync/post_install.go
+++ b/pkg/sync/post_install.go
@@ -11,7 +11,7 @@ import (
 // postInstallEvent flattens the resolved topo layers into the PostInstall
 // payload. Packages recorded in failedAndIgnored (last-layer AUR build
 // failures tolerated by the installer) are marked installed = false.
-func postInstallEvent(targets []map[string]*dep.InstallInfo, failedAndIgnored map[string]error) *settingslua.PostInstallEvent {
+func postInstallEvent(targets []map[string]*dep.InstallInfo) *settingslua.PostInstallEvent {
 	merged := map[string]*dep.InstallInfo{}
 	for _, layer := range targets {
 		maps.Copy(merged, layer)
@@ -22,16 +22,12 @@ func postInstallEvent(targets []map[string]*dep.InstallInfo, failedAndIgnored ma
 	packages := make([]settingslua.PostInstallPackage, 0, len(names))
 	for _, name := range names {
 		info := merged[name]
-		_, failed := failedAndIgnored[name]
 		packages = append(packages, settingslua.PostInstallPackage{
 			Name:         name,
 			Version:      info.Version,
 			LocalVersion: info.LocalVersion,
 			Source:       luaSource(info.Source),
 			Reason:       luaReason(info.Reason),
-			Installed:    !failed,
-			Upgrade:      info.Upgrade,
-			Devel:        info.Devel,
 		})
 	}
 

--- a/pkg/sync/post_install_test.go
+++ b/pkg/sync/post_install_test.go
@@ -59,12 +59,7 @@ func TestPostInstallEvent(t *testing.T) {
 		},
 	}
 
-	// pkgB failed to install.
-	failedAndIgnored := map[string]error{
-		"pkgB": assert.AnError,
-	}
-
-	event := postInstallEvent(targets, failedAndIgnored)
+	event := postInstallEvent(targets)
 
 	// Must be sorted by name.
 	want := &settingslua.PostInstallEvent{
@@ -75,9 +70,6 @@ func TestPostInstallEvent(t *testing.T) {
 				LocalVersion: "1.0-1",
 				Source:       "aur",
 				Reason:       "explicit",
-				Installed:    true,
-				Upgrade:      true,
-				Devel:        false,
 			},
 			{
 				Name:         "pkgB",
@@ -85,18 +77,12 @@ func TestPostInstallEvent(t *testing.T) {
 				LocalVersion: "",
 				Source:       "aur",
 				Reason:       "dependency",
-				Installed:    false, // in failedAndIgnored
-				Upgrade:      false,
-				Devel:        true,
 			},
 			{
-				Name:      "pkgC",
-				Version:   "3.0-1",
-				Source:    "sync",
-				Reason:    "make_dependency",
-				Installed: true,
-				Upgrade:   false,
-				Devel:     false,
+				Name:    "pkgC",
+				Version: "3.0-1",
+				Source:  "sync",
+				Reason:  "make_dependency",
 			},
 		},
 	}

--- a/pkg/sync/post_install_test.go
+++ b/pkg/sync/post_install_test.go
@@ -17,15 +17,13 @@ func TestPostInstallEvent(t *testing.T) {
 	base := "aur-base"
 	targets := []map[string]*dep.InstallInfo{
 		{
-			// Layer 0: two AUR packages, one of which will fail.
+			// Layer 0: two AUR packages.
 			"pkgA": {
 				Source:       dep.AUR,
 				Reason:       dep.Explicit,
 				Version:      "2.0-1",
 				LocalVersion: "1.0-1",
 				AURBase:      &base,
-				Upgrade:      true,
-				Devel:        false,
 			},
 			"pkgB": {
 				Source:       dep.AUR,
@@ -33,8 +31,6 @@ func TestPostInstallEvent(t *testing.T) {
 				Version:      "1.1-1",
 				LocalVersion: "",
 				AURBase:      &base,
-				Upgrade:      false,
-				Devel:        true,
 			},
 		},
 		{
@@ -43,8 +39,6 @@ func TestPostInstallEvent(t *testing.T) {
 				Source:  dep.Sync,
 				Reason:  dep.MakeDep,
 				Version: "3.0-1",
-				Upgrade: false,
-				Devel:   false,
 			},
 			// pkgA appears in layer 1 too; layer merge last-wins → this version.
 			"pkgA": {
@@ -53,8 +47,6 @@ func TestPostInstallEvent(t *testing.T) {
 				Version:      "2.0-2",
 				LocalVersion: "1.0-1",
 				AURBase:      &base,
-				Upgrade:      true,
-				Devel:        false,
 			},
 		},
 	}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -127,7 +127,7 @@ func (o *OperationService) Run(ctx context.Context, run *runtime.Runtime,
 
 	if !cmdArgs.ExistsArg("w", "downloadonly") && run.Lua != nil &&
 		run.Lua.HasAutocmd(settingslua.EventPostInstall) {
-		if err := run.Lua.RunPostInstall(postInstallEvent(targets, failedAndIgnored)); err != nil {
+		if err := run.Lua.RunPostInstall(postInstallEvent(targets)); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
Remove fields that might not be necessary. It's easier to add, than it is to remove