### PR TITLE
fix(query): improve multi-term search ranking and filtering

### DIFF
--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -195,7 +195,7 @@ func (s *SourceQueryBuilder) Execute(ctx context.Context, dbExecutor db.Executor
 
 	sortableResults := &abstractResults{
 		results:         []abstractResult{},
-		search:          strings.ToLower(strings.Join(pkgS, "")),
+		search:          strings.ToLower(strings.Join(pkgS, " ")),
 		metric:          metric,
 		separateSources: s.separateSources,
 		repoOrder:       dbExecutor.Repos(),
@@ -341,7 +341,7 @@ func matchesSearch(pkg *aur.Pkg, terms []string) bool {
 	desc := strings.ToLower(pkg.Description)
 	for _, pkgN := range terms {
 		if strings.ContainsFunc(pkgN, unicode.IsSymbol) {
-			return true
+			continue
 		}
 
 		targ := strings.ToLower(pkgN)


### PR DESCRIPTION
## Summary

Two fixes to improve search quality for multi-term queries:

1. **Search string separator** — Join search terms with a space instead of an empty separator. Previously  produced strings like  from , which gave poor Jaro-Winkler similarity scores and never matched exactly. Now produces .

2. **matchesSearch symbol early-return** — Changed  to  when a search term contains a symbol. Previously, if any term contained a symbol (e.g., ), the entire multi-term filter was bypassed, returning all results without checking other terms. Now only the symbol-containing term is skipped (AUR RPC already handles substring matching for those), while non-symbol terms are still checked.