### PR TITLE
fix(diff): place --color flag before pathspec separator

### DIFF
--- a/pkg/menus/diff_menu.go
+++ b/pkg/menus/diff_menu.go
@@ -78,16 +78,17 @@ func collectPkgbuildDiffs(ctx context.Context, cmdBuilder exe.ICmdBuilder, logge
 			}
 		}
 
-		args := []string{
-			"--no-pager", "diff",
-			start + "..HEAD@{upstream}", "--src-prefix",
-			dir + "/", "--dst-prefix", dir + "/", "--", ".", ":(exclude).SRCINFO",
-		}
+		args := []string{"--no-pager", "diff"}
 		if text.UseColor {
 			args = append(args, "--color=always")
 		} else {
 			args = append(args, "--color=never")
 		}
+
+		args = append(args,
+			start+"..HEAD@{upstream}", "--src-prefix",
+			dir+"/", "--dst-prefix", dir+"/", "--", ".", ":(exclude).SRCINFO",
+		)
 
 		stdout, stderr, err := cmdBuilder.Capture(cmdBuilder.BuildGitCmd(ctx, dir, args...))
 		if err != nil {


### PR DESCRIPTION
Since #2905, PKGBUILD diffs lose color even with `Color` enabled in pacman.conf.

`collectPkgbuildDiffs` appends `--color=always`/`never` after the `--`
separator, so git treats it as a pathspec and ignores it. This predates
#2905 but was masked: `Show()` gave git a TTY, so auto color worked. With
`Capture()` git sees a pipe and disables color.

Fix: append the color flag before the range and pathspecs.

Tested: `TZ=UTC make test`, `make lint`, and manual diff review with color
on/off. Related: #2905, #1243.