### PR TITLE
feat: next add minage option to prefer older package versions

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -79,6 +79,7 @@ Permanent configuration options:
 
     --requestsplitn <n>   Max amount of packages to query per AUR request
     --completioninterval  <n> Time in days to refresh completion cache
+    --minage      <days>  Prefer package versions at least this old on upgrade (0 disables)
     --sortby    <field>   Sort AUR results by a specific field during search
     --searchby  <field>   Search for packages using a specified field
     --answerclean   <a>   Set a predetermined answer for the clean build menu

--- a/doc/init.lua
+++ b/doc/init.lua
@@ -32,6 +32,7 @@ yay.opt.answer_edit = ""
 
 yay.opt.request_split_n = 150
 yay.opt.completion_refresh_time = 7
+yay.opt.min_age = 0
 yay.opt.max_concurrent_downloads = 1
 
 yay.opt.bottom_up = true

--- a/doc/lua.md
+++ b/doc/lua.md
@@ -77,7 +77,7 @@ startup and reports the offending keys/values so misconfigurations fail fast.
 
 **Integers**
 
-`request_split_n`, `completion_refresh_time`, `max_concurrent_downloads`
+`request_split_n`, `completion_refresh_time`, `min_age`, `max_concurrent_downloads`
 
 **Booleans**
 

--- a/meta/yay.d.lua
+++ b/meta/yay.d.lua
@@ -44,6 +44,7 @@
 ---@field answer_edit yay.menuAnswer yay v13.0.1+ Pre-select edit menu answer (also accepts menu syntax: ranges, ^n).
 ---@field request_split_n integer Max packages per AUR RPC request (use values > 0).
 ---@field completion_refresh_time integer Completion cache refresh days: -1 (never), 0 (always), >0 (every N days).
+---@field min_age integer Prefer package versions at least this old on upgrade; 0 disables.
 ---@field max_concurrent_downloads integer Parallel PKGBUILD source downloads; 0 uses CPU count.
 ---@field bottom_up boolean Show AUR packages before repo packages in mixed results.
 ---@field sudo_loop boolean Keep sudo session alive in the background during long builds.

--- a/minage.go
+++ b/minage.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+
+	"github.com/Jguer/yay/v13/pkg/dep"
+	"github.com/Jguer/yay/v13/pkg/dep/topo"
+	"github.com/Jguer/yay/v13/pkg/runtime"
+	"github.com/Jguer/yay/v13/pkg/settings/parser"
+	"github.com/Jguer/yay/v13/pkg/upgrade"
+)
+
+func minAgeApplies(cmdArgs *parser.Arguments) bool {
+	return cmdArgs.ExistsArg("u", "sysupgrade")
+}
+
+func minAgeAdjuster(run *runtime.Runtime, dryRun bool) *upgrade.MinAgeAdjuster {
+	return &upgrade.MinAgeAdjuster{
+		CacheDirs:  run.PacmanConf.CacheDir,
+		BuildDir:   run.Cfg.BuildDir,
+		AURURL:     run.Cfg.AURURL,
+		PacmanBin:  run.Cfg.PacmanBin,
+		CmdBuilder: run.CmdBuilder,
+		DryRun:     dryRun,
+	}
+}
+
+func applyMinAge(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Arguments,
+	graph *topo.Graph[string, *dep.InstallInfo], dryRun bool,
+) []string {
+	if run.Cfg.MinAge <= 0 {
+		return nil
+	}
+
+	if !dryRun && !minAgeApplies(cmdArgs) {
+		return nil
+	}
+
+	report, ignore := upgrade.ApplyMinAge(ctx, graph, run.Cfg.MinAge, minAgeAdjuster(run, dryRun))
+	upgrade.PrintMinAgeReport(run.Logger, report, run.Cfg.MinAge)
+
+	return ignore
+}

--- a/minage_test.go
+++ b/minage_test.go
@@ -1,0 +1,31 @@
+//go:build !integration
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v13/pkg/settings/parser"
+)
+
+func TestMinAgeApplies_onlySysupgrade(t *testing.T) {
+	t.Parallel()
+
+	install := parser.MakeArguments()
+	_ = install.AddArg("S")
+	install.AddTarget("foo")
+	require.False(t, minAgeApplies(install))
+
+	sysupgrade := parser.MakeArguments()
+	_ = sysupgrade.AddArg("S")
+	_ = sysupgrade.AddArg("u")
+	require.True(t, minAgeApplies(sysupgrade))
+
+	fullUpgrade := parser.MakeArguments()
+	_ = fullUpgrade.AddArg("S")
+	_ = fullUpgrade.AddArg("y")
+	_ = fullUpgrade.AddArg("u")
+	require.True(t, minAgeApplies(fullUpgrade))
+}

--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -29,6 +29,8 @@ type InstallInfo struct {
 	SyncDBName   string
 	SrcinfoPath  string
 	Maintainer   string
+	PkgArchive   string
+	AURGitRef    string
 	Source       Source
 	Reason       Reason
 	IsGroup      bool
@@ -312,6 +314,19 @@ func (g *Grapher) addDepNodes(ctx context.Context, pkg *aur.Pkg, graph *topo.Gra
 	}
 }
 
+func syncLastModified(pkg alpm.Package) int64 {
+	if pkg == nil {
+		return 0
+	}
+
+	t := pkg.BuildDate()
+	if t.IsZero() {
+		return 0
+	}
+
+	return t.Unix()
+}
+
 func (g *Grapher) GraphSyncPkg(ctx context.Context,
 	graph *topo.Graph[string, *InstallInfo],
 	pkg alpm.Package, upgradeInfo *db.SyncUpgrade,
@@ -330,10 +345,11 @@ func (g *Grapher) GraphSyncPkg(ctx context.Context,
 
 	dbName := pkg.DB().Name()
 	info := &InstallInfo{
-		Source:     Sync,
-		Reason:     Explicit,
-		Version:    pkg.Version(),
-		SyncDBName: dbName,
+		Source:       Sync,
+		Reason:       Explicit,
+		Version:      pkg.Version(),
+		SyncDBName:   dbName,
+		LastModified: syncLastModified(pkg),
 	}
 
 	if upgradeInfo == nil {
@@ -699,10 +715,11 @@ func (g *Grapher) addNodes(
 				Color:      colorMap[depType],
 				Background: bgColorMap[Sync],
 				Value: &InstallInfo{
-					Source:     Sync,
-					Reason:     depType,
-					Version:    alpmPkg.Version(),
-					SyncDBName: dbName,
+					Source:       Sync,
+					Reason:       depType,
+					Version:      alpmPkg.Version(),
+					SyncDBName:   dbName,
+					LastModified: syncLastModified(alpmPkg),
 				},
 			})
 

--- a/pkg/dep/dep_unit_test.go
+++ b/pkg/dep/dep_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Jguer/aur"
 	alpm "github.com/Jguer/dyalpm"
@@ -102,9 +103,10 @@ func TestGrapher_GraphSyncPkgAndUpgrade(t *testing.T) {
 	require.False(t, info.Upgrade)
 
 	upgraded := grapher.GraphSyncPkg(context.TODO(), nil, &mock.Package{
-		PName:    "yaysrc",
-		PVersion: "2.0.0",
-		PDB:      mock.NewDB("core"),
+		PName:      "yaysrc",
+		PVersion:   "2.0.0",
+		PDB:        mock.NewDB("core"),
+		PBuildDate: time.Unix(1_700_000_100, 0),
 	}, &db.SyncUpgrade{
 		Package: &mock.Package{
 			PName: "yaysrc",
@@ -118,6 +120,7 @@ func TestGrapher_GraphSyncPkgAndUpgrade(t *testing.T) {
 	require.NotNil(t, upgradeInfo)
 	require.True(t, upgradeInfo.Upgrade)
 	require.Equal(t, "1.0.0", upgradeInfo.LocalVersion)
+	require.Equal(t, int64(1_700_000_100), upgradeInfo.LastModified)
 }
 
 func TestGrapher_GraphSyncGroupAndValidateNodeInfo(t *testing.T) {
@@ -201,4 +204,17 @@ func TestMakeAURPKGFromSrcinfo(t *testing.T) {
 
 	_, err = makeAURPKGFromSrcinfo(dbFail, srcinfo)
 	require.Error(t, err)
+}
+
+func TestSyncLastModified(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, int64(0), syncLastModified(nil))
+
+	zero := &mock.Package{}
+	require.Equal(t, int64(0), syncLastModified(zero))
+
+	built := time.Unix(1_700_000_000, 0)
+	pkg := &mock.Package{PBuildDate: built}
+	require.Equal(t, built.Unix(), syncLastModified(pkg))
 }

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -179,6 +179,11 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.RemoveMake = "askyes"
 	case "separatesources":
 		c.SeparateSources = boolValue
+	case "minage":
+		n, err := strconv.Atoi(value)
+		if err == nil && n >= 0 {
+			c.MinAge = n
+		}
 	default:
 		return false
 	}

--- a/pkg/settings/args_test.go
+++ b/pkg/settings/args_test.go
@@ -1,0 +1,28 @@
+//go:build !integration
+
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleOptionMinAge(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig("test")
+
+	require.True(t, cfg.handleOption("minage", "14"))
+	require.Equal(t, 14, cfg.MinAge)
+
+	require.True(t, cfg.handleOption("minage", "0"))
+	require.Equal(t, 0, cfg.MinAge)
+
+	cfg.MinAge = 7
+	require.True(t, cfg.handleOption("minage", "not-a-number"))
+	require.Equal(t, 7, cfg.MinAge)
+
+	require.True(t, cfg.handleOption("minage", "-1"))
+	require.Equal(t, 7, cfg.MinAge)
+}

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -70,6 +70,7 @@ type Configuration struct {
 	Debug                  bool   `json:"debug" lua:"debug"`
 	UseRPC                 bool   `json:"rpc" lua:"rpc"`
 	DoubleConfirm          bool   `json:"doubleconfirm" lua:"double_confirm"` // confirm install before and after build
+	MinAge                 int    `json:"minage" lua:"min_age"`               // skip packages newer than N days (--minage)
 
 	CompletionPath string `json:"-" lua:"-"`
 	VCSFilePath    string `json:"-" lua:"-"`

--- a/pkg/settings/config_test.go
+++ b/pkg/settings/config_test.go
@@ -312,3 +312,15 @@ func TestConfiguration_setPrivilegeElevator_pacman_auth_sudo(t *testing.T) {
 	assert.Equal(t, "-v", config.SudoFlags)
 	assert.True(t, config.SudoLoop)
 }
+
+func TestConfigurationMinAgeJSON(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig("test")
+	require.NoError(t, json.Unmarshal([]byte(`{"minage":14}`), cfg))
+	require.Equal(t, 14, cfg.MinAge)
+
+	out, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.Contains(t, string(out), `"minage":14`)
+}

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -438,6 +438,7 @@ func isArg(arg string) bool {
 	case "singlelineresults":
 	case "doublelineresults":
 	case "separatesources":
+	case "minage":
 	default:
 		return false
 	}
@@ -532,6 +533,7 @@ func hasParam(arg string) bool {
 	case "completioninterval":
 	case "sortby":
 	case "searchby":
+	case "minage":
 	default:
 		return false
 	}

--- a/pkg/sync/build/installer.go
+++ b/pkg/sync/build/installer.go
@@ -156,6 +156,8 @@ func (installer *Installer) handleLayer(ctx context.Context,
 		mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()
 	aurDeps, aurExp, aurOrigTargetBases := mapset.NewThreadUnsafeSet[string](),
 		mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()
+	cacheDeps, cacheExp := mapset.NewThreadUnsafeSet[string](), mapset.NewThreadUnsafeSet[string]()
+	var cacheArchives []string
 
 	upgradeSync := false
 	for name, info := range layer {
@@ -182,6 +184,26 @@ func (installer *Installer) handleLayer(ctx context.Context,
 				}
 			}
 		case dep.Sync:
+			if info.PkgArchive != "" {
+				cacheArchives = append(cacheArchives, info.PkgArchive)
+				switch info.Reason {
+				case dep.Explicit:
+					if cmdArgs.ExistsArg("asdeps", "asdep") {
+						cacheDeps.Add(name)
+					} else {
+						cacheExp.Add(name)
+					}
+				case dep.Dep, dep.MakeDep, dep.CheckDep:
+					if cmdArgs.ExistsArg("asexplicit", "asexp") && installer.origTargets.Contains(name) {
+						cacheExp.Add(name)
+					} else {
+						cacheDeps.Add(name)
+					}
+				}
+
+				continue
+			}
+
 			if info.Upgrade {
 				upgradeSync = true
 				continue // do not add to targets, let pacman handle it
@@ -218,6 +240,18 @@ func (installer *Installer) handleLayer(ctx context.Context,
 		excluded, upgradeSync, installer.appendNoConfirm())
 	if errShow != nil {
 		return ErrInstallRepoPkgs
+	}
+
+	if len(cacheArchives) > 0 {
+		if err := installPkgArchive(ctx, installer.exeCmd, installer.targetMode,
+			installer.vcsStore, cmdArgs, cacheArchives, installer.appendNoConfirm()); err != nil {
+			return err
+		}
+
+		if err := setInstallReason(ctx, installer.exeCmd, installer.targetMode, cmdArgs,
+			cacheDeps.ToSlice(), cacheExp.ToSlice()); err != nil {
+			return err
+		}
 	}
 
 	errAur := installer.installAURPackages(ctx, cmdArgs, aurDeps, aurExp,

--- a/pkg/sync/build/pkg_archive_test.go
+++ b/pkg/sync/build/pkg_archive_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Jguer/yay/v13/pkg/settings/exe"
+	"github.com/Jguer/yay/v13/pkg/settings/parser"
+	"github.com/Jguer/yay/v13/pkg/vcs"
 )
 
 func TestParsePackageList(t *testing.T) {
@@ -164,4 +166,40 @@ func TestParsePackageList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInstallPkgArchive(t *testing.T) {
+	t.Parallel()
+
+	var builtArgs *parser.Arguments
+	runner := &exe.MockRunner{
+		ShowFn: func(cmd *exec.Cmd) error {
+			return nil
+		},
+	}
+	cmdBuilder := &exe.MockBuilder{
+		Runner: runner,
+		BuildPacmanCmdFn: func(ctx context.Context, args *parser.Arguments, mode parser.TargetMode, noConfirm bool) *exec.Cmd {
+			builtArgs = args
+
+			return exec.CommandContext(ctx, "pacman")
+		},
+	}
+
+	cmdArgs := parser.MakeArguments()
+	require.NoError(t, cmdArgs.AddArg("S", "y", "u"))
+
+	err := installPkgArchive(
+		context.Background(),
+		cmdBuilder,
+		parser.ModeAny,
+		&vcs.Mock{},
+		cmdArgs,
+		[]string{"/cache/foo.pkg.tar.zst"},
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, builtArgs)
+	require.Equal(t, "U", builtArgs.Op)
+	require.Equal(t, []string{"/cache/foo.pkg.tar.zst"}, builtArgs.Targets)
 }

--- a/pkg/sync/workdir/preparer.go
+++ b/pkg/sync/workdir/preparer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Jguer/yay/v13/pkg/settings/parser"
 	"github.com/Jguer/yay/v13/pkg/sync/build"
 	"github.com/Jguer/yay/v13/pkg/text"
+	"github.com/Jguer/yay/v13/pkg/upgrade"
 
 	gosrc "github.com/Morganamilo/go-srcinfo"
 	mapset "github.com/deckarep/golang-set/v2"
@@ -213,6 +214,19 @@ func (preper *Preparer) PrepareWorkspace(ctx context.Context,
 		preper.cmdBuilder, preper.log.Child("download"), aurBasesToClone.ToSlice(),
 		preper.cfg.AURURL, preper.cfg.BuildDir, false); errA != nil {
 		return nil, errA
+	}
+
+	for _, layer := range targets {
+		for _, info := range layer {
+			if info.AURGitRef == "" || info.AURBase == "" {
+				continue
+			}
+
+			pkgDir := filepath.Join(preper.cfg.BuildDir, info.AURBase)
+			if err := upgrade.CheckoutAURGitRef(ctx, preper.cmdBuilder, pkgDir, info.AURGitRef); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if !preper.downloadSources {

--- a/pkg/sync/workdir/preparer_test.go
+++ b/pkg/sync/workdir/preparer_test.go
@@ -3,15 +3,31 @@
 package workdir
 
 import (
+	"context"
+	"errors"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/Jguer/yay/v13/pkg/dep"
 	"github.com/Jguer/yay/v13/pkg/settings"
+	"github.com/Jguer/yay/v13/pkg/settings/exe"
 	"github.com/Jguer/yay/v13/pkg/text"
 )
+
+const preparerTestSrcinfo = `pkgbase = foobase
+pkgver = 1.2.3
+pkgrel = 2
+arch = x86_64
+
+pkgname = foobase
+`
 
 func newTestLogger() *text.Logger {
 	return text.NewLogger(io.Discard, io.Discard, strings.NewReader(""), true, "test")
@@ -68,4 +84,41 @@ func TestPreDownloadSourcesHooks(t *testing.T) {
 			assert.Equal(t, tc.wantHook, got)
 		})
 	}
+}
+
+func TestPreparer_PrepareWorkspace_checkoutFailure(t *testing.T) {
+	t.Parallel()
+
+	buildDir := t.TempDir()
+	pkgDir := filepath.Join(buildDir, "foobase")
+	require.NoError(t, os.MkdirAll(filepath.Join(pkgDir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, ".SRCINFO"), []byte(preparerTestSrcinfo), 0o600))
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			if strings.Contains(strings.Join(cmd.Args, " "), " checkout ") {
+				return "", "", errors.New("checkout failed")
+			}
+
+			return "", "", nil
+		},
+	}
+
+	preper := NewPreparerWithoutHooks(nil, &exe.MockBuilder{Runner: runner}, &settings.Configuration{
+		BuildDir: buildDir,
+		AURURL:   "https://aur.archlinux.org",
+	}, newTestLogger(), false)
+
+	targets := []map[string]*dep.InstallInfo{{
+		"foobase": {
+			Source:    dep.AUR,
+			AURBase:   "foobase",
+			Version:   "1.2.3-2",
+			AURGitRef: "deadbeef",
+		},
+	}}
+
+	_, err := preper.PrepareWorkspace(context.Background(), nil, targets)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "checkout failed")
 }

--- a/pkg/upgrade/age.go
+++ b/pkg/upgrade/age.go
@@ -1,0 +1,271 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/leonelquinteros/gotext"
+
+	"github.com/Jguer/yay/v13/pkg/dep"
+	"github.com/Jguer/yay/v13/pkg/dep/topo"
+	"github.com/Jguer/yay/v13/pkg/settings/exe"
+	"github.com/Jguer/yay/v13/pkg/text"
+)
+
+// MinAgeAction describes how minage adjusted a package.
+type MinAgeAction int
+
+const (
+	MinAgeKept MinAgeAction = iota
+	MinAgeDowngraded
+	MinAgeSkipped
+)
+
+// MinAgeEntry records a minage decision for one package.
+type MinAgeEntry struct {
+	Action        MinAgeAction
+	Name          string
+	Version       string
+	RemoteVersion string
+	Age           time.Duration
+	Trigger       string
+	SourcePath    string
+}
+
+// MinAgeAdjuster supplies paths and commands for downgrade lookups.
+type MinAgeAdjuster struct {
+	CacheDirs  []string
+	BuildDir   string
+	AURURL     string
+	PacmanBin  string
+	CmdBuilder exe.ICmdBuilder
+	// DryRun skips cache and AUR downgrade lookups (keep/skip from metadata only).
+	DryRun bool
+}
+
+func packageAge(lastModified int64) time.Duration {
+	if lastModified == 0 {
+		return 0
+	}
+
+	return text.NowFunc().Sub(time.Unix(lastModified, 0))
+}
+
+func packageTooYoung(lastModified int64, minAgeDays int) bool {
+	if minAgeDays <= 0 || lastModified == 0 {
+		return false
+	}
+
+	return packageAge(lastModified) < time.Duration(minAgeDays)*24*time.Hour
+}
+
+// ApplyMinAge keeps, downgrades, or removes packages younger than minAgeDays.
+// pacmanIgnore lists repo packages pacman -u must skip (kept or cache-installed).
+func ApplyMinAge(ctx context.Context, graph *topo.Graph[string, *dep.InstallInfo],
+	minAgeDays int, adj *MinAgeAdjuster,
+) (report []MinAgeEntry, pacmanIgnore []string) {
+	if minAgeDays <= 0 || graph == nil || adj == nil {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+
+	for {
+		trigger, triggerInfo := findYoungPackage(graph, minAgeDays)
+		if trigger == "" {
+			break
+		}
+
+		if triggerInfo.Upgrade && triggerInfo.LocalVersion != "" {
+			remote := triggerInfo.Version
+			for _, name := range graph.Prune(trigger) {
+				if name == trigger {
+					report = append(report, MinAgeEntry{
+						Action:        MinAgeKept,
+						Name:          name,
+						Version:       triggerInfo.LocalVersion,
+						RemoteVersion: remote,
+						Age:           packageAge(triggerInfo.LastModified),
+					})
+					pacmanIgnore = append(pacmanIgnore, name)
+				} else {
+					recordMinAgePrune(&report, seen, name, trigger, triggerInfo)
+				}
+			}
+
+			continue
+		}
+
+		if !adj.DryRun {
+			if path, version, built, ok := FindEligibleCachePackage(ctx, adj.CmdBuilder, adj.PacmanBin,
+				adj.CacheDirs, trigger, minAgeDays); ok {
+				oldRemote := triggerInfo.Version
+				triggerInfo.Version = version
+				triggerInfo.LastModified = built
+				triggerInfo.PkgArchive = path
+				triggerInfo.Upgrade = false
+				report = append(report, MinAgeEntry{
+					Action:        MinAgeDowngraded,
+					Name:          trigger,
+					Version:       version,
+					RemoteVersion: oldRemote,
+					Age:           packageAge(built),
+					SourcePath:    path,
+				})
+				pacmanIgnore = append(pacmanIgnore, trigger)
+
+				continue
+			}
+
+			if triggerInfo.Source == dep.AUR && triggerInfo.AURBase != "" && adj.CmdBuilder != nil {
+				if gitRef, version, built, ok := findAURVersionBefore(ctx, adj.CmdBuilder,
+					adj.AURURL, adj.BuildDir, triggerInfo.AURBase, minAgeDays); ok {
+					oldRemote := triggerInfo.Version
+					triggerInfo.Version = version
+					triggerInfo.LastModified = built
+					triggerInfo.AURGitRef = gitRef
+					triggerInfo.Upgrade = false
+					report = append(report, MinAgeEntry{
+						Action:        MinAgeDowngraded,
+						Name:          trigger,
+						Version:       version,
+						RemoteVersion: oldRemote,
+						Age:           packageAge(built),
+						SourcePath:    gitRef,
+					})
+
+					continue
+				}
+			}
+		}
+
+		for _, name := range graph.Prune(trigger) {
+			recordMinAgePrune(&report, seen, name, trigger, triggerInfo)
+		}
+	}
+
+	return report, pacmanIgnore
+}
+
+func findYoungPackage(graph *topo.Graph[string, *dep.InstallInfo], minAgeDays int) (string, *dep.InstallInfo) {
+	var young []string
+
+	_ = graph.ForEach(func(name string, info *dep.InstallInfo) error {
+		if info.Source == dep.Local || info.Source == dep.Missing {
+			return nil
+		}
+
+		if packageTooYoung(info.LastModified, minAgeDays) {
+			young = append(young, name)
+		}
+
+		return nil
+	})
+
+	if len(young) == 0 {
+		return "", nil
+	}
+
+	slices.Sort(young)
+	trigger := young[0]
+
+	return trigger, graph.GetNodeInfo(trigger).Value
+}
+
+func recordMinAgePrune(report *[]MinAgeEntry, seen map[string]struct{}, name, trigger string,
+	triggerInfo *dep.InstallInfo,
+) {
+	if _, ok := seen[name]; ok {
+		return
+	}
+
+	seen[name] = struct{}{}
+	entry := MinAgeEntry{
+		Action: MinAgeSkipped,
+		Name:   name,
+	}
+	if name == trigger {
+		entry.Age = packageAge(triggerInfo.LastModified)
+	} else {
+		entry.Trigger = trigger
+	}
+
+	*report = append(*report, entry)
+}
+
+func minAgeSectionHeader(action MinAgeAction, count, minAgeDays int) string {
+	switch action {
+	case MinAgeKept:
+		return gotext.Get("%s kept at current version (remote newer than %d days).",
+			gotext.GetN("package", "packages", count), minAgeDays)
+	case MinAgeDowngraded:
+		return gotext.Get("%s downgraded to meet minimum age (%d days).",
+			gotext.GetN("package", "packages", count), minAgeDays)
+	case MinAgeSkipped:
+		return gotext.Get("%s skipped (no version old enough, minimum %d days).",
+			gotext.GetN("package", "packages", count), minAgeDays)
+	default:
+		return ""
+	}
+}
+
+// PrintMinAgeReport prints minage adjustments.
+func PrintMinAgeReport(logger *text.Logger, report []MinAgeEntry, minAgeDays int) {
+	if len(report) == 0 {
+		return
+	}
+
+	counts := make(map[MinAgeAction]int, 3)
+	for i := range report {
+		counts[report[i].Action]++
+	}
+
+	for _, action := range []MinAgeAction{MinAgeKept, MinAgeDowngraded, MinAgeSkipped} {
+		count := counts[action]
+		if count == 0 {
+			continue
+		}
+
+		logger.Printf("%s"+text.Bold(" %d ")+"%s\n", text.Bold(text.Cyan("::")),
+			count, text.Bold(minAgeSectionHeader(action, count, minAgeDays)))
+		printMinAgeEntries(logger, report, action, minAgeDays)
+	}
+
+	logger.Println()
+}
+
+func printMinAgeEntries(logger *text.Logger, report []MinAgeEntry, action MinAgeAction, minAgeDays int) {
+	for i := range report {
+		entry := &report[i]
+		if entry.Action != action {
+			continue
+		}
+
+		line := fmt.Sprintf("  %s", text.Bold(entry.Name))
+		switch entry.Action {
+		case MinAgeKept:
+			line += " — " + gotext.Get("keeping %s (remote %s is %s old)",
+				text.Bold(entry.Version), text.Bold(entry.RemoteVersion),
+				text.Bold(text.FormatDuration(entry.Age)))
+		case MinAgeDowngraded:
+			line += " — " + gotext.Get("%s -> %s (%s old)",
+				text.Bold(entry.RemoteVersion), text.Bold(entry.Version),
+				text.Bold(text.FormatDuration(entry.Age)))
+			if entry.SourcePath != "" && entry.SourcePath[0] == '/' {
+				line += " [" + entry.SourcePath + "]"
+			}
+		case MinAgeSkipped:
+			if entry.Trigger != "" {
+				line += " — " + gotext.Get("skipped: dependency %s is younger than %d days",
+					text.Bold(entry.Trigger), minAgeDays)
+			} else {
+				line += " — " + gotext.Get("package is %s old (minimum %d days)",
+					text.Bold(text.FormatDuration(entry.Age)), minAgeDays)
+			}
+		}
+
+		logger.Println(line)
+	}
+}

--- a/pkg/upgrade/age_test.go
+++ b/pkg/upgrade/age_test.go
@@ -1,0 +1,423 @@
+//go:build !integration
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v13/pkg/dep"
+	"github.com/Jguer/yay/v13/pkg/dep/topo"
+	"github.com/Jguer/yay/v13/pkg/settings/exe"
+	"github.com/Jguer/yay/v13/pkg/text"
+)
+
+func TestApplyMinAge_skipYoung(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	newPkg := now.Add(-2 * day).Unix()
+
+	graph := dep.NewGraph()
+	graph.AddNode("new")
+	graph.SetNodeInfo("new", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{Source: dep.AUR, LastModified: newPkg, Upgrade: true},
+	})
+
+	report, _ := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{})
+	require.Equal(t, 0, graph.Len())
+	require.Len(t, report, 1)
+	require.Equal(t, MinAgeSkipped, report[0].Action)
+}
+
+func TestApplyMinAge_keepUpgrade(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	newPkg := now.Add(-2 * day).Unix()
+
+	graph := dep.NewGraph()
+	graph.AddNode("yay")
+	graph.SetNodeInfo("yay", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{
+			Source:       dep.AUR,
+			LastModified: newPkg,
+			Upgrade:      true,
+			LocalVersion: "12.0.0-1",
+			Version:      "12.1.0-1",
+		},
+	})
+
+	report, ignore := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{})
+	require.Equal(t, 0, graph.Len())
+	require.Len(t, report, 1)
+	require.Equal(t, MinAgeKept, report[0].Action)
+	require.Equal(t, "12.0.0-1", report[0].Version)
+	require.Equal(t, []string{"yay"}, ignore)
+}
+
+func TestApplyMinAge_unknownAgeAllowed(t *testing.T) {
+	t.Parallel()
+
+	graph := dep.NewGraph()
+	graph.AddNode("sync-pkg")
+	graph.SetNodeInfo("sync-pkg", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{Source: dep.Sync, LastModified: 0, Upgrade: true},
+	})
+
+	report, _ := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{})
+	require.Empty(t, report)
+	require.Equal(t, 1, graph.Len())
+}
+
+func TestApplyMinAge_disabled(t *testing.T) {
+	t.Parallel()
+
+	graph := dep.NewGraph()
+	graph.AddNode("pkg")
+	graph.SetNodeInfo("pkg", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{Source: dep.AUR, LastModified: time.Now().Unix()},
+	})
+
+	report, ignore := ApplyMinAge(context.Background(), graph, 0, &MinAgeAdjuster{})
+	require.Nil(t, report)
+	require.Nil(t, ignore)
+	require.Equal(t, 1, graph.Len())
+}
+
+func TestApplyMinAge_downgradeCache(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	newPkg := now.Add(-2 * day).Unix()
+	oldBuilt := now.Add(-30 * day).Unix()
+
+	cacheDir := t.TempDir()
+	pkgPath := filepath.Join(cacheDir, "foo-1.0.0-1-x86_64.pkg.tar.zst")
+	require.NoError(t, os.WriteFile(pkgPath, []byte("x"), 0o600))
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			return fmt.Sprintf("foo|1.0.0-1|%d", oldBuilt), "", nil
+		},
+	}
+
+	graph := dep.NewGraph()
+	info := &dep.InstallInfo{
+		Source:       dep.Sync,
+		LastModified: newPkg,
+		Version:      "2.0.0-1",
+		Upgrade:      true,
+	}
+	graph.AddNode("foo")
+	graph.SetNodeInfo("foo", &topo.NodeInfo[*dep.InstallInfo]{Value: info})
+
+	report, ignore := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{
+		CacheDirs:  []string{cacheDir},
+		PacmanBin:  "pacman",
+		CmdBuilder: &exe.MockBuilder{Runner: runner},
+	})
+	require.Len(t, report, 1)
+	require.Equal(t, MinAgeDowngraded, report[0].Action)
+	require.Equal(t, "1.0.0-1", report[0].Version)
+	require.Equal(t, pkgPath, info.PkgArchive)
+	require.Equal(t, "1.0.0-1", info.Version)
+	require.False(t, info.Upgrade)
+	require.Equal(t, []string{"foo"}, ignore)
+	require.Equal(t, 1, graph.Len())
+}
+
+func TestApplyMinAge_downgradeAUR(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	buildDir := t.TempDir()
+	pkgDir := filepath.Join(buildDir, "foobase")
+	require.NoError(t, os.MkdirAll(filepath.Join(pkgDir, ".git"), 0o755))
+
+	newPkg := now.Add(-2 * day).Unix()
+	oldTS := now.Add(-30 * day).Unix()
+	commit := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			joined := strings.Join(cmd.Args, " ")
+			switch {
+			case strings.Contains(joined, " pull "):
+				return "", "", nil
+			case strings.Contains(joined, " log "):
+				return fmt.Sprintf("%d %s", oldTS, commit), "", nil
+			case strings.Contains(joined, " show "):
+				return testAURSrcinfo, "", nil
+			default:
+				return "", "", fmt.Errorf("unexpected command: %s", joined)
+			}
+		},
+	}
+
+	graph := dep.NewGraph()
+	info := &dep.InstallInfo{
+		Source:       dep.AUR,
+		AURBase:      "foobase",
+		LastModified: newPkg,
+		Version:      "9.9.9-1",
+		Upgrade:      true,
+	}
+	graph.AddNode("foobase")
+	graph.SetNodeInfo("foobase", &topo.NodeInfo[*dep.InstallInfo]{Value: info})
+
+	report, ignore := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{
+		BuildDir:   buildDir,
+		AURURL:     "https://aur.archlinux.org",
+		CmdBuilder: &exe.MockBuilder{Runner: runner},
+	})
+	require.Len(t, report, 1)
+	require.Equal(t, MinAgeDowngraded, report[0].Action)
+	require.Equal(t, "1.2.3-2", report[0].Version)
+	require.Equal(t, commit, info.AURGitRef)
+	require.Equal(t, "1.2.3-2", info.Version)
+	require.False(t, info.Upgrade)
+	require.Empty(t, ignore)
+	require.Equal(t, 1, graph.Len())
+}
+
+func TestApplyMinAge_skipDependent(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	youngPkg := now.Add(-2 * day).Unix()
+	oldPkg := now.Add(-30 * day).Unix()
+
+	graph := dep.NewGraph()
+	graph.AddNode("young-lib")
+	graph.SetNodeInfo("young-lib", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{Source: dep.Sync, LastModified: youngPkg, Upgrade: true, Version: "2.0.0-1"},
+	})
+	graph.AddNode("app")
+	graph.SetNodeInfo("app", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{Source: dep.Sync, LastModified: oldPkg, Upgrade: true, Version: "1.0.0-1"},
+	})
+	require.NoError(t, graph.DependOn("app", "young-lib"))
+
+	report, _ := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{})
+	require.Equal(t, 0, graph.Len())
+	require.Len(t, report, 2)
+
+	byName := make(map[string]MinAgeEntry, len(report))
+	for i := range report {
+		byName[report[i].Name] = report[i]
+	}
+
+	require.Equal(t, MinAgeSkipped, byName["young-lib"].Action)
+	require.Equal(t, MinAgeSkipped, byName["app"].Action)
+	require.Equal(t, "young-lib", byName["app"].Trigger)
+}
+
+func TestApplyMinAge_dryRunSkipsDowngrade(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	newPkg := now.Add(-2 * day).Unix()
+
+	cacheDir := t.TempDir()
+	pkgPath := filepath.Join(cacheDir, "foo-1.0.0-1-x86_64.pkg.tar.zst")
+	require.NoError(t, os.WriteFile(pkgPath, []byte("x"), 0o600))
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			return "", "", fmt.Errorf("dry run must not query cache: %v", cmd.Args)
+		},
+	}
+
+	graph := dep.NewGraph()
+	graph.AddNode("foo")
+	graph.SetNodeInfo("foo", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{
+			Source:       dep.Sync,
+			LastModified: newPkg,
+			Version:      "2.0.0-1",
+			Upgrade:      true,
+		},
+	})
+
+	report, _ := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{
+		CacheDirs:  []string{cacheDir},
+		PacmanBin:  "pacman",
+		CmdBuilder: &exe.MockBuilder{Runner: runner},
+		DryRun:     true,
+	})
+	require.Equal(t, 0, graph.Len())
+	require.Len(t, report, 1)
+	require.Equal(t, MinAgeSkipped, report[0].Action)
+}
+
+func TestFindYoungPackage_lexicographic(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	young := now.Add(-2 * day).Unix()
+
+	graph := dep.NewGraph()
+	for _, name := range []string{"zzz", "aaa"} {
+		graph.AddNode(name)
+		graph.SetNodeInfo(name, &topo.NodeInfo[*dep.InstallInfo]{
+			Value: &dep.InstallInfo{Source: dep.Sync, LastModified: young, Upgrade: true},
+		})
+	}
+
+	name, _ := findYoungPackage(graph, 7)
+	require.Equal(t, "aaa", name)
+}
+
+func TestApplyMinAge_keepUpgradePrunesDependent(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	youngPkg := now.Add(-2 * day).Unix()
+	oldPkg := now.Add(-30 * day).Unix()
+
+	graph := dep.NewGraph()
+	graph.AddNode("yay")
+	graph.SetNodeInfo("yay", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{
+			Source:       dep.AUR,
+			LastModified: youngPkg,
+			Upgrade:      true,
+			LocalVersion: "12.0.0-1",
+			Version:      "12.1.0-1",
+		},
+	})
+	graph.AddNode("makedep")
+	graph.SetNodeInfo("makedep", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{Source: dep.Sync, LastModified: oldPkg, Upgrade: true, Version: "1.0.0-1"},
+	})
+	require.NoError(t, graph.DependOn("yay", "makedep"))
+
+	report, _ := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{})
+	require.Equal(t, 0, graph.Len())
+	require.Len(t, report, 2)
+
+	byName := make(map[string]MinAgeEntry, len(report))
+	for i := range report {
+		byName[report[i].Name] = report[i]
+	}
+
+	require.Equal(t, MinAgeKept, byName["yay"].Action)
+	require.Equal(t, MinAgeSkipped, byName["makedep"].Action)
+	require.Equal(t, "yay", byName["makedep"].Trigger)
+}
+
+func TestApplyMinAge_dryRunSkipsAUR(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	buildDir := t.TempDir()
+	pkgDir := filepath.Join(buildDir, "foobase")
+	require.NoError(t, os.MkdirAll(filepath.Join(pkgDir, ".git"), 0o755))
+
+	newPkg := now.Add(-2 * day).Unix()
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			return "", "", fmt.Errorf("dry run must not query AUR git: %v", cmd.Args)
+		},
+	}
+
+	graph := dep.NewGraph()
+	graph.AddNode("foobase")
+	graph.SetNodeInfo("foobase", &topo.NodeInfo[*dep.InstallInfo]{
+		Value: &dep.InstallInfo{
+			Source:       dep.AUR,
+			AURBase:      "foobase",
+			LastModified: newPkg,
+			Version:      "9.9.9-1",
+			Upgrade:      true,
+		},
+	})
+
+	report, _ := ApplyMinAge(context.Background(), graph, 7, &MinAgeAdjuster{
+		BuildDir:   buildDir,
+		AURURL:     "https://aur.archlinux.org",
+		CmdBuilder: &exe.MockBuilder{Runner: runner},
+		DryRun:     true,
+	})
+	require.Equal(t, 0, graph.Len())
+	require.Len(t, report, 1)
+	require.Equal(t, MinAgeSkipped, report[0].Action)
+}
+
+func TestPrintMinAgeReport(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	var buf strings.Builder
+	logger := text.NewLogger(&buf, io.Discard, strings.NewReader(""), false, "test")
+
+	PrintMinAgeReport(logger, []MinAgeEntry{
+		{
+			Action:        MinAgeKept,
+			Name:          "yay",
+			Version:       "12.0.0-1",
+			RemoteVersion: "12.1.0-1",
+			Age:           2 * day,
+		},
+		{
+			Action:        MinAgeDowngraded,
+			Name:          "foo",
+			Version:       "1.0.0-1",
+			RemoteVersion: "2.0.0-1",
+			Age:           30 * day,
+			SourcePath:    "/var/cache/pacman/pkg/foo.pkg.tar.zst",
+		},
+		{
+			Action:  MinAgeSkipped,
+			Name:    "app",
+			Trigger: "young-lib",
+		},
+	}, 7)
+
+	out := buf.String()
+	require.Contains(t, out, "yay")
+	require.Contains(t, out, "foo")
+	require.Contains(t, out, "app")
+	require.Contains(t, out, "young-lib")
+}

--- a/pkg/upgrade/aur_age.go
+++ b/pkg/upgrade/aur_age.go
@@ -1,0 +1,82 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	gosrc "github.com/Morganamilo/go-srcinfo"
+
+	"github.com/Jguer/yay/v13/pkg/download"
+	"github.com/Jguer/yay/v13/pkg/settings/exe"
+	"github.com/Jguer/yay/v13/pkg/text"
+)
+
+func findAURVersionBefore(ctx context.Context, cmdBuilder exe.ICmdBuilder, aurURL, buildDir, base string,
+	minAgeDays int,
+) (gitRef, version string, lastModified int64, ok bool) {
+	if minAgeDays <= 0 || base == "" {
+		return "", "", 0, false
+	}
+
+	pkgDir := filepath.Join(buildDir, base)
+	if _, err := download.AURPKGBUILDRepo(ctx, cmdBuilder, aurURL, base, buildDir, false); err != nil {
+		return "", "", 0, false
+	}
+
+	cutoff := text.NowFunc().Add(-time.Duration(minAgeDays) * 24 * time.Hour)
+	before := cutoff.UTC().Format(time.RFC3339)
+
+	logCmd := cmdBuilder.BuildGitCmd(ctx, pkgDir, "log", "--before="+before, "-1", "--format=%at %H")
+	stdout, _, err := cmdBuilder.Capture(logCmd)
+	if err != nil {
+		return "", "", 0, false
+	}
+
+	fields := strings.Fields(strings.TrimSpace(stdout))
+	if len(fields) != 2 {
+		return "", "", 0, false
+	}
+
+	ts, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return "", "", 0, false
+	}
+
+	commit := fields[1]
+	showCmd := cmdBuilder.BuildGitCmd(ctx, pkgDir, "show", commit+":.SRCINFO")
+	srcinfoOut, _, err := cmdBuilder.Capture(showCmd)
+	if err != nil {
+		return "", "", 0, false
+	}
+
+	srcinfo, err := gosrc.Parse(srcinfoOut)
+	if err != nil {
+		return "", "", 0, false
+	}
+
+	return commit, srcinfo.Version(), ts, true
+}
+
+// CheckoutAURGitRef checks out a pinned AUR commit in an existing clone.
+func CheckoutAURGitRef(ctx context.Context, cmdBuilder exe.ICmdBuilder, pkgDir, gitRef string) error {
+	if gitRef == "" {
+		return nil
+	}
+
+	if _, err := os.Stat(filepath.Join(pkgDir, ".git")); err != nil {
+		return fmt.Errorf("aur git ref %s: %w", gitRef, err)
+	}
+
+	cmd := cmdBuilder.BuildGitCmd(ctx, pkgDir, "checkout", gitRef)
+	_, stderr, err := cmdBuilder.Capture(cmd)
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, stderr)
+	}
+
+	return nil
+}

--- a/pkg/upgrade/aur_age_test.go
+++ b/pkg/upgrade/aur_age_test.go
@@ -1,0 +1,141 @@
+//go:build !integration
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v13/pkg/settings/exe"
+	"github.com/Jguer/yay/v13/pkg/text"
+)
+
+const testAURSrcinfo = `pkgbase = foobase
+pkgver = 1.2.3
+pkgrel = 2
+arch = x86_64
+
+pkgname = foobase
+`
+
+func TestFindAURVersionBefore(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	buildDir := t.TempDir()
+	pkgDir := filepath.Join(buildDir, "foobase")
+	require.NoError(t, os.MkdirAll(filepath.Join(pkgDir, ".git"), 0o755))
+
+	oldTS := now.Add(-30 * day).Unix()
+	commit := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			joined := strings.Join(cmd.Args, " ")
+			switch {
+			case strings.Contains(joined, " pull "):
+				return "", "", nil
+			case strings.Contains(joined, " log "):
+				return fmt.Sprintf("%d %s", oldTS, commit), "", nil
+			case strings.Contains(joined, " show "):
+				return testAURSrcinfo, "", nil
+			default:
+				return "", "", fmt.Errorf("unexpected command: %s", joined)
+			}
+		},
+	}
+
+	gitRef, version, built, ok := findAURVersionBefore(
+		context.Background(),
+		&exe.MockBuilder{Runner: runner},
+		"https://aur.archlinux.org",
+		buildDir,
+		"foobase",
+		7,
+	)
+	require.True(t, ok)
+	require.Equal(t, commit, gitRef)
+	require.Equal(t, "1.2.3-2", version)
+	require.Equal(t, oldTS, built)
+}
+
+func TestFindAURVersionBefore_noHistory(t *testing.T) {
+	t.Parallel()
+
+	buildDir := t.TempDir()
+	pkgDir := filepath.Join(buildDir, "foobase")
+	require.NoError(t, os.MkdirAll(filepath.Join(pkgDir, ".git"), 0o755))
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			joined := strings.Join(cmd.Args, " ")
+			switch {
+			case strings.Contains(joined, " pull "):
+				return "", "", nil
+			case strings.Contains(joined, " log "):
+				return "", "", nil
+			default:
+				return "", "", fmt.Errorf("unexpected command: %s", joined)
+			}
+		},
+	}
+
+	gitRef, version, built, ok := findAURVersionBefore(
+		context.Background(),
+		&exe.MockBuilder{Runner: runner},
+		"https://aur.archlinux.org",
+		buildDir,
+		"foobase",
+		7,
+	)
+	require.False(t, ok)
+	require.Empty(t, gitRef)
+	require.Empty(t, version)
+	require.Zero(t, built)
+}
+
+func TestCheckoutAURGitRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty ref", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, CheckoutAURGitRef(context.Background(), &exe.MockBuilder{}, t.TempDir(), ""))
+	})
+
+	t.Run("missing git dir", func(t *testing.T) {
+		t.Parallel()
+		err := CheckoutAURGitRef(context.Background(), &exe.MockBuilder{}, t.TempDir(), "abc")
+		require.Error(t, err)
+	})
+
+	t.Run("checkout", func(t *testing.T) {
+		t.Parallel()
+
+		pkgDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(pkgDir, ".git"), 0o755))
+
+		checkedOut := ""
+		runner := &exe.MockRunner{
+			CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+				require.Contains(t, strings.Join(cmd.Args, " "), " checkout abc")
+				checkedOut = "abc"
+
+				return "", "", nil
+			},
+		}
+
+		require.NoError(t, CheckoutAURGitRef(context.Background(), &exe.MockBuilder{Runner: runner}, pkgDir, "abc"))
+		require.Equal(t, "abc", checkedOut)
+	})
+}

--- a/pkg/upgrade/cache.go
+++ b/pkg/upgrade/cache.go
@@ -1,0 +1,74 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Jguer/yay/v13/pkg/db"
+	"github.com/Jguer/yay/v13/pkg/settings/exe"
+	"github.com/Jguer/yay/v13/pkg/text"
+)
+
+func pacmanQueryFile(ctx context.Context, cmdBuilder exe.ICmdBuilder, pacmanBin, pkgPath string) (
+	name, version string, buildTime int64, err error,
+) {
+	cmd := exec.CommandContext(ctx, pacmanBin, "-Qp", "--print-format", "%n|%v|%t", pkgPath)
+	stdout, _, err := cmdBuilder.Capture(cmd)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	parts := strings.Split(strings.TrimSpace(stdout), "|")
+	if len(parts) != 3 {
+		return "", "", 0, fmt.Errorf("unexpected pacman -Qp output: %q", stdout)
+	}
+
+	ts, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	return parts[0], parts[1], ts, nil
+}
+
+// FindEligibleCachePackage returns the newest pacman-cached package at least minAgeDays old.
+func FindEligibleCachePackage(ctx context.Context, cmdBuilder exe.ICmdBuilder, pacmanBin string, cacheDirs []string,
+	pkgName string, minAgeDays int,
+) (path, version string, buildTime int64, ok bool) {
+	if minAgeDays <= 0 || len(cacheDirs) == 0 || pacmanBin == "" {
+		return "", "", 0, false
+	}
+
+	cutoff := text.NowFunc().Add(-time.Duration(minAgeDays) * 24 * time.Hour)
+	var bestPath, bestVersion string
+	var bestTime int64
+
+	for _, dir := range cacheDirs {
+		matches, err := filepath.Glob(filepath.Join(dir, pkgName+"-*.pkg.tar*"))
+		if err != nil {
+			continue
+		}
+
+		for _, candidate := range matches {
+			name, ver, built, errQ := pacmanQueryFile(ctx, cmdBuilder, pacmanBin, candidate)
+			if errQ != nil || name != pkgName || built == 0 || time.Unix(built, 0).After(cutoff) {
+				continue
+			}
+
+			if bestPath == "" || db.VerCmp(ver, bestVersion) > 0 {
+				bestPath, bestVersion, bestTime = candidate, ver, built
+			}
+		}
+	}
+
+	if bestPath == "" {
+		return "", "", 0, false
+	}
+
+	return bestPath, bestVersion, bestTime, true
+}

--- a/pkg/upgrade/cache_test.go
+++ b/pkg/upgrade/cache_test.go
@@ -1,0 +1,119 @@
+//go:build !integration
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v13/pkg/settings/exe"
+	"github.com/Jguer/yay/v13/pkg/text"
+)
+
+func TestFindEligibleCachePackage(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	oldBuilt := now.Add(-30 * day).Unix()
+	recentBuilt := now.Add(-2 * day).Unix()
+
+	cacheDir := t.TempDir()
+	oldPkg := filepath.Join(cacheDir, "foo-1.0.0-1-x86_64.pkg.tar.zst")
+	newerOldPkg := filepath.Join(cacheDir, "foo-1.1.0-1-x86_64.pkg.tar.zst")
+	recentPkg := filepath.Join(cacheDir, "foo-2.0.0-1-x86_64.pkg.tar.zst")
+
+	require.NoError(t, os.WriteFile(oldPkg, []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(newerOldPkg, []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(recentPkg, []byte("x"), 0o600))
+
+	query := map[string]struct {
+		version string
+		built   int64
+	}{
+		oldPkg:      {"1.0.0-1", oldBuilt},
+		newerOldPkg: {"1.1.0-1", oldBuilt},
+		recentPkg:   {"2.0.0-1", recentBuilt},
+	}
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			if !strings.Contains(strings.Join(cmd.Args, " "), "-Qp") {
+				return "", "", fmt.Errorf("unexpected command: %v", cmd.Args)
+			}
+
+			info, ok := query[cmd.Args[len(cmd.Args)-1]]
+			if !ok {
+				return "", "", fmt.Errorf("unexpected package path: %s", cmd.Args[len(cmd.Args)-1])
+			}
+
+			return fmt.Sprintf("foo|%s|%d", info.version, info.built), "", nil
+		},
+	}
+
+	path, version, built, ok := FindEligibleCachePackage(
+		context.Background(),
+		&exe.MockBuilder{Runner: runner},
+		"pacman",
+		[]string{cacheDir},
+		"foo",
+		7,
+	)
+	require.True(t, ok)
+	require.Equal(t, newerOldPkg, path)
+	require.Equal(t, "1.1.0-1", version)
+	require.Equal(t, oldBuilt, built)
+}
+
+func TestFindEligibleCachePackage_noEligible(t *testing.T) {
+	t.Parallel()
+
+	const day = 24 * time.Hour
+	now := time.Unix(1_700_000_000, 0)
+	text.NowFunc = func() time.Time { return now }
+
+	recentBuilt := now.Add(-2 * day).Unix()
+	cacheDir := t.TempDir()
+	recentPkg := filepath.Join(cacheDir, "foo-2.0.0-1-x86_64.pkg.tar.zst")
+	require.NoError(t, os.WriteFile(recentPkg, []byte("x"), 0o600))
+
+	runner := &exe.MockRunner{
+		CaptureFn: func(cmd *exec.Cmd) (string, string, error) {
+			return fmt.Sprintf("foo|2.0.0-1|%d", recentBuilt), "", nil
+		},
+	}
+
+	path, version, built, ok := FindEligibleCachePackage(
+		context.Background(),
+		&exe.MockBuilder{Runner: runner},
+		"pacman",
+		[]string{cacheDir},
+		"foo",
+		7,
+	)
+	require.False(t, ok)
+	require.Empty(t, path)
+	require.Empty(t, version)
+	require.Zero(t, built)
+}
+
+func TestFindEligibleCachePackage_disabled(t *testing.T) {
+	t.Parallel()
+
+	path, version, built, ok := FindEligibleCachePackage(
+		context.Background(), nil, "pacman", []string{"/var/cache/pacman/pkg"}, "foo", 0)
+	require.False(t, ok)
+	require.Empty(t, path)
+	require.Empty(t, version)
+	require.Zero(t, built)
+}

--- a/print.go
+++ b/print.go
@@ -146,6 +146,10 @@ func printUpdateList(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.
 		return errSysUp
 	}
 
+	if run.Cfg.MinAge > 0 {
+		applyMinAge(ctx, run, cmdArgs, graph, true)
+	}
+
 	if graph.Len() == 0 {
 		return fmt.Errorf("")
 	}

--- a/sync.go
+++ b/sync.go
@@ -69,10 +69,14 @@ func syncInstall(ctx context.Context,
 
 		upService.AURWarnings.Print()
 
+		minAgeIgnore := applyMinAge(ctx, run, cmdArgs, graph, false)
+
 		excluded, errSysUp = upService.UserExcludeUpgrades(graph)
 		if errSysUp != nil {
 			return errSysUp
 		}
+
+		excluded = append(excluded, minAgeIgnore...)
 	}
 
 	opService := sync.NewOperationService(ctx, dbExecutor, run)


### PR DESCRIPTION
Add --minage option so upgrades prefer package versions that are at least N days old. This lets users avoid pulling in freshly released builds that had no time to get bug reports.

- Track a last-modified timestamp on synced packages to compute age.
- On sysupgrade or dry-run print, walk the dependency graph and, for each package younger than the minimum age, keep the local version, downgrade to an older cached or AUR build, or skip it along with its dependents.
- Fetch older AUR versions by checking package git history and pin the resolved commit before build.
- Install downgraded sync packages from the local pacman cache and restore their original install reason.
- Report kept, downgraded, and skipped packages before the actual upgrade runs.
- Exclude minage-adjusted packages from pacman own upgrade pass so the chosen older versions are not overwritten.