### PR TITLE
Add option to skip the upgrade exclusion prompt

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -180,6 +180,7 @@ func usage(logger *text.Logger) {
 		{"--cleanmenu", gotext.Get("Give the option to clean build PKGBUILDS")},
 		{"--diffmenu", gotext.Get("Give the option to show diffs for build files")},
 		{"--editmenu", gotext.Get("Give the option to edit/view PKGBUILDS")},
+		{"--noupgrademenu", gotext.Get("Do not prompt for package exclusions during upgrades")},
 		{"--askremovemake", gotext.Get("Ask to remove makedepends after install")},
 		{"--askyesremovemake", gotext.Get("Ask to remove makedepends after install(\"Y\" as default)")},
 		{"--removemake", gotext.Get("Remove makedepends after install")},

--- a/completions/bash
+++ b/completions/bash
@@ -74,7 +74,7 @@ _yay() {
           save builddir editor editorflags makepkg pacman git gitflags gpg gpgflags mflags config requestsplitn sudoloop sudo sudoflags
           redownload noredownload redownloadall rebuild rebuildall rebuildtree norebuild sortby
           singlelineresults doublelineresults answerclean answerdiff answeredit answerupgrade noanswerclean noanswerdiff
-          noansweredit noanswerupgrade cleanmenu diffmenu editmenu cleanafter keepsrc topdown bottomup devel separatesources
+          noansweredit noanswerupgrade cleanmenu diffmenu editmenu noupgrademenu cleanafter keepsrc topdown bottomup devel separatesources
           provides pgpfetch
           useask combinedupgrade aur repo makepkgconf
           nomakepkgconf askremovemake askyesremovemake removemake noremovemake completioninterval aururl aurrpcurl

--- a/completions/fish
+++ b/completions/fish
@@ -218,6 +218,7 @@ complete -c $progname -n "not $noopt" -l noanswerupgrade -d 'Unset the answer fo
 complete -c $progname -n "not $noopt" -l cleanmenu -d 'Give the option to clean build PKGBUILDS' -f
 complete -c $progname -n "not $noopt" -l diffmenu -d 'Give the option to show diffs for build files' -f
 complete -c $progname -n "not $noopt" -l editmenu -d 'Give the option to edit/view PKGBUILDS' -f
+complete -c $progname -n "not $noopt" -l noupgrademenu -d 'Do not prompt for package exclusions during upgrades' -f
 complete -c $progname -n "not $noopt" -l askremovemake -d 'Ask to remove make deps after install' -f
 complete -c $progname -n "not $noopt" -l askyesremovemake -d 'Ask to remove make deps after install(with "Y" as default)' -f
 complete -c $progname -n "not $noopt" -l removemake -d 'Remove make deps after install' -f

--- a/completions/zsh
+++ b/completions/zsh
@@ -75,6 +75,7 @@ _pacman_opts_common=(
 	'--cleanmenu[Give the option to clean build PKGBUILDS]'
 	'--diffmenu[Give the option to show diffs for build files]'
 	'--editmenu[Give the option to edit/view PKGBUILDS]'
+	'--noupgrademenu[Do not prompt for package exclusions during upgrades]'
 	'(--askyesremovemake --removemake --noremovemake)--askremovemake[Ask to remove makedepends after install]'
 	'(--askremovemake --removemake --noremovemake)--askyesremovemake[Ask to remove makedepends after install(with "Y" as default)]'
 	'(--askremovemake --askyesremovemake --noremovemake)--removemake[Remove makedepends after install]'

--- a/doc/lua.md
+++ b/doc/lua.md
@@ -82,7 +82,7 @@ startup and reports the offending keys/values so misconfigurations fail fast.
 **Booleans**
 
 `bottom_up`, `sudo_loop`, `devel`, `clean_after`, `keep_src`, `provides`,
-`pgp_fetch`, `clean_menu`, `diff_menu`, `edit_menu`, `combined_upgrade`,
+`pgp_fetch`, `clean_menu`, `diff_menu`, `edit_menu`, `no_upgrade_menu`, `combined_upgrade`,
 `use_ask`, `batch_install`, `single_line_results`, `separate_sources`, `debug`,
 `rpc`, `double_confirm`
 

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -321,6 +321,13 @@ before building.
 recommended to edit pkgbuild variables unless you know what you are doing.
 
 .TP
+.B \-\-noupgrademenu
+Do not show the package exclusion prompt after listing available upgrades. All
+remaining packages are accepted; exclusions from UpgradeSelect hooks still
+apply. Set 'noupgrademenu' in the configuration file, or use
+'--noupgrademenu=false' temporarily, to restore the prompt.
+
+.TP
 .B \-\-askremovemake
 Ask to remove makedepends after installing packages.
 

--- a/meta/yay.d.lua
+++ b/meta/yay.d.lua
@@ -55,6 +55,7 @@
 ---@field clean_menu boolean Show pre-build clean menu.
 ---@field diff_menu boolean Show diff menu before building.
 ---@field edit_menu boolean Show PKGBUILD edit menu before building.
+---@field no_upgrade_menu boolean Skip the package exclusion prompt after listing upgrades.
 ---@field combined_upgrade boolean Use combined repo+AUR upgrade flow on sysupgrade.
 ---@field use_ask boolean Use pacman's --ask to auto-confirm known conflicts.
 ---@field batch_install boolean Queue AUR package installs instead of installing each package immediately.

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -161,6 +161,8 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.DiffMenu = boolValue
 	case "editmenu":
 		c.EditMenu = boolValue
+	case "noupgrademenu":
+		c.NoUpgradeMenu = boolValue
 	case "useask":
 		c.UseAsk = boolValue
 	case "combinedupgrade":

--- a/pkg/settings/args_test.go
+++ b/pkg/settings/args_test.go
@@ -1,0 +1,46 @@
+//go:build !integration
+
+package settings
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Jguer/yay/v13/pkg/settings/parser"
+)
+
+func TestConfiguration_ParseCommandLineNoUpgradeMenu(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	tests := []struct {
+		name  string
+		arg   string
+		start bool
+		want  bool
+	}{
+		{name: "enable", arg: "--noupgrademenu", start: false, want: true},
+		{name: "disable", arg: "--noupgrademenu=false", start: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Args = []string{"yay", tt.arg}
+			cfg := &Configuration{NoUpgradeMenu: tt.start}
+			args := parser.MakeArguments()
+
+			require.NoError(t, cfg.ParseCommandLine(args))
+			assert.Equal(t, tt.want, cfg.NoUpgradeMenu)
+			assert.NotContains(t, args.Options, "noupgrademenu")
+		})
+	}
+}
+
+func TestDefaultConfigShowsUpgradeMenu(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, DefaultConfig("test").NoUpgradeMenu)
+}

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -62,6 +62,7 @@ type Configuration struct {
 	CleanMenu              bool   `json:"cleanmenu" lua:"clean_menu"`
 	DiffMenu               bool   `json:"diffmenu" lua:"diff_menu"`
 	EditMenu               bool   `json:"editmenu" lua:"edit_menu"`
+	NoUpgradeMenu          bool   `json:"noupgrademenu" lua:"no_upgrade_menu"`
 	CombinedUpgrade        bool   `json:"combinedupgrade" lua:"combined_upgrade"`
 	UseAsk                 bool   `json:"useask" lua:"use_ask"`
 	BatchInstall           bool   `json:"batchinstall" lua:"batch_install"`
@@ -231,6 +232,7 @@ func DefaultConfig(version string) *Configuration {
 		CleanMenu:              true,
 		DiffMenu:               true,
 		EditMenu:               false,
+		NoUpgradeMenu:          false,
 		UseAsk:                 false,
 		CombinedUpgrade:        true,
 		SeparateSources:        true,

--- a/pkg/settings/lua/lua_test.go
+++ b/pkg/settings/lua/lua_test.go
@@ -11,6 +11,7 @@ type testConfig struct {
 	BuildDir      string `json:"buildDir" lua:"build_dir"`
 	RequestSplitN int    `json:"requestsplitn" lua:"request_split_n"`
 	Devel         bool   `json:"devel" lua:"devel"`
+	NoUpgradeMenu bool   `json:"noupgrademenu" lua:"no_upgrade_menu"`
 	AnswerClean   string `json:"answerclean" lua:"answer_clean"`
 	AnswerDiff    string `json:"answerdiff" lua:"answer_diff"`
 	AnswerEdit    string `json:"answeredit" lua:"answer_edit"`
@@ -26,6 +27,7 @@ func TestApply(t *testing.T) {
 		yay.opt.build_dir = "/tmp/yay"
 		yay.opt.request_split_n = 200
 		yay.opt.devel = true
+		yay.opt.no_upgrade_menu = true
 	`))
 
 	cfg := &testConfig{}
@@ -36,6 +38,7 @@ func TestApply(t *testing.T) {
 	assert.Equal(t, "/tmp/yay", cfg.BuildDir)
 	assert.Equal(t, 200, cfg.RequestSplitN)
 	assert.True(t, cfg.Devel)
+	assert.True(t, cfg.NoUpgradeMenu)
 }
 
 func TestApplyUnknownAndTypeMismatch(t *testing.T) {

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -421,6 +421,7 @@ func isArg(arg string) bool {
 	case "cleanmenu":
 	case "diffmenu":
 	case "editmenu":
+	case "noupgrademenu":
 	case "useask":
 	case "combinedupgrade":
 	case "a", "aur":

--- a/pkg/settings/parser/parser_test.go
+++ b/pkg/settings/parser/parser_test.go
@@ -326,6 +326,9 @@ func Test_isArg(t *testing.T) {
 
 	got = isArg("dbpath")
 	assert.True(t, got)
+
+	got = isArg("noupgrademenu")
+	assert.True(t, got)
 }
 
 func TestArguments_ParseStdin(t *testing.T) {

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -385,6 +385,9 @@ func (u *UpgradeService) UserExcludeUpgrades(graph *topo.Graph[string, *dep.Inst
 	}
 
 	u.printUpgradeSelection(allUp)
+	if u.cfg.NoUpgradeMenu {
+		return excluded, nil
+	}
 
 	u.log.Infoln(gotext.Get("Packages to exclude: (eg: \"1 2 3\", \"1-3\", \"^4\" or repo name)"))
 	u.log.Warnln(gotext.Get("Excluding packages may cause partial upgrades and break systems"))

--- a/pkg/upgrade/service_test.go
+++ b/pkg/upgrade/service_test.go
@@ -838,6 +838,53 @@ func TestUpgradeService_UserExcludeUpgradesWithoutLuaHookUsesNativeMenu(t *testi
 	assert.False(t, graph.Exists("new-dep"))
 }
 
+func TestUpgradeService_UserExcludeUpgradesNoUpgradeMenuAvoidsInput(t *testing.T) {
+	t.Parallel()
+	graph := newUpgradeSelectTestGraph(t)
+	var output strings.Builder
+	logger := text.NewLogger(&output, io.Discard, strings.NewReader(""), true, "test")
+	u := newUpgradeSelectTestService(strings.NewReader(""), nil)
+	u.log = logger
+	u.cfg.NoUpgradeMenu = true
+
+	excluded, err := u.UserExcludeUpgrades(graph)
+	require.NoError(t, err)
+
+	assert.Empty(t, excluded)
+	assert.True(t, graph.Exists("linux"))
+	assert.True(t, graph.Exists("yay"))
+	assert.True(t, graph.Exists("example-git"))
+	assert.True(t, graph.Exists("new-dep"))
+	assert.Contains(t, output.String(), "to upgrade/install")
+	assert.NotContains(t, output.String(), "Packages to exclude")
+}
+
+func TestUpgradeService_UserExcludeUpgradesNoUpgradeMenuStillRunsLuaHook(t *testing.T) {
+	t.Parallel()
+	engine := settingslua.New()
+	defer engine.Close()
+	require.NoError(t, engine.L.DoString(`
+		yay.create_autocmd("UpgradeSelect", {
+			callback = function()
+				return { exclude = { "example-git" } }
+			end,
+		})
+	`))
+
+	graph := newUpgradeSelectTestGraph(t)
+	u := newUpgradeSelectTestService(strings.NewReader(""), engine)
+	u.cfg.NoUpgradeMenu = true
+
+	excluded, err := u.UserExcludeUpgrades(graph)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"example-git", "new-dep"}, excluded)
+	assert.True(t, graph.Exists("linux"))
+	assert.True(t, graph.Exists("yay"))
+	assert.False(t, graph.Exists("example-git"))
+	assert.False(t, graph.Exists("new-dep"))
+}
+
 func TestUpgradeService_UserExcludeUpgradesLuaHookPrunesGraph(t *testing.T) {
 	t.Parallel()
 	engine := settingslua.New()


### PR DESCRIPTION
Fixes #2814.

## Summary

- add a `noupgrademenu` JSON/CLI option and `no_upgrade_menu` Lua option
- keep listing available upgrades while accepting the remaining packages without reading stdin
- preserve `UpgradeSelect` hook exclusions and keep the prompt enabled by default
- document the option and expose it in Bash, Fish, and Zsh completions

## Testing

- `make test`
- `GOFLAGS="-buildvcs=false -tags=next" /app/bin/golangci-lint run ./...`
- `bash -n completions/bash`

Tests were run in `ghcr.io/jguer/yay-builder:latest`, matching the repository's Arch/libalpm CI environment.
