### PR TITLE
Add warnings for recent AUR maintainer changes 

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -391,6 +391,10 @@ func handleSync(ctx context.Context, run *runtime.Runtime, cmdArgs *parser.Argum
 
 	switch {
 	case cmdArgs.ExistsArg("s", "search"):
+		run.RefreshAdoption(ctx, cmdArgs.ExistsArg("y", "refresh"))
+		if b, ok := run.QueryBuilder.(*query.SourceQueryBuilder); ok {
+			b.SetAdoptions(run.AdoptionStore.Active())
+		}
 		return syncSearch(ctx, targets, dbExecutor, run.QueryBuilder, !cmdArgs.ExistsArg("q", "quiet"))
 	case cmdArgs.ExistsArg("p", "print", "print-format"):
 		return run.CmdBuilder.Show(run.CmdBuilder.BuildPacmanCmd(ctx,

--- a/pkg/adoption/adoption.go
+++ b/pkg/adoption/adoption.go
@@ -1,0 +1,235 @@
+// Package adoption tracks recent AUR maintainer changes by diffing periodic
+// snapshots of the bulk metadata archive, and reports them as warnings.
+//
+// NOTE: This is a "workaround," the proper fix is to have the AUR RPC
+// handle maintainership data.
+//
+// Caches package modified time and maintainer, updates on refresh & diffs
+// against the previous capture to flag changes. 
+//
+// Reconstruction has one inherent gap: packages absent from the prior snapshot
+// carry no baseline, so their pre-baseline history cannot be dated. This is the
+// consequence of the AUR not timestamping maintainer changes server-side.
+package adoption
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// StoreFileName is the on-disk name of the persisted store, placed in the cache
+// directory by the caller.
+const StoreFileName = "adoption.json"
+
+const (
+	// Alert the user if the maintainer has changed within the last 30 days. 
+	// Change as you see fit.
+	Window = 30 * 24 * time.Hour
+	// Tolerate a maintainership cache that's no older than 24h before 
+	// refreshing on next search / transaction. Change as you see fit.
+	DefaultMaxAge = 24 * time.Hour
+)
+
+var NowFunc = time.Now
+
+type Kind string
+
+const (
+	// Flags changing from one value to another, be that maintained > orphan
+	// or maintainer A > maintainer B.
+	KindMaintainerChange Kind = "maintainer-change"
+	// Covers if a malactor adopts a package, poisons it, and orphans it immediately.
+	// I encourage further Kind additions of any are thought of. 
+	KindOrphanModified Kind = "orphan-modified"
+)
+
+type Entry struct {
+	Maintainer   string `json:"m"`
+	LastModified int64  `json:"lm"`
+}
+
+type Snapshot struct {
+	ETag         string           `json:"etag"`
+	LastModified time.Time        `json:"last_modified"` // archive Last-Modified header
+	FetchedAt    time.Time        `json:"fetched_at"`
+	Entries      map[string]Entry `json:"entries"`
+}
+
+type Record struct {
+	Kind       Kind      `json:"kind"`
+	From       string    `json:"from"`
+	To         string    `json:"to"`
+	ObservedAt time.Time `json:"observed_at"`
+}
+
+type Store struct {
+	Snapshot Snapshot          `json:"snapshot"`
+	Records  map[string]Record `json:"records"`
+
+	path string
+	mu   sync.Mutex
+}
+
+func NewStore(path string) *Store {
+	return &Store{
+		path:     path,
+		Records:  map[string]Record{},
+		Snapshot: Snapshot{Entries: map[string]Entry{}},
+	}
+}
+
+func (s *Store) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, s); err != nil {
+		return err
+	}
+	if s.Records == nil {
+		s.Records = map[string]Record{}
+	}
+	if s.Snapshot.Entries == nil {
+		s.Snapshot.Entries = map[string]Entry{}
+	}
+	return nil
+}
+
+func (s *Store) Save() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saveLocked()
+}
+
+func (s *Store) saveLocked() error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}
+
+func (s *Store) Validators() (etag string, lastModified time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Snapshot.ETag, s.Snapshot.LastModified
+}
+
+func (s *Store) ShouldRefresh(maxAge time.Duration) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return NowFunc().Sub(s.Snapshot.FetchedAt) >= maxAge
+}
+
+// Apply installs a freshly fetched snapshot, reconstructs transitions against
+// the prior snapshot, records them anchored to observedAt (archive
+// Last-Modified), prunes expired records.
+func (s *Store) Apply(entries map[string]Entry, etag string, archiveLastModified, fetchedAt, observedAt time.Time) (map[string]Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	changes := diff(s.Snapshot.Entries, entries, observedAt)
+	for name, r := range changes {
+		s.Records[name] = r
+	}
+	s.Snapshot = Snapshot{
+		ETag:         etag,
+		LastModified: archiveLastModified,
+		FetchedAt:    fetchedAt,
+		Entries:      entries,
+	}
+	s.pruneLocked()
+	return changes, s.saveLocked()
+}
+
+func (s *Store) Touch(fetchedAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Snapshot.FetchedAt = fetchedAt
+	s.pruneLocked()
+	return s.saveLocked()
+}
+
+// Check single package upon transaction (ex: install), if a transition is found, it's returned.
+func (s *Store) Check(name, maintainer string, lastModified int64, observedAt time.Time) (Record, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur := Entry{Maintainer: maintainer, LastModified: lastModified}
+	prev, seen := s.Snapshot.Entries[name]
+	s.Snapshot.Entries[name] = cur
+	if !seen {
+		return Record{}, false
+	}
+	r, ok := transition(prev, cur, observedAt)
+	if ok {
+		s.Records[name] = r
+	}
+	_ = s.saveLocked()
+	return r, ok
+}
+
+// Current records; prune expired.
+func (s *Store) Active() map[string]Record {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked()
+	out := make(map[string]Record, len(s.Records))
+	for k, v := range s.Records {
+		out[k] = v
+	}
+	return out
+}
+
+func (s *Store) pruneLocked() {
+	cutoff := NowFunc().Add(-Window)
+	for name, r := range s.Records {
+		if r.ObservedAt.Before(cutoff) {
+			delete(s.Records, name)
+		}
+	}
+}
+
+func diff(prev, cur map[string]Entry, observedAt time.Time) map[string]Record {
+	out := make(map[string]Record)
+	for name, c := range cur {
+		p, seen := prev[name]
+		if !seen {
+			continue
+		}
+		if r, ok := transition(p, c, observedAt); ok {
+			out[name] = r
+		}
+	}
+	return out
+}
+
+// We do what we can.
+func transition(prev, cur Entry, observedAt time.Time) (Record, bool) {
+	switch {
+	case prev.Maintainer != cur.Maintainer:
+		return Record{KindMaintainerChange, prev.Maintainer, cur.Maintainer, observedAt}, true
+	case prev.Maintainer == "" && cur.Maintainer == "" && cur.LastModified > prev.LastModified:
+		return Record{KindOrphanModified, "", "", observedAt}, true
+	}
+	return Record{}, false
+}

--- a/pkg/adoption/archive.go
+++ b/pkg/adoption/archive.go
@@ -1,0 +1,156 @@
+package adoption
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const ExtArchiveURL = "https://aur.archlinux.org/packages-meta-ext-v1.json.gz"
+
+type FetchResult struct {
+	Entries      map[string]Entry
+	ETag         string
+	LastModified time.Time
+	NotModified  bool
+}
+
+// Fetch the archive & pull relevant info from it when GET is not 304
+func Fetch(ctx context.Context, client *http.Client, prevETag string, prevLastModified time.Time) (FetchResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ExtArchiveURL, nil)
+	if err != nil {
+		return FetchResult{}, err
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	if prevETag != "" {
+		req.Header.Set("If-None-Match", prevETag)
+	}
+	if !prevLastModified.IsZero() {
+		req.Header.Set("If-Modified-Since", prevLastModified.UTC().Format(http.TimeFormat))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return FetchResult{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified {
+		return FetchResult{NotModified: true}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return FetchResult{}, fmt.Errorf("archive fetch: unexpected status %s", resp.Status)
+	}
+
+	// Explicit header kills net/http. Use gzip instead.
+	zr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("archive gzip: %w", err)
+	}
+	defer zr.Close()
+
+	entries, err := parseEntries(zr)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("archive parse: %w", err)
+	}
+
+	lastModified, _ := http.ParseTime(resp.Header.Get("Last-Modified"))
+	return FetchResult{
+		Entries:      entries,
+		ETag:         resp.Header.Get("ETag"),
+		LastModified: lastModified,
+	}, nil
+}
+
+func parseEntries(r io.Reader) (map[string]Entry, error) {
+	dec := json.NewDecoder(r)
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil, fmt.Errorf("unexpected top-level token %v", tok)
+	}
+
+	out := make(map[string]Entry, 1<<16)
+	consumeArray := func() error {
+		for dec.More() {
+			var p struct {
+				Name         string `json:"Name"`
+				Maintainer   string `json:"Maintainer"`
+				LastModified int64  `json:"LastModified"`
+			}
+			if err := dec.Decode(&p); err != nil {
+				return err
+			}
+			if p.Name != "" {
+				out[p.Name] = Entry{Maintainer: p.Maintainer, LastModified: p.LastModified}
+			}
+		}
+		_, err := dec.Token() // closing ']'
+		return err
+	}
+
+	switch delim {
+	case '[':
+		if err := consumeArray(); err != nil {
+			return nil, err
+		}
+	case '{':
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, _ := keyTok.(string)
+			if key == "results" {
+				t2, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				if d, ok := t2.(json.Delim); !ok || d != '[' {
+					return nil, fmt.Errorf("results is not an array")
+				}
+				if err := consumeArray(); err != nil {
+					return nil, err
+				}
+			} else if err := skipValue(dec); err != nil {
+				return nil, err
+			}
+		}
+		if _, err := dec.Token(); err != nil { // closing '}'
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unexpected delimiter %q", delim)
+	}
+	return out, nil
+}
+
+func skipValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	d, ok := tok.(json.Delim)
+	if !ok {
+		return nil // scalar consumed
+	}
+	for dec.More() {
+		if d == '{' {
+			if _, err := dec.Token(); err != nil { // key
+				return err
+			}
+		}
+		if err := skipValue(dec); err != nil { // value or element
+			return err
+		}
+	}
+	_, err = dec.Token() // closing delim
+	return err
+}

--- a/pkg/adoption/format.go
+++ b/pkg/adoption/format.go
@@ -17,6 +17,16 @@ func FormatWarning(name string, r Record) string {
 	return text.Bold(text.Red(msg))
 }
 
+func FormatTag(r Record) string {
+	age := text.FormatDuration(NowFunc().Sub(r.ObservedAt))
+
+	label := "maintainer changed"
+	if r.Kind == KindOrphanModified {
+		label = "orphan modified"
+	}
+	return text.Bold(text.Red("(" + label + " " + age + " ago)"))
+}
+
 func maintainerLabel(m string) string {
 	if m == "" {
 		return "(orphan)"

--- a/pkg/adoption/format.go
+++ b/pkg/adoption/format.go
@@ -1,0 +1,25 @@
+package adoption
+
+import "github.com/Jguer/yay/v13/pkg/text"
+
+// Mirrors the age-tag convention already used for recently modified packages.
+func FormatWarning(name string, r Record) string {
+	age := text.FormatDuration(NowFunc().Sub(r.ObservedAt))
+
+	var msg string
+	switch r.Kind {
+	case KindOrphanModified:
+		msg = name + ": orphan modified " + age + " ago (transient maintainership)"
+	default:
+		msg = name + ": maintainer changed " + maintainerLabel(r.From) +
+			" \u2192 " + maintainerLabel(r.To) + " " + age + " ago"
+	}
+	return text.Bold(text.Red(msg))
+}
+
+func maintainerLabel(m string) string {
+	if m == "" {
+		return "(orphan)"
+	}
+	return m
+}

--- a/pkg/adoption/refresh.go
+++ b/pkg/adoption/refresh.go
@@ -1,0 +1,31 @@
+package adoption
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+func Refresh(ctx context.Context, client *http.Client, store *Store, maxAge time.Duration, force bool) (int, error) {
+	if !force && !store.ShouldRefresh(maxAge) {
+		return 0, nil
+	}
+
+	etag, lastModified := store.Validators()
+	res, err := Fetch(ctx, client, etag, lastModified)
+	if err != nil {
+		return 0, err
+	}
+
+	now := NowFunc()
+	if res.NotModified {
+		return 0, store.Touch(now)
+	}
+
+	observedAt := res.LastModified
+	if observedAt.IsZero() {
+		observedAt = now
+	}
+	changes, err := store.Apply(res.Entries, res.ETag, res.LastModified, now, observedAt)
+	return len(changes), err
+}

--- a/pkg/query/aur_warnings.go
+++ b/pkg/query/aur_warnings.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Jguer/aur"
 	alpm "github.com/Jguer/dyalpm"
 
+	"github.com/Jguer/yay/v13/pkg/adoption"
 	"github.com/Jguer/yay/v13/pkg/db"
 	"github.com/Jguer/yay/v13/pkg/text"
 )
@@ -17,12 +18,21 @@ type AURWarnings struct {
 	OutOfDate  []string
 	Missing    []string
 	LocalNewer []string
+	Adopted    []string
 
-	log *text.Logger
+	adopted map[string]adoption.Record
+	log     *text.Logger
 }
 
 func NewWarnings(logger *text.Logger) *AURWarnings {
 	return &AURWarnings{log: logger}
+}
+
+// SetAdoptions supplies the active maintainer-change records against which
+// AddToWarnings matches. Records are reconstructed from AUR metadata snapshots
+// and remain active for adoption.Window.
+func (warnings *AURWarnings) SetAdoptions(records map[string]adoption.Record) {
+	warnings.adopted = records
 }
 
 func (warnings *AURWarnings) AddToWarnings(remote map[string]alpm.Package, aurPkg *aur.Pkg) {
@@ -30,6 +40,10 @@ func (warnings *AURWarnings) AddToWarnings(remote map[string]alpm.Package, aurPk
 	pkg, ok := remote[name]
 	if !ok {
 		return
+	}
+	
+	if rec, adopted := warnings.adopted[name]; adopted {
+		warnings.Adopted = append(warnings.Adopted, adoption.FormatWarning(name, rec))
 	}
 
 	if aurPkg.Maintainer == "" && !pkg.ShouldIgnore() {
@@ -81,6 +95,10 @@ func (warnings *AURWarnings) Print() {
 
 	if len(warnings.OutOfDate) > 0 {
 		warnings.log.Warnln(gotext.Get("Flagged Out Of Date AUR Packages:"), formatNames(warnings.OutOfDate))
+	}
+
+	for _, adopted := range warnings.Adopted {
+		warnings.log.Warnln(adopted)
 	}
 
 	if len(warnings.LocalNewer) > 0 {

--- a/pkg/query/query_builder.go
+++ b/pkg/query/query_builder.go
@@ -14,7 +14,8 @@ import (
 	"github.com/adrg/strutil/metrics"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/leonelquinteros/gotext"
-
+	
+	"github.com/Jguer/yay/v13/pkg/adoption"
 	"github.com/Jguer/yay/v13/pkg/db"
 	"github.com/Jguer/yay/v13/pkg/intrange"
 	settingslua "github.com/Jguer/yay/v13/pkg/settings/lua"
@@ -55,6 +56,7 @@ type SourceQueryBuilder struct {
 	aurClient aur.QueryClient
 	logger    *text.Logger
 	lua       *settingslua.Engine
+	adopted   map[string]adoption.Record
 }
 
 func NewSourceQueryBuilder(
@@ -404,6 +406,10 @@ func (s *SourceQueryBuilder) applySearchFilter(results []abstractResult) []abstr
 
 	return filtered
 }
+	
+func (s *SourceQueryBuilder) SetAdoptions(records map[string]adoption.Record) {
+	s.adopted = records
+}
 
 func (s *SourceQueryBuilder) renderAUR(pkg *aur.Pkg, dbExecutor db.Executor) string {
 	var localVersion string
@@ -432,7 +438,11 @@ func (s *SourceQueryBuilder) renderAUR(pkg *aur.Pkg, dbExecutor db.Executor) str
 		}
 	}
 
-	return aurPkgSearchStringResolved(pkg, localVersion, s.singleLineResults)
+	var adoptedTag string
+	if rec, ok := s.adopted[pkg.Name]; ok {
+		adoptedTag = adoption.FormatTag(rec)
+	}
+	return aurPkgSearchStringResolved(pkg, localVersion, s.singleLineResults, adoptedTag)
 }
 
 func (s *SourceQueryBuilder) renderSync(pkg alpm.Package, dbExecutor db.Executor) string {

--- a/pkg/query/types.go
+++ b/pkg/query/types.go
@@ -48,7 +48,7 @@ func getSearchBy(value string) aur.By {
 
 // aurPkgSearchStringResolved renders a search result for an AUR package.
 // It accepts pre-resolved installed state to avoid a second LocalPackage call.
-func aurPkgSearchStringResolved(pkg *aur.Pkg, localVersion string, singleLineResults bool) string {
+func aurPkgSearchStringResolved(pkg *aur.Pkg, localVersion string, singleLineResults bool, adoptedTag string) string {
 	linkText := text.Bold(text.ColorHash("aur")) + "/" + text.Bold(pkg.Name)
 	toPrint := text.CreateRepoLink("aur", "", pkg.Name, linkText) +
 		" " + text.Cyan(pkg.Version) +
@@ -65,6 +65,10 @@ func aurPkgSearchStringResolved(pkg *aur.Pkg, localVersion string, singleLineRes
 
 	if pkg.OutOfDate != 0 {
 		toPrint += text.Bold(text.Red(gotext.Get("(Out-of-date: %s)", text.FormatTime(pkg.OutOfDate)))) + " "
+	}
+	
+	if adoptedTag != "" {
+		toPrint += adoptedTag + " "
 	}
 
 	switch {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/leonelquinteros/gotext"
 
+	"github.com/Jguer/yay/v13/pkg/adoption"
 	"github.com/Jguer/yay/v13/pkg/query"
 	"github.com/Jguer/yay/v13/pkg/settings"
 	"github.com/Jguer/yay/v13/pkg/settings/exe"
@@ -28,16 +29,17 @@ import (
 )
 
 type Runtime struct {
-	Cfg          *settings.Configuration
-	QueryBuilder query.Builder
-	PacmanConf   *pacmanconf.Config
-	VCSStore     vcs.Store
-	CmdBuilder   exe.ICmdBuilder
-	HTTPClient   *http.Client
-	VoteClient   *vote.Client
-	AURClient    aur.QueryClient
-	Logger       *text.Logger
-	Lua          *settingslua.Engine // not goroutine-safe
+	Cfg           *settings.Configuration
+	QueryBuilder  query.Builder
+	PacmanConf    *pacmanconf.Config
+	VCSStore      vcs.Store
+	AdoptionStore *adoption.Store
+	CmdBuilder    exe.ICmdBuilder
+	HTTPClient    *http.Client
+	VoteClient    *vote.Client
+	AURClient     aur.QueryClient
+	Logger        *text.Logger
+	Lua           *settingslua.Engine // not goroutine-safe
 }
 
 func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version string) (*Runtime, error) {
@@ -128,6 +130,11 @@ func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version 
 		return nil, err
 	}
 
+	adoptionStore := adoption.NewStore(cfg.AdoptionFilePath)
+	if errAdopt := adoptionStore.Load(); errAdopt != nil {
+		logger.Child("adoption").Warnln(gotext.Get("failed to load AUR maintainer cache: %s", errAdopt))
+	}
+
 	queryBuilder := query.NewSourceQueryBuilder(
 		aurCache,
 		logger.Child("mixed.querybuilder"), cfg.SortBy,
@@ -135,16 +142,31 @@ func NewRuntime(cfg *settings.Configuration, cmdArgs *parser.Arguments, version 
 		cfg.BottomUp, cfg.SingleLineResults, cfg.SeparateSources)
 
 	run := &Runtime{
-		Cfg:          cfg,
-		QueryBuilder: queryBuilder,
-		PacmanConf:   pacmanConf,
-		VCSStore:     vcsStore,
-		CmdBuilder:   cmdBuilder,
-		HTTPClient:   httpClient,
-		VoteClient:   voteClient,
-		AURClient:    aurCache,
-		Logger:       logger,
+		Cfg:           cfg,
+		QueryBuilder:  queryBuilder,
+		PacmanConf:    pacmanConf,
+		VCSStore:      vcsStore,
+		AdoptionStore: adoptionStore,
+		CmdBuilder:    cmdBuilder,
+		HTTPClient:    httpClient,
+		VoteClient:    voteClient,
+		AURClient:     aurCache,
+		Logger:        logger,
 	}
 
 	return run, nil
+}
+
+// RefreshAdoption conditionally refreshes the AUR maintainer-change snapshot.
+// The refresh is bounded by AdoptionMaxAge unless force is set (for example on
+// an explicit -y). Failures are advisory and logged rather than propagated.
+func (r *Runtime) RefreshAdoption(ctx context.Context, force bool) {
+	if r.AdoptionStore == nil {
+		return
+	}
+
+	maxAge := time.Duration(r.Cfg.AdoptionMaxAge) * time.Hour
+	if _, err := adoption.Refresh(ctx, r.HTTPClient, r.AdoptionStore, maxAge, force); err != nil {
+		r.Logger.Child("adoption").Warnln(gotext.Get("failed to refresh AUR maintainer data: %s", err))
+	}
 }

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -71,8 +71,11 @@ type Configuration struct {
 	UseRPC                 bool   `json:"rpc" lua:"rpc"`
 	DoubleConfirm          bool   `json:"doubleconfirm" lua:"double_confirm"` // confirm install before and after build
 
-	CompletionPath string `json:"-" lua:"-"`
-	VCSFilePath    string `json:"-" lua:"-"`
+	AdoptionMaxAge int `json:"adoptionmaxage" lua:"adoption_max_age"` // hours; snapshot staleness bound before refresh (0 = always)
+
+	CompletionPath   string `json:"-" lua:"-"`
+	VCSFilePath      string `json:"-" lua:"-"`
+	AdoptionFilePath string `json:"-" lua:"-"`
 	// ConfigPath     string `json:"-"`
 	SaveConfig bool               `json:"-" lua:"-"`
 	Mode       parser.TargetMode  `json:"-" lua:"-"`
@@ -238,6 +241,7 @@ func DefaultConfig(version string) *Configuration {
 		Debug:                  false,
 		UseRPC:                 true,
 		DoubleConfirm:          true,
+		AdoptionMaxAge:         24,
 		Mode:                   parser.ModeAny,
 	}
 }
@@ -253,6 +257,7 @@ func NewConfig(logger *text.Logger, configPath, version string) (*Configuration,
 	newConfig.BuildDir = cacheHome
 	newConfig.CompletionPath = filepath.Join(cacheHome, completionFileName)
 	newConfig.VCSFilePath = filepath.Join(cacheHome, vcsFileName)
+	newConfig.AdoptionFilePath = filepath.Join(cacheHome, adoptionFileName)
 	newConfig.load(configPath)
 
 	if aurdest := os.Getenv("AURDEST"); aurdest != "" {

--- a/pkg/settings/dirs.go
+++ b/pkg/settings/dirs.go
@@ -8,7 +8,8 @@ import (
 const (
 	configFileName     string = "config.json" // configFileName holds the name of the config file.
 	luaConfigFileName  string = "init.lua"
-	vcsFileName        string = "vcs.json" // vcsFileName holds the name of the vcs file.
+	vcsFileName        string = "vcs.json"      
+	adoptionFileName   string = "adoption.json" 
 	completionFileName string = "completion.cache"
 	systemdCache       string = "/var/cache/yay" // systemd should handle cache creation
 )

--- a/print.go
+++ b/print.go
@@ -101,6 +101,8 @@ func localStatistics(ctx context.Context, run *runtime.Runtime, dbExecutor db.Ex
 	biggestPackages(run.Logger, dbExecutor)
 	run.Logger.Println(text.Bold(text.Cyan("===========================================")))
 
+	run.RefreshAdoption(ctx, false)
+
 	aurData, err := run.AURClient.Get(ctx, &aur.Query{
 		Needles: remoteNames,
 		By:      aur.Name,
@@ -110,6 +112,7 @@ func localStatistics(ctx context.Context, run *runtime.Runtime, dbExecutor db.Ex
 	}
 
 	warnings := query.NewWarnings(run.Logger.Child("warnings"))
+	warnings.SetAdoptions(run.AdoptionStore.Active())
 	for i := range aurData {
 		warnings.AddToWarnings(remote, &aurData[i])
 	}

--- a/sync.go
+++ b/sync.go
@@ -55,10 +55,13 @@ func syncInstall(ctx context.Context,
 	if cmdArgs.ExistsArg("u", "sysupgrade") {
 		var errSysUp error
 
+		run.RefreshAdoption(ctx, cmdArgs.ExistsArg("y", "refresh"))
+
 		upService := upgrade.NewUpgradeService(
 			grapher, aurCache, dbExecutor, run.VCSStore,
 			run.Cfg, settings.NoConfirm, run.Logger.Child("upgrade"))
 		upService.SetLua(run.Lua)
+		upService.AURWarnings.SetAdoptions(run.AdoptionStore.Active())
 
 		graph, errSysUp = upService.GraphUpgrades(ctx,
 			graph, cmdArgs.ExistsDouble("u", "sysupgrade"),

--- a/sync.go
+++ b/sync.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leonelquinteros/gotext"
 
+	"github.com/Jguer/yay/v13/pkg/adoption"
 	"github.com/Jguer/yay/v13/pkg/db"
 	"github.com/Jguer/yay/v13/pkg/dep"
 	"github.com/Jguer/yay/v13/pkg/runtime"
@@ -42,7 +43,9 @@ func syncInstall(ctx context.Context,
 			return errRefresh
 		}
 	}
-
+	
+	run.RefreshAdoption(ctx, refreshArg)
+	
 	grapher := dep.NewGrapher(dbExecutor, aurCache, false, settings.NoConfirm,
 		noDeps, noCheck, cmdArgs.ExistsArg("needed"), run.Logger.Child("grapher"))
 
@@ -76,6 +79,26 @@ func syncInstall(ctx context.Context,
 		if errSysUp != nil {
 			return errSysUp
 		}
+	}
+	
+	if active := run.AdoptionStore.Active(); len(active) > 0 {
+		warned := false
+		_= graph.ForEach(func(name string, ii *dep.InstallInfo) error {
+			if ii.Source != dep.AUR {
+				return nil
+			}
+			
+			if rec, ok := active[name]; ok {
+				if !warned {
+					run.Logger.Warnln(gotext.Get("Recent AUR maintainer change(s) detected - review the PKGBUILD before installing:"))
+					warned = true
+				}
+				
+				run.Logger.Warnln(adoption.FormatWarning(name, rec))
+			}
+			
+			return nil
+		})
 	}
 
 	opService := sync.NewOperationService(ctx, dbExecutor, run)


### PR DESCRIPTION
<img width="694" height="194" alt="image" src="https://github.com/user-attachments/assets/36f856f4-b68b-426b-bacb-bb31c2193347" />
<img width="762" height="93" alt="image" src="https://github.com/user-attachments/assets/9865f79a-7133-4872-9546-e2fe6c5adfb8" />


Adds a warning to AUR packages that have recently changed maintainers.
Caches packages-meta-ext-v1 for maintainer and lastModified. Refreshed
and diff'd upon sync or for individual packages upon transaction.

Currently flags any maintainership change within the last 30 days, pulls
new maintainer database if it hasn't done so within the last 24 hours.
Both are configurable.

Covers:
- Maintainer A -> Maintainer B
- Orphan -> New Maintainer
- Orphan -> Malicious Maintainer -> Orphan (flags an orphan that has
  been recently updated, yet still has no maintainer)

Should be fairly easy to expand upon and add more conditions to be
flagged.

Minimally tested, as the AUR is currently frozen. 