### PR TITLE
Update man page version to v13 and sync VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "go.lintTool": "golangci-lint",
     "gopls": {
-        "formatting.gofumpt": true,
-        "formatting.local": "github.com/Jguer/yay/v12"
+        "formatting.local": "github.com/Jguer/yay/v13"
     }
 }

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -1,4 +1,4 @@
-.TH "YAY" "8" "2019\-10\-21" "Yay v12.0+" "Yay Manual"
+.TH "YAY" "8" "2026\-06\-17" "Yay v13.0+" "Yay Manual"
 .nh
 .ad l
 .SH NAME


### PR DESCRIPTION
Updated the man page version from v12.0+ to v13.0+ and cleaned up VS Code settings (remove obsolete gofumpt, update local import to v13).