### PR TITLE
feat: add minage lua hook example for aur upgrade filtering

### DIFF
--- a/doc/examples/minage.lua
+++ b/doc/examples/minage.lua
@@ -1,0 +1,90 @@
+-- Exclude AUR upgrades younger than a minimum age (minage policy).
+--
+-- Enable from init.lua:
+--   require("hooks.minage")
+-- after copying this file to <config_dir>/hooks/minage.lua
+--
+-- What this hook does (via UpgradeSelect):
+--   * Skips AUR/devel upgrades whose last_modified is newer than min_age_days.
+--   * Keeps the installed version when local_version is set.
+--   * Prunes pulled dependencies when an excluded upgrade requires it.
+--
+-- Limitations (hook API / yay data):
+--   * Repo/sync upgrades have no last_modified in UpgradeSelect today; they are not filtered.
+--   * Young packages in pulled_dependencies cannot be excluded (only warned); exclude only
+--     accepts names from event.data.upgrades.
+--   * No downgrade to an older pacman cache or AUR git commit.
+--   * Does not run for yay -Qu (upgrade list only).
+--
+-- Hook design gaps compared to a core minage feature:
+--   * UpgradeSelect only receives direct upgrade candidates, not a mutable graph.
+--   * No way to pass a chosen older version or cache path back to yay.
+
+local min_age_days = 3
+-- false keeps yay's native exclusion menu and partial-upgrade warning (safer default).
+local skip_menu = false
+
+local SECONDS_PER_DAY = 24 * 60 * 60
+
+local function is_aur_upgrade(repository)
+  return repository == "aur" or repository == "devel"
+end
+
+local function package_too_young(last_modified, cutoff)
+  return last_modified > 0 and last_modified >= cutoff
+end
+
+local function format_age_days(last_modified)
+  local age = (os.time() - last_modified) / SECONDS_PER_DAY
+  if age < 0 then
+    return 0
+  end
+  return age
+end
+
+local function log_young_pkg(pkg, age_days, action)
+  if pkg.local_version ~= "" then
+    yay.log.warn(string.format(
+      "minage: %s %s at %s (remote %s is only %.1f days old, minimum %d)",
+      action, pkg.name, pkg.local_version, pkg.remote_version, age_days, min_age_days))
+  else
+    yay.log.warn(string.format(
+      "minage: %s %s (%s, only %.1f days old, minimum %d)",
+      action, pkg.name, pkg.remote_version, age_days, min_age_days))
+  end
+end
+
+yay.create_autocmd("UpgradeSelect", {
+  desc = "exclude AUR upgrades younger than min_age_days",
+  callback = function(event)
+    if min_age_days <= 0 then
+      return { exclude = {}, skip_menu = false }
+    end
+
+    local upgrades = event.data and event.data.upgrades or {}
+    local pulled = event.data and event.data.pulled_dependencies or {}
+    local cutoff = os.time() - (min_age_days * SECONDS_PER_DAY)
+    local exclude = {}
+
+    for _, pkg in ipairs(upgrades) do
+      if is_aur_upgrade(pkg.repository) and package_too_young(pkg.last_modified, cutoff) then
+        local action = pkg.local_version ~= "" and "keeping" or "excluding"
+        log_young_pkg(pkg, format_age_days(pkg.last_modified), action)
+        exclude[#exclude + 1] = pkg.name
+      end
+    end
+
+    for _, pkg in ipairs(pulled) do
+      if is_aur_upgrade(pkg.repository) and package_too_young(pkg.last_modified, cutoff) then
+        log_young_pkg(pkg, format_age_days(pkg.last_modified),
+          "young pulled dependency (cannot exclude via hook, will still install)")
+      end
+    end
+
+    if #exclude > 0 then
+      yay.log.info(string.format("minage: excluded %d package(s)", #exclude))
+    end
+
+    return { exclude = exclude, skip_menu = skip_menu }
+  end,
+})

--- a/doc/init.lua
+++ b/doc/init.lua
@@ -54,6 +54,13 @@ yay.opt.rpc = true
 yay.opt.double_confirm = true
 
 -- Hooks
+-- Copy an example from doc/examples/ into <config_dir>/hooks/ and require it.
+-- For example, to skip AUR upgrades younger than 7 days (see minage.lua to tune):
+--
+--   require("hooks.minage")
+--
+-- See doc/examples/minage.lua for configuration and hook API limitations.
+--
 -- Run Lua before yay prints the upgrade exclusion menu. Return package names
 -- from event.data.upgrades to pre-exclude them. Set skip_menu = false, or omit
 -- it, to show the native menu after these exclusions are applied.

--- a/doc/lua.md
+++ b/doc/lua.md
@@ -177,7 +177,9 @@ exclusions and skips the native menu. With `skip_menu = false` or no return
 value, hook exclusions are applied first and then the native menu is shown.
 
 More examples: [`doc/examples/recently_modified.lua`](https://github.com/Jguer/yay/blob/next/doc/examples/recently_modified.lua)
-(pre-exclude recently modified AUR upgrades) and
+(pre-exclude recently modified AUR upgrades),
+[`doc/examples/minage.lua`](https://github.com/Jguer/yay/blob/next/doc/examples/minage.lua)
+(skip AUR upgrades younger than a configurable minimum age), and
 [`doc/examples/maintainer_change.lua`](https://github.com/Jguer/yay/blob/next/doc/examples/maintainer_change.lua) (warn on
 AUR maintainer changes).
 


### PR DESCRIPTION
- Add a lua hook example that excludes aur and devel upgrades newer
than a configurable minimum age.
- Document the hook limitations, including missing repo timestamps,
pulled dependency handling, and lack of version downgrade support.
- Reference the new example from init.lua comments and lua hook docs
so users can discover and enable it.