### PR TITLE
feat: add option to skip upgrade exclusion menu

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -177,6 +177,7 @@ func usage(logger *text.Logger) {
 		{"--noanswerdiff", gotext.Get("Unset the answer for the edit diff menu")},
 		{"--noansweredit", gotext.Get("Unset the answer for the edit pkgbuild menu")},
 		{"--noanswerupgrade", gotext.Get("Unset the answer for the upgrade menu")},
+		{"--noexcludemenu", gotext.Get("Skip the package exclusion menu during upgrades")},
 		{"--cleanmenu", gotext.Get("Give the option to clean build PKGBUILDS")},
 		{"--diffmenu", gotext.Get("Give the option to show diffs for build files")},
 		{"--editmenu", gotext.Get("Give the option to edit/view PKGBUILDS")},

--- a/doc/yay.8
+++ b/doc/yay.8
@@ -295,6 +295,10 @@ Unset the answer for the edit pkgbuild menu.
 Unset the answer for the upgrade menu.
 
 .TP
+.B \-\-noexcludemenu
+Skip the package exclusion menu during upgrades.
+
+.TP
 .B \-\-cleanmenu
 Show the clean menu. This menu gives you the chance to fully delete the
 downloaded build files from Yay's cache before redownloading a fresh copy.

--- a/pkg/settings/args.go
+++ b/pkg/settings/args.go
@@ -116,6 +116,8 @@ func (c *Configuration) handleOption(option, value string) bool {
 		c.AnswerUpgrade = value
 	case "noanswerupgrade":
 		c.AnswerUpgrade = ""
+	case "noexcludemenu":
+		c.NoExcludeMenu = boolValue
 	case "gpgflags":
 		c.GpgFlags = value
 	case "mflags":

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -38,6 +38,7 @@ type Configuration struct {
 	AnswerDiff             string `json:"answerdiff" lua:"answer_diff"`
 	AnswerEdit             string `json:"answeredit" lua:"answer_edit"`
 	AnswerUpgrade          string `json:"answerupgrade" lua:"-"`
+	NoExcludeMenu          bool   `json:"noexcludemenu" lua:"no_exclude_menu"`
 	GitBin                 string `json:"gitbin" lua:"git_bin"`
 	GpgBin                 string `json:"gpgbin" lua:"gpg_bin"`
 	GpgFlags               string `json:"gpgflags" lua:"gpg_flags"`
@@ -226,6 +227,7 @@ func DefaultConfig(version string) *Configuration {
 		AnswerDiff:             "",
 		AnswerEdit:             "",
 		AnswerUpgrade:          "",
+		NoExcludeMenu:          false,
 		RemoveMake:             "ask",
 		Provides:               true,
 		CleanMenu:              true,

--- a/pkg/settings/parser/parser.go
+++ b/pkg/settings/parser/parser.go
@@ -400,6 +400,7 @@ func isArg(arg string) bool {
 	case "noansweredit":
 	case "answerupgrade":
 	case "noanswerupgrade":
+	case "noexcludemenu":
 	case "gpgflags":
 	case "mflags":
 	case "gitflags":

--- a/pkg/upgrade/service.go
+++ b/pkg/upgrade/service.go
@@ -375,6 +375,9 @@ func (u *UpgradeService) UserExcludeUpgrades(graph *topo.Graph[string, *dep.Inst
 	if skipMenu {
 		return excluded, nil
 	}
+	if u.cfg.NoExcludeMenu {
+		return excluded, nil
+	}
 	if len(excluded) > 0 {
 		// The hook pruned packages; refresh the selection to reflect the
 		// smaller graph and skip the menu if nothing is left to upgrade.


### PR DESCRIPTION
Fixes #2814.

Add a `noexcludemenu` configuration and command-line option to skip the interactive package exclusion menu during upgrades. This is useful for unattended workflows that still want upgrade selection and confirmation behavior without being prompted to exclude packages.

The option defaults to false, is accepted as `--noexcludemenu` or `--noexcludemenu=false`, is persisted with `--save`, and is documented in the built-in help and man page. Existing hooks and the default interactive behavior remain unchanged.

Validation:
- `git diff --check`
- Go test/build could not be run because Go is not installed in the environment.