### PR TITLE
fix: fallback to SyncPackage when SyncSatisfier misses packages in cu…

### DIFF
--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -677,9 +677,18 @@ func (g *Grapher) addNodes(
 
 	// Check Sync
 	for _, depString := range targetsToFind.ToSlice() {
+		depName, _, _ := splitDep(depString)
 		alpmPkg := g.dbExecutor.SyncSatisfier(depString)
 		if alpmPkg == nil {
-			continue
+			// Fallback: try exact name match. SyncSatisfier uses FindDBSatisfier
+			// which can miss packages in custom repos in certain edge cases
+			// (e.g. dependency exists in the repo DB but FindDBSatisfier
+			// doesn't return it). See yay issue #2246, #2518.
+			if syncPkg := g.dbExecutor.SyncPackage(depName); syncPkg != nil {
+				alpmPkg = syncPkg
+			} else {
+				continue
+			}
 		}
 
 		if err := graph.DependOn(alpmPkg.Name(), parentPkgName); err != nil {

--- a/pkg/dep/dep_graph_test.go
+++ b/pkg/dep/dep_graph_test.go
@@ -718,6 +718,109 @@ func TestGrapher_GraphFromAUR_Deps_gourou(t *testing.T) {
 	}
 }
 
+// TestGrapher_GraphFromAUR_SyncPackageFallback tests the fallback in addNodes
+// where SyncSatisfier returns nil but SyncPackage finds the dependency by
+// exact name match.
+func TestGrapher_GraphFromAUR_SyncPackageFallback(t *testing.T) {
+	t.Parallel()
+
+	mockDB := &mock.DBExecutor{
+		SyncPackageFn: func(s string) mock.IPackage {
+			switch s {
+			case "sync-dep":
+				return &mock.Package{
+					PName:    "sync-dep",
+					PVersion: "2.0.0-1",
+					PDB:      mock.NewDB("extra"),
+				}
+			}
+			return nil
+		},
+		PackagesFromGroupFn: func(string) []mock.IPackage { return nil },
+		SyncSatisfierFn: func(s string) mock.IPackage {
+			switch s {
+			case "my-aur-pkg":
+				return nil
+			case "sync-dep":
+				return nil
+			}
+			panic("implement me " + s)
+		},
+		LocalSatisfierExistsFn: func(s string) bool {
+			switch s {
+			case "my-aur-pkg", "sync-dep":
+				return false
+			}
+			panic("implement me " + s)
+		},
+		LocalPackageFn: func(string) mock.IPackage { return nil },
+	}
+
+	mockAUR := &mockaur.MockAUR{GetFn: func(ctx context.Context, query *aurc.Query) ([]aur.Pkg, error) {
+		mockPkgs := map[string]aur.Pkg{
+			"my-aur-pkg": {
+				Name:        "my-aur-pkg",
+				PackageBase: "my-aur-pkg",
+				Version:     "1.0.0-1",
+				Depends:     []string{"sync-dep"},
+			},
+		}
+
+		pkgs := make([]aur.Pkg, 0, len(query.Needles))
+		for _, needle := range query.Needles {
+			if pkg, ok := mockPkgs[needle]; ok {
+				pkgs = append(pkgs, pkg)
+			}
+		}
+		return pkgs, nil
+	}}
+
+	installInfos := map[string]*InstallInfo{
+		"my-aur-pkg exp": {
+			Source:  AUR,
+			Reason:  Explicit,
+			Version: "1.0.0-1",
+			AURBase: "my-aur-pkg",
+		},
+		"sync-dep dep": {
+			Source:     Sync,
+			Reason:     Dep,
+			Version:    "2.0.0-1",
+			SyncDBName: "extra",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		targets    []string
+		wantLayers []map[string]*InstallInfo
+		wantErr    bool
+	}{
+		{
+			name:    "sync-package-fallback",
+			targets: []string{"my-aur-pkg"},
+			wantLayers: []map[string]*InstallInfo{
+				{"my-aur-pkg": installInfos["my-aur-pkg exp"]},
+				{"sync-dep": installInfos["sync-dep dep"]},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGrapher(mockDB, mockAUR,
+				false, true, false, false, false,
+				text.NewLogger(io.Discard, io.Discard, &os.File{}, true, "test"))
+			got, err := g.GraphFromTargets(t.Context(), nil, tt.targets)
+			require.NoError(t, err)
+			layers := got.TopoSortedLayers(nil)
+			require.EqualValues(t, tt.wantLayers, layers, layers)
+		})
+	}
+}
+
 func TestGrapher_GraphFromTargets_ReinstalledDeps(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
…stom repos

SyncSatisfier uses FindDBSatisfier which can fail to find packages in non-standard binary repos in certain edge cases. When it returns nil, try SyncPackage for an exact name match as a fallback.

Also adds TestGrapher_GraphFromAUR_SyncPackageFallback to cover the fallback path.