### PR TITLE
fix(dep): fall back to pkgbase fields when building packages from .SRCINFO

### DIFF
--- a/pkg/dep/dep_graph.go
+++ b/pkg/dep/dep_graph.go
@@ -248,7 +248,7 @@ func (g *Grapher) GraphFromSrcInfos(ctx context.Context, graph *topo.Graph[strin
 
 	aurPkgsAdded := []*aurc.Pkg{}
 	for pkgBuildDir, pkgbuild := range srcInfos {
-		aurPkgs, err := makeAURPKGFromSrcinfo(g.dbExecutor, pkgbuild)
+		aurPkgs, err := PackagesFromSrcinfo(g.dbExecutor, pkgbuild)
 		if err != nil {
 			return nil, err
 		}
@@ -836,17 +836,30 @@ func (g *Grapher) provideMenu(dep string, options []aur.Pkg) *aur.Pkg {
 	}
 }
 
-func makeAURPKGFromSrcinfo(dbExecutor db.Executor, srcInfo *gosrc.Srcinfo) ([]*aur.Pkg, error) {
+// PackagesFromSrcinfo converts repository metadata into package metadata used
+// by dependency resolution and local package information displays.
+func PackagesFromSrcinfo(dbExecutor db.Executor, srcInfo *gosrc.Srcinfo) ([]*aur.Pkg, error) {
 	pkgs := make([]*aur.Pkg, 0, 1)
 
 	alpmArch, err := dbExecutor.AlpmArchitectures()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading architectures for .SRCINFO: %w", err)
 	}
 
 	alpmArch = append(alpmArch, "") // srcinfo assumes no value as ""
 
 	getDesc := func(pkg *gosrc.Package) string { return cmp.Or(pkg.Pkgdesc, srcInfo.Pkgdesc) }
+
+	// srcInfo.Packages holds only the per-package overrides; anything declared
+	// once at the pkgbase level lives on srcInfo itself. Fall back to it so a
+	// plain (non-split) PKGBUILD does not report these as empty.
+	fallback := func(pkg, base []string) []string {
+		if len(pkg) > 0 {
+			return pkg
+		}
+
+		return base
+	}
 
 	for i := range srcInfo.Packages {
 		pkg := &srcInfo.Packages[i]
@@ -858,7 +871,7 @@ func makeAURPKGFromSrcinfo(dbExecutor db.Executor, srcInfo *gosrc.Srcinfo) ([]*a
 			PackageBase:   srcInfo.Pkgbase,
 			Version:       srcInfo.Version(),
 			Description:   getDesc(pkg),
-			URL:           pkg.URL,
+			URL:           cmp.Or(pkg.URL, srcInfo.URL),
 			Depends:       slices.Concat(archStringToString(alpmArch, pkg.Depends), archStringToString(alpmArch, srcInfo.Depends)),
 			MakeDepends:   archStringToString(alpmArch, srcInfo.MakeDepends),
 			CheckDepends:  archStringToString(alpmArch, srcInfo.CheckDepends),
@@ -866,8 +879,8 @@ func makeAURPKGFromSrcinfo(dbExecutor db.Executor, srcInfo *gosrc.Srcinfo) ([]*a
 			Provides:      slices.Concat(archStringToString(alpmArch, pkg.Provides), archStringToString(alpmArch, srcInfo.Provides)),
 			Replaces:      slices.Concat(archStringToString(alpmArch, pkg.Replaces), archStringToString(alpmArch, srcInfo.Replaces)),
 			OptDepends:    slices.Concat(archStringToString(alpmArch, pkg.OptDepends), archStringToString(alpmArch, srcInfo.OptDepends)),
-			Groups:        pkg.Groups,
-			License:       pkg.License,
+			Groups:        fallback(pkg.Groups, srcInfo.Groups),
+			License:       fallback(pkg.License, srcInfo.License),
 			Keywords:      []string{},
 		})
 	}

--- a/pkg/dep/dep_unit_test.go
+++ b/pkg/dep/dep_unit_test.go
@@ -157,7 +157,7 @@ func TestProvideMenuAndMakeAURPKGFromSrcinfo(t *testing.T) {
 	require.Equal(t, "aur-pkg-two", grapherNoConfirm.provideMenu("dep", opts).Name)
 }
 
-func TestMakeAURPKGFromSrcinfo(t *testing.T) {
+func TestPackagesFromSrcinfo(t *testing.T) {
 	t.Parallel()
 
 	assertErr := errors.New("arch error")
@@ -188,7 +188,7 @@ func TestMakeAURPKGFromSrcinfo(t *testing.T) {
 		},
 	}
 
-	pkgs, err := makeAURPKGFromSrcinfo(dbExecutor, srcinfo)
+	pkgs, err := PackagesFromSrcinfo(dbExecutor, srcinfo)
 	require.NoError(t, err)
 	require.Len(t, pkgs, 1)
 	require.Equal(t, []string{"pkgdep", "xdep"}, pkgs[0].Depends)
@@ -199,6 +199,56 @@ func TestMakeAURPKGFromSrcinfo(t *testing.T) {
 		},
 	}
 
-	_, err = makeAURPKGFromSrcinfo(dbFail, srcinfo)
+	_, err = PackagesFromSrcinfo(dbFail, srcinfo)
 	require.Error(t, err)
+}
+
+func TestPackagesFromSrcinfoPkgbaseFallback(t *testing.T) {
+	t.Parallel()
+
+	dbExecutor := &mock.DBExecutor{
+		AlpmArchitecturesFn: func() ([]string, error) {
+			return []string{"x86_64"}, nil
+		},
+	}
+
+	srcinfo := &gosrc.Srcinfo{
+		PackageBase: gosrc.PackageBase{
+			Pkgbase: "yay",
+		},
+		Package: gosrc.Package{
+			URL:     "https://example.com/yay",
+			Groups:  []string{"base-group"},
+			License: []string{"MIT"},
+		},
+		Packages: []gosrc.Package{
+			{
+				Pkgname: "yay",
+			},
+		},
+	}
+
+	pkgs, err := PackagesFromSrcinfo(dbExecutor, srcinfo)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	require.Equal(t, "https://example.com/yay", pkgs[0].URL)
+	require.Equal(t, []string{"base-group"}, pkgs[0].Groups)
+	require.Equal(t, []string{"MIT"}, pkgs[0].License)
+
+	// A per-package override must still win over the pkgbase value.
+	srcinfo.Packages = []gosrc.Package{
+		{
+			Pkgname: "yay",
+			URL:     "https://example.com/yay-override",
+			Groups:  []string{"override-group"},
+			License: []string{"GPL"},
+		},
+	}
+
+	pkgs, err = PackagesFromSrcinfo(dbExecutor, srcinfo)
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	require.Equal(t, "https://example.com/yay-override", pkgs[0].URL)
+	require.Equal(t, []string{"override-group"}, pkgs[0].Groups)
+	require.Equal(t, []string{"GPL"}, pkgs[0].License)
 }


### PR DESCRIPTION
`srcInfo.Packages` holds only the *per-package overrides* from a `.SRCINFO`.
Anything declared once at the pkgbase level lives on the `Srcinfo` value
itself. `PackagesFromSrcinfo` (formerly `makeAURPKGFromSrcinfo`) read `URL`,
`Groups` and `License` straight off the per-package entry, so for a plain
(non-split) PKGBUILD — where those are only ever declared at pkgbase level —
all three came back empty.

Visible today in `yay -U`/srcinfo installs: no URL, no groups, no license on
packages that clearly declare them.

## Changes

- Fall back to the pkgbase value when the per-package override is empty, for
  `URL`, `Groups` and `License`. A per-package override still wins.
- Wrap the `AlpmArchitectures()` error so a failure here is attributable.
- Export `makeAURPKGFromSrcinfo` as `PackagesFromSrcinfo`. It is unexported
  today but converts `.SRCINFO` metadata into package metadata, which is useful
  outside `pkg/dep`; a follow-up PR consumes it.

## Tests

`TestPackagesFromSrcinfoPkgbaseFallback` asserts a package inherits all three
fields from pkgbase, then that per-package overrides still take precedence.
Verified it is a real regression test — with the fix reverted it fails
(`expected "https://example.com/yay", actual ""`), not just compiles differently.

Ran in a Linux container, since `pkg/dep` cannot build on macOS
(`Pdeathsig` in `pkg/settings/exe` is linux-only):

```
gofmt -l pkg/dep                   # clean
GOOS=linux go build ./pkg/dep/...  # clean
GOOS=linux go vet ./pkg/dep/...    # clean
docker run --rm -v "$PWD":/app -w /app golang:1.26 go test ./pkg/dep/...
# ok github.com/Jguer/yay/v13/pkg/dep
```
